### PR TITLE
Releases v0.2.2 + v0.2.3: mode-safe Foundations sheet + component finalize write-back

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "throughline",
   "description": "Throughline — build a complete design system end to end. Author tokens, styles, icons, and components in Figma, then stand up a monorepo, sync tokens to framework-specific code via Style Dictionary, and generate Storybook stories with Chromatic. One unbroken line from design to code. Built for designers becoming developers; explanation scales to your comfort level.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": {
     "name": "Jordan Pease"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "throughline",
   "description": "Throughline — build a complete design system end to end. Author tokens, styles, icons, and components in Figma, then stand up a monorepo, sync tokens to framework-specific code via Style Dictionary, and generate Storybook stories with Chromatic. One unbroken line from design to code. Built for designers becoming developers; explanation scales to your comfort level.",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": {
     "name": "Jordan Pease"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-06-03
+
+### Fixed
+- **`token-sheet-builder` now fully binds the Foundations page chrome to the
+  system, not just the swatches.** Previously section titles, labels, and
+  hex/value text kept raw fonts and hardcoded colors, and section/background
+  fills were unbound — so switching the file from Dark to Light left titles and
+  panels stranded (e.g. black text on a black surface) and the showcase looked
+  broken. The skill now requires every text node to use a text style and every
+  fill (text *and* chrome/background) to bind to a semantic color variable, and
+  adds a both-modes validation step (set the non-default mode, screenshot,
+  confirm legibility, restore) to catch any unbound fill before the checkpoint.
+
 ## [0.2.1] - 2026-06-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-06-03
+
+### Fixed
+- **Finalizing a component now updates its Figma doc card.** When a component
+  reached the end of the pipeline (code + stories built and approved), its Figma
+  artboard kept showing the `draft` pill forever — nothing promoted it. Components
+  now have an explicit lifecycle: `component-builder` creates them at `draft`, and
+  `storybook-chromatic-builder` promotes them to `stable` on finalize, writing the
+  new chip color (→ success) and last-updated date back into the doc card (a new
+  Step 6). The status chip, its label, and the date node are now built with
+  deterministic names (`Status`, `Status Label`, `Last Updated`) so the write-back
+  can find them, and a canonical "Promoting a component's status" routine in
+  `references/figma-component-standards.md` keeps the manifest and the artboard in
+  sync. Falls back gracefully (manifest-only) when Figma isn't connected.
+
 ## [0.2.2] - 2026-06-03
 
 ### Fixed

--- a/references/figma-component-standards.md
+++ b/references/figma-component-standards.md
@@ -123,9 +123,39 @@ shows:
 - **Status indicator** — a chip reading `draft` / `beta` / `stable` /
   `deprecated`, colored from semantic tokens (e.g. warning for draft/beta,
   success for stable, neutral/danger for deprecated). Source the value from
-  `components.meta[name].status`.
+  `components.meta[name].status`. **Name the chip frame `Status` and its label
+  text node `Status Label`** so the finalize write-back (below) can find and
+  update them later — a chip with no deterministic name can't be promoted.
 - **Last updated** — a date, from `components.meta[name].updatedAt`, refreshed
-  whenever the component is rebuilt.
+  whenever the component is rebuilt. **Name this text node `Last Updated`** for
+  the same reason.
+
+### Promoting a component's status (write-back on finalize)
+
+A component's status is not static: it starts at `draft` (built in Figma, no code
+yet) and is **promoted to `stable` when its code component and stories are built
+and approved** (the `storybook-chromatic-builder` finalize step / pipeline
+stage 3). Promotion must update **both** the manifest and the live Figma doc card,
+or the card lies — it keeps showing `draft` after the component is actually done.
+This is the canonical routine; the finalize step references it rather than
+re-describing it:
+
+1. Set `components.meta[name].status` to the new status (`stable` on finalize) and
+   `components.meta[name].updatedAt` to today (ISO date). The manifest is the
+   source of truth.
+2. If Figma is connected (use `figma.mechanism`), locate the component's doc card
+   by its deterministic name, then inside it:
+   - set the `Status Label` text to the new status (e.g. `stable`);
+   - re-bind the `Status` chip fill to the matching semantic color variable
+     (`stable` → success, `draft`/`beta` → warning, `deprecated` → neutral/danger)
+     — re-bind the variable, don't hardcode a hex, so it stays mode-aware;
+   - set the `Last Updated` text to today's date.
+   Then run the visual-validation loop (screenshot → confirm the chip recolored
+   and the date changed → re-screenshot).
+3. If Figma is **not** connected, still do step 1, and tell the user the card will
+   reconcile to the manifest the next time a Figma session runs (the doc card
+   always renders from `components.meta[name]`). Offer to reconnect and update it
+   now if they want it reflected immediately.
 
 **Icons are the one exception:** the whole icon set lives on a *single* doc card
 holding the icon grid — one card for all icons, not one card per icon.

--- a/references/manifest-schema.md
+++ b/references/manifest-schema.md
@@ -181,9 +181,15 @@ bailing or running silently.
   component's documentation artboard (see
   `${CLAUDE_PLUGIN_ROOT}/references/figma-component-standards.md`): `{ "Button":
   { "status": "stable", "updatedAt": "<ISO>" } }`. `status` is one of
-  `"draft"` / `"beta"` / `"stable"` / `"deprecated"`. Re-running a component
-  refreshes its `updatedAt`. Keep `built` (names) as the source of truth for
-  "exists"; `meta` is supplementary doc metadata.
+  `"draft"` / `"beta"` / `"stable"` / `"deprecated"`. **Lifecycle:** a component
+  is created at `"draft"` by `component-builder` (Figma exists, no code yet) and
+  promoted to `"stable"` by `storybook-chromatic-builder` when its code + stories
+  are built and approved. That promotion also writes the new chip color +
+  last-updated date back into the Figma doc card (see "Promoting a component's
+  status" in `${CLAUDE_PLUGIN_ROOT}/references/figma-component-standards.md`) — so
+  the manifest and the artboard never disagree. Re-running a component refreshes
+  its `updatedAt`. Keep `built` (names) as the source of truth for "exists";
+  `meta` is supplementary doc metadata.
 - `instanceSwapUpgradePending` — array of component names whose icon/component
   slots were built with the **toggle + manual-swap fallback** because the
   library wasn't published yet, so the typed `INSTANCE_SWAP` dropdown is still

--- a/skills/component-builder/SKILL.md
+++ b/skills/component-builder/SKILL.md
@@ -95,7 +95,11 @@ deterministic naming):
   with the component name, a short description, a status chip
   (`draft`/`beta`/`stable`/`deprecated`), and a last-updated date — and arrange
   the cards in an orderly grid inside a parent Section, never floating on bare
-  canvas. Follow the "Documentation artboards & canvas layout" rules in
+  canvas. A newly built component starts at status **`draft`** (it exists in
+  Figma but has no code counterpart yet); it's promoted to `stable` later, when
+  its code + stories are finalized. Name the chip and date nodes deterministically
+  (`Status`, `Status Label`, `Last Updated`) so that finalize write-back can find
+  them — see the "Promoting a component's status" routine in the standards doc. Follow the "Documentation artboards & canvas layout" rules in
   `${CLAUDE_PLUGIN_ROOT}/references/figma-component-standards.md`, and run its
   visual-validation loop (screenshot → fix any overlaps/misalignment →
   re-screenshot) before the checkpoint.
@@ -158,7 +162,8 @@ without it, components silently diverge between Figma and code.
 ## Step 6 — Checkpoint and hand off
 
 Update the manifest: add each built component to `components.built`, and record
-its `components.meta[name]` (`status`, `updatedAt`) to match the doc card. Ensure
+its `components.meta[name]` (`status: "draft"`, `updatedAt`) to match the doc
+card. (Finalize to `stable` happens later, in storybook-chromatic-builder.) Ensure
 any component built with the toggle + manual-swap fallback is listed in
 `components.instanceSwapUpgradePending`. Append `component-builder` to
 `completedSkills`.

--- a/skills/component-pipeline/SKILL.md
+++ b/skills/component-pipeline/SKILL.md
@@ -56,7 +56,11 @@ Offer: "Tokens are synced. Build the code component and its stories now?" If yes
 invoke `storybook-chromatic-builder` for this one component: build the code
 counterpart implementing the captured slot contract, generate its stories
 (subagent-driven), wire Code Connect if available. **Checkpoint:** confirm the
-component renders and stories build.
+component renders and stories build. On approval, that skill **finalizes** the
+component — promoting its status from `draft` to `stable` and writing the new
+chip color + last-updated date back into its Figma doc card (its Step 6). Since
+Figma is still connected from stage 1, the card updates live; the chip should no
+longer read `draft` once the pipeline finishes.
 
 ## Resumability
 

--- a/skills/storybook-chromatic-builder/SKILL.md
+++ b/skills/storybook-chromatic-builder/SKILL.md
@@ -134,15 +134,45 @@ mode shows the real code. It's plan-gated (Figma Organization/Enterprise).
   run after the user publishes. This does **not** block the code side: implement
   each slot prop from the recorded slot contract regardless of the Figma dropdown.
 
-## Step 6 — Update manifest + hand off
+## Step 6 — Finalize component status (Figma write-back)
+
+A component built and storied here is now **done** — but its Figma doc card was
+stamped `draft` by component-builder and won't change on its own. Once the code
+component renders and its stories build (and the user has approved the result),
+**promote each finalized component to `stable`** so the design system tells the
+truth in both places.
+
+For every component you finalized in this run, follow the **"Promoting a
+component's status (write-back on finalize)"** routine in
+`${CLAUDE_PLUGIN_ROOT}/references/figma-component-standards.md`:
+
+- Set `components.meta[name].status` = `"stable"` and refresh
+  `components.meta[name].updatedAt` to today.
+- If Figma is connected (per `figma.mechanism`), open the component's doc card and
+  update the `Status Label` text to `stable`, re-bind the `Status` chip fill to
+  the **success** semantic color variable (mode-aware, not a hardcoded hex), and
+  set `Last Updated` to today's date — then screenshot to confirm the chip
+  recolored and the date changed.
+- If Figma isn't connected, still update the manifest and tell the user the card
+  will reconcile next Figma session (or offer to reconnect and fix it now).
+
+Do this automatically as part of finishing — the user already approved the
+component; don't make them ask for the chip to flip. (`stable` is the finalized
+status; if a component is intentionally still experimental, leave it at `beta`
+and say so.)
+
+## Step 7 — Update manifest + hand off
 
 Set `storybook.initialized` = `true`, `storybook.chromatic` accordingly,
 `storybook.codeConnect` accordingly. Append `storybook-chromatic-builder` to
-`completedSkills`. Note the ongoing loop: new components flow through the
+`completedSkills`. (Per-component `status`/`updatedAt` were already updated in
+Step 6.) Note the ongoing loop: new components flow through the
 component-pipeline orchestrator; token changes flow through `/sync-figma-tokens`.
 
 ## What this skill must NOT do
 
+- Never finish a finalized component while leaving its Figma doc card on `draft`
+  — promote the status and write it back (Step 6).
 - Never write a story per library icon — one gallery story.
 - Never put a secret value through chat or commit it — user places it, scaled to
   level.

--- a/skills/token-sheet-builder/SKILL.md
+++ b/skills/token-sheet-builder/SKILL.md
@@ -56,6 +56,26 @@ Prioritize visual quality: generous spacing, clear section headers, consistent
 swatch sizing, the brand's own type and color applied to the page chrome. This
 is a showcase.
 
+**Bind the page chrome too — not just the swatches.** The sheet must fully
+consume the system, including its own titles, labels, descriptions, and section
+backgrounds. Concretely:
+
+- **Every text node gets a text style.** Section titles, group labels, swatch
+  numbers, hex/value text, captions — map each to an existing text style
+  (e.g. section headers → a Heading style, descriptions → Body, micro-labels →
+  Caption). Don't leave raw font/size/weight on any text; don't mint one-off
+  documentation-only styles — snap to the nearest existing style instead.
+- **Every fill binds to a semantic color variable** — text fills (→
+  `text/primary`, `text/secondary`, etc.) *and* chrome/background fills (page
+  background, card and section surfaces → `bg/default`, `bg/subtle`, `bg/muted`).
+  Primitive swatches stay bound to their primitive (that's the point of them).
+
+The reason is **mode robustness**: if any title or background uses a hardcoded
+color, switching the file from Dark to Light (or any mode swap) leaves that piece
+stranded — light text on a light surface, a black title on a black panel — and
+the whole showcase looks broken. Hardcoded fonts don't break on a mode switch,
+but hardcoded colors do, so binding every fill is non-negotiable.
+
 **Lay it out cleanly.** Build every section with proper auto layout and arrange
 the sections inside a parent Section/Frame so nothing overlaps — follow the
 "Documentation artboards & canvas layout" rules in
@@ -63,6 +83,13 @@ the sections inside a parent Section/Frame so nothing overlaps — follow the
 visual-validation loop (screenshot → fix any overlapping text or colliding
 sections → re-screenshot) before the checkpoint. A showcase with overlaps isn't
 a showcase.
+
+**Validate both modes.** If the file has more than one mode (e.g. Dark/Light),
+temporarily set the sheet frame to the non-default mode
+(`setExplicitVariableModeForCollection`), screenshot, and confirm everything
+stays legible — no invisible titles, no stranded backgrounds. Then clear the
+explicit mode to restore the default. If anything breaks, the culprit is a fill
+that isn't bound to a semantic variable — bind it and re-check.
 
 ## Step 3 — Checkpoint
 
@@ -80,4 +107,6 @@ with a token sync. Offer natural next steps (icons, components). Don't auto-run.
 
 - Beautiful and on-brand is a requirement, not a nice-to-have.
 - Live-bind where possible; be honest about what needs a regenerate.
+- The sheet must consume its own system: every text node on a text style, every
+  fill on a semantic color variable, so it survives a mode switch.
 - One dedicated page named **Foundations**.


### PR DESCRIPTION
Two related design-system fidelity fixes, each its own release commit.

## v0.2.2 — `token-sheet-builder` fully binds the Foundations page chrome

The generated **Foundations** stylesheet only bound its swatches to the system; the page *chrome* (section titles, labels, hex/value text) kept raw fonts and hardcoded colors, and section/background fills were unbound. Switching the file Dark→Light stranded titles and panels (e.g. black text on a black surface) and the showcase looked broken.

- Skill now requires **every text node on a text style** and **every fill (text + chrome/background) bound to a semantic color variable**.
- Adds a **both-modes validation step** (set the non-default mode, screenshot, confirm legibility, restore) to catch any unbound fill before the checkpoint.
- Applied + verified live on the test file (247/247 text nodes styled, all fills bound, Dark↔Light confirmed clean).

## v0.2.3 — finalizing a component updates its Figma doc card

A component that reached the end of the pipeline (code + stories built and approved) kept showing the `draft` pill forever — nothing promoted it.

- Components now have an explicit lifecycle: `component-builder` creates them at **`draft`**; `storybook-chromatic-builder` promotes them to **`stable`** on finalize (new Step 6), writing the new chip color (→ success) and last-updated date back into the doc card.
- Chip/label/date nodes get **deterministic names** (`Status`, `Status Label`, `Last Updated`) so the write-back can find them.
- Canonical **"Promoting a component's status"** routine added to `references/figma-component-standards.md` so the manifest and the artboard never disagree; manifest-only fallback when Figma isn't connected.

## Files
- `skills/token-sheet-builder/SKILL.md`
- `skills/component-builder/SKILL.md`
- `skills/storybook-chromatic-builder/SKILL.md`
- `skills/component-pipeline/SKILL.md`
- `references/figma-component-standards.md`, `references/manifest-schema.md`
- `.claude-plugin/plugin.json` (→ 0.2.3), `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)