### PR TITLE
Per-category Figma variable collection structure

### DIFF
--- a/docs/superpowers/plans/2026-06-03-figma-variable-collection-structure.md
+++ b/docs/superpowers/plans/2026-06-03-figma-variable-collection-structure.md
@@ -1,0 +1,630 @@
+# Figma Variable Collection Structure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Change the design-system skills so a generated token system uses per-category Figma variable collections (each owning its own mode axis), adds border-width tokens, and reverses the anti-redundancy doctrine — fixing the mode-collision and missing-border-width bugs at the source.
+
+**Architecture:** Pure markdown edits to plugin skill/reference files. No code, no test runner. Each task edits one file (or one tight cluster), with `grep` checks standing in for tests: verify the *old* guidance is gone and the *new* guidance is present, then a read-through for internal consistency. Frequent commits, one per task.
+
+**Tech Stack:** Markdown skill files under `skills/`, `references/`, `commands/`. Source of truth: `docs/superpowers/specs/2026-06-03-figma-variable-collection-structure-design.md`.
+
+**Conventions for every task:**
+- Edits use the Edit tool with the exact anchor strings quoted below.
+- "Verify" steps run from repo root: `/Users/jordansstudio/dev/throughline/.claude/worktrees/nervous-mestorf-38e650`.
+- Commit messages end with the repo's `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` trailer.
+
+---
+
+### Task 1: Rewrite `token-builder` Step 1 — Tiers bullet → collection structure
+
+**Files:**
+- Modify: `skills/token-builder/SKILL.md:76-80` (the `**Tiers**` bullet)
+
+- [ ] **Step 1: Replace the Tiers bullet with a Collection-structure bullet**
+
+Anchor to replace (the bullet currently at lines 76-80):
+
+```
+- **Tiers** — default to **two-tier** (primitive + semantic). Only raise the
+  option of a third **component** tier if the user signals multi-brand,
+  white-labeling, or a very large/robust component library — for a single-brand
+  project it adds complexity without payoff, so don't even surface it. If the
+  user opts in, component tokens alias onto semantic tokens (e.g.
+  `button.bg.primary` → `{color.bg.emphasis}`).
+```
+
+New text:
+
+```
+- **Tiers** — default to **two-tier** (primitive + semantic). Only raise the
+  option of a third **component** tier if the user signals multi-brand,
+  white-labeling, or a very large/robust component library — for a single-brand
+  project it adds complexity without payoff, so don't even surface it. If the
+  user opts in, component tokens alias onto semantic tokens (e.g.
+  `button.bg.primary` → `{color.bg.emphasis}`).
+- **Collection structure** — two *tiers*, but **one collection per category per
+  tier**, never one giant `Primitives` + one giant `Semantic`. In Figma a mode
+  axis (Light/Dark, Desktop/Mobile, Brand) belongs to the *collection*, so every
+  variable in a collection is forced to share its modes. Putting `space` in the
+  same collection as `color` drags spacing into Light/Dark, which is meaningless.
+  Default layout (single-brand): private primitive collections `_Color/Primitive`,
+  `_Typography/Primitive`, `_Radius/Primitive`, `_Border/Primitive`, and a
+  **public** `Spacing/Primitive`; published semantic collections `Color/Semantic`
+  (Light/Dark), `Spacing/Semantic`, `Typography/Semantic`, `Radius/Semantic`,
+  `Border/Semantic`. Privacy is the leading-`_` prefix. `size/icon/*` lives in
+  `Spacing/Primitive`; don't create a `Sizing` collection unless control
+  heights/avatars become real tokens.
+- **Multi-brand** — keep two axes in two collections so they don't multiply.
+  Brand lives on `_Color/Primitive` (modes = Brand A, Brand B = raw palettes);
+  Theme lives on `Color/Semantic` (modes = Light, Dark). A frame sets both
+  independently and Figma resolves `bg/default`(Light) → `{gray/50}` → Brand A's
+  gray. This keeps each collection ≤2 modes — under the Figma **Professional cap
+  of 4 modes/collection**. (Brand-on-primitive assumes brands differ in raw
+  palette, same role mapping; if a brand needs a *different* mapping, it also
+  becomes a mode on `Color/Semantic`.)
+```
+
+- [ ] **Step 2: Verify the new bullets are present**
+
+Run: `grep -n "Collection structure" skills/token-builder/SKILL.md && grep -n "Professional cap" skills/token-builder/SKILL.md`
+Expected: both match (one line each).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/token-builder/SKILL.md
+git commit -m "token-builder: add per-category collection + multi-brand structure to Step 1
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Reverse the anti-redundancy rule in `token-builder` → structural consistency
+
+**Files:**
+- Modify: `skills/token-builder/SKILL.md:85-100` (the `### The anti-redundancy rule` section)
+
+- [ ] **Step 1: Replace the entire anti-redundancy section**
+
+Anchor to replace (heading + body, lines 85-100):
+
+```
+### The anti-redundancy rule (prevents the "different every time" problem)
+
+A semantic token earns its existence **only when it represents a genuine mapping
+decision** — a role that could plausibly point at a different primitive, or that
+changes across modes. Do **not** manufacture a semantic token that is a 1:1
+passthrough to the only primitive that could fill it, and do **not** create a
+parallel semantic collection for a category that has no real mapping choices
+(this is the redundant-borders trap: a "semantic" border layer that just mirrors
+the one primitive border value adds pure overhead).
+
+Apply this test per category: *"Could this semantic role sensibly point at a
+different primitive, now or in another mode?"* If yes, it's a real semantic
+token. If no, keep that category single-tier — consumers reference the primitive
+directly, and you don't build a mirror collection. This is what makes the output
+consistent run-to-run instead of an arbitrary guess about which categories to
+duplicate.
+```
+
+New text:
+
+```
+### The structural-consistency rule (prevents the "different every time" problem)
+
+Every token concern gets **both** a primitive and a semantic collection, even
+when the semantic tier is a 1:1 passthrough today. A dimensional semantic tier
+(`Spacing/Semantic`, `Radius/Semantic`, `Border/Semantic`) is justified by a
+**plausible future mode axis** — e.g. adding Desktop/Mobile to spacing later —
+which only works if the semantic collection already exists to carry that axis.
+Building every concern the same way is also what makes the output consistent
+run-to-run instead of an arbitrary guess about which categories to duplicate.
+
+The one guardrail: **consistency does not license invented roles.** Semantic
+names must be real usage roles (`inset/md`, `width/focus`, `text/primary`),
+never just renamed primitive steps (`space/12`, `width/1`). A passthrough role
+with a meaningful name is fine; a fake role nobody applies is not. If you can't
+name a genuine role for a category, give it semantic roles that map to actual
+usage rather than mirroring the primitive scale step-for-step.
+```
+
+- [ ] **Step 2: Verify the doctrine flipped**
+
+Run: `grep -n "structural-consistency rule" skills/token-builder/SKILL.md && ! grep -n "keep that category single-tier" skills/token-builder/SKILL.md`
+Expected: heading matches; the old "single-tier" phrase is gone (command exits 0).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/token-builder/SKILL.md
+git commit -m "token-builder: replace anti-redundancy rule with structural-consistency doctrine
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Rewrite `token-builder` Step 2 (primitive tier) for per-category collections + privacy + border width
+
+**Files:**
+- Modify: `skills/token-builder/SKILL.md:102-124` (Step 2 body, through the manifest-update line)
+
+- [ ] **Step 1: Replace the Step 2 body**
+
+Anchor to replace — from the heading line `## Step 2 — Build the PRIMITIVE tier, then PAUSE` through the line `Do not proceed to the semantic tier until the user confirms.` (lines 102-124).
+
+New text:
+
+```
+## Step 2 — Build the PRIMITIVE tier, then PAUSE
+
+Create the **per-category primitive collections** and their variables via a
+scripted loop on the active write mechanism. Default set:
+
+- `_Color/Primitive` — color ramps (`gray/50…900`, `brand/50…900`,
+  `success`/`warning`/`danger`, `white`, `black`).
+- `Spacing/Primitive` — the spacing scale (`space/0,2,4,8,12,16,24,32,48,64`)
+  **plus** `size/icon/{sm,md,lg}`.
+- `_Typography/Primitive` — `family/*`, `size/*`, `weight/*`, `lineHeight/*`,
+  `letterSpacing/*`.
+- `_Radius/Primitive` — `radius/{none,sm,md,lg,xl,full}`.
+- `_Border/Primitive` — `width/{0,1,2,4}`. **Do not skip border width** — borders
+  need a width primitive, not only a color.
+
+**Privacy:** the leading-`_` prefix hides a collection from the published
+library. Keep color/type/radius/border primitives private (they're always
+consumed through semantics or styles). Make **`Spacing/Primitive` public** (no
+underscore) — spacing semantics are intentionally minimal, so designers will grab
+raw `space/*` for one-off gaps. Note the trade-off in your checkpoint summary: a
+value applied directly from `Spacing/Primitive` is *frozen across device modes*;
+only `Spacing/Semantic` carries future Desktop/Mobile responsiveness.
+
+**Modes at the primitive tier:** primitives are usually mode-free (a single
+*Value* mode). The exception is multi-brand: give `_Color/Primitive` a Brand mode
+axis (Brand A, Brand B) holding each brand's raw palette. All other primitive
+collections stay single-mode.
+
+Then **stop and checkpoint.** This is the critical seam: semantic tokens are
+about to alias onto these primitives, so the primitive names and values must be
+right *before* you build on them. Show the user the created collections —
+summarize the ramps and scales, note which are public vs private, and if helpful
+mention the token-sheet-builder skill can render them visually later. Ask for
+explicit confirmation: "Here are your primitives. Once you're happy, I'll build
+the semantic layer on top — and after that, renaming primitives gets disruptive,
+so this is the moment to adjust names or values."
+
+Update the manifest: `tokens.primitivesBuilt` = `true`, add every created
+collection name to `tokens.collections`.
+
+Do not proceed to the semantic tier until the user confirms.
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `grep -n "_Border/Primitive" skills/token-builder/SKILL.md && grep -n "Make \*\*\`Spacing/Primitive\` public" skills/token-builder/SKILL.md && ! grep -n "Create the primitive variable collection (e.g. named" skills/token-builder/SKILL.md`
+Expected: border + public-spacing matches present; old singular-collection phrasing gone (exit 0).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/token-builder/SKILL.md
+git commit -m "token-builder: rewrite primitive tier for per-category collections, privacy, border width
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Rewrite `token-builder` Step 3 (semantic tier) for per-category collections, per-axis modes, border-width semantics
+
+**Files:**
+- Modify: `skills/token-builder/SKILL.md:126-152` (Step 3 body)
+
+- [ ] **Step 1: Replace the Step 3 body**
+
+Anchor to replace — from `## Step 3 — Build the SEMANTIC tier as aliases` through the manifest-update line ending `add the semantic collection to tokens.collections.` (lines 126-152).
+
+New text:
+
+```
+## Step 3 — Build the SEMANTIC tier as aliases
+
+Create the **per-category semantic collections**, where every variable
+**references a primitive**, not a literal value. Bind each semantic variable to
+its primitive so the alias is live. Default set and modes:
+
+- `Color/Semantic` — modes **Light, Dark** (+ a Brand mode only if a brand needs
+  a different *mapping*, not just a different palette). Roles: `bg/{default,
+  subtle,muted,emphasis,inverse}`, `text/{primary,secondary,disabled,inverse,
+  link}`, `border/{default,subtle,focus,emphasis}`, `status/{success,warning,
+  danger}/{bg,text,border}`.
+- `Spacing/Semantic` — single *Default* mode now, structured so Desktop/Mobile
+  can be added later. Roles: `inset/{xs,sm,md,lg,xl}`, `stack/*`, `inline/*`.
+- `Typography/Semantic` — single *Default* mode (room for Desktop/Mobile). Roles:
+  `size/{body,bodyLg,heading/sm…xl,caption}` and role line-heights; these feed
+  the text styles built in Step 4.
+- `Radius/Semantic` — single mode. Roles: `control`, `card`, `pill`, `field`.
+- `Border/Semantic` — single mode. Roles: `width/{default,focus,emphasis}`
+  aliasing `_Border/Primitive` widths.
+
+These dimensional semantic tiers are often passthroughs today — that's expected
+under the structural-consistency rule; keep the role names real (`inset/md`, not
+`space/16`).
+
+The **color** semantic tier is where the Light/Dark switch lives:
+`color.bg.default` → `{gray/50}` in Light and `{gray/900}` in Dark. Primitives
+stay fixed; the semantic aliases differ per mode. This is exactly what lets the
+sync layer emit `:root`/`.dark` for web later.
+
+**Mode-application reality (state this to the user):** a frame can now carry up
+to three independent modes — Brand (`_Color/Primitive`), Theme (`Color/Semantic`),
+and later Device (`Spacing`/`Typography`). That's the cost of independent axes.
+
+Verify the aliases resolve (a quick read showing semantic tokens point at
+primitives, not literals). Then checkpoint: show the semantic layer and
+demonstrate the cascade if useful ("change `gray/50` and `bg/default` follows").
+
+Update the manifest: `tokens.semanticBuilt` = `true`, add every semantic
+collection to `tokens.collections`.
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `grep -n "width/{default,focus,emphasis}" skills/token-builder/SKILL.md && grep -n "up to three independent modes" skills/token-builder/SKILL.md && ! grep -n "Create the semantic variable collection (e.g." skills/token-builder/SKILL.md`
+Expected: border-width semantic + three-modes matches present; old singular phrasing gone.
+
+- [ ] **Step 3: Read-through consistency check**
+
+Read `skills/token-builder/SKILL.md` Steps 1-3 end to end. Confirm: collection names are spelled identically everywhere (`_Color/Primitive`, `Spacing/Primitive`, `Color/Semantic`, …); no remaining reference to a single `Primitives`/`Semantic` collection; the "Notes that matter" section (still below) doesn't contradict the new structure.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/token-builder/SKILL.md
+git commit -m "token-builder: rewrite semantic tier for per-category collections and per-axis modes
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Update `token-builder` "Notes that matter" for privacy + multi-mode primitives
+
+**Files:**
+- Modify: `skills/token-builder/SKILL.md:188-198` (the `## Notes that matter` list)
+
+- [ ] **Step 1: Add three notes to the list**
+
+Anchor — the existing first bullet:
+
+```
+- **Never flatten semantic into literals.** Aliases are the whole point.
+```
+
+Replace with:
+
+```
+- **Never flatten semantic into literals.** Aliases are the whole point.
+- **One collection per category per tier.** Modes belong to the collection, so
+  splitting by category is what keeps color's Light/Dark from infecting spacing.
+- **Privacy is the `_` prefix.** Only `Spacing/Primitive` is public by default;
+  all other primitives are private.
+- **Primitives can be multi-mode.** Brand lives on `_Color/Primitive`; the sync
+  layer must emit brand themes from the primitive tier, not just light/dark from
+  semantics.
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `grep -n "One collection per category per tier" skills/token-builder/SKILL.md`
+Expected: one match.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/token-builder/SKILL.md
+git commit -m "token-builder: add structure/privacy/multi-mode-primitive notes
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Reverse the second anti-redundancy copy in `brainstorm-before-build.md` (import mode)
+
+**Files:**
+- Modify: `references/brainstorm-before-build.md:52-67` (Import bullet) and `:53` two-tier wording
+
+- [ ] **Step 1: Replace the "Flag redundancy as a cleanup opportunity" paragraph**
+
+Anchor to replace (lines 58-67):
+
+```
+  **Flag redundancy as a cleanup opportunity.** While ingesting, apply the
+  anti-redundancy test (see token-builder Step 1). If their existing set
+  contains redundant structure — e.g. a "semantic" collection that just mirrors
+  primitives 1:1 with no real mapping decision — don't silently preserve it and
+  don't silently collapse it. Surface it: "Your imported system has a few places
+  that look redundant — for example, your semantic border tokens just pass
+  through to single primitives. I can collapse those to keep things lean, or
+  preserve your structure exactly as-is. Which would you prefer?" Let the user
+  choose per case (or all at once). Cleaning up is often the more valuable
+  service, but it's their system, so it's their call.
+```
+
+New text:
+
+```
+  **Organize into per-category collections.** While ingesting, map their values
+  onto the structural-consistency model (see token-builder Step 1): one
+  primitive and one semantic collection per category, split so each category owns
+  its own mode axis. Passthrough dimensional semantics (e.g. border-width
+  semantics that alias a single primitive) are **expected and kept** — they exist
+  to carry a future mode axis — so do not collapse them. The only thing to flag
+  is a genuine naming problem: a "semantic" token that's just a renamed primitive
+  step with no real role (`space-12` rather than `inset/md`). Surface those:
+  "A few of your semantic names mirror primitive steps rather than naming a role
+  — want me to rename them to usage roles, or keep them as-is?" Let the user
+  choose. Keep structure; fix only fake roles.
+```
+
+- [ ] **Step 2: Update the two-tier framing in the Import bullet**
+
+Anchor (line 53): `existing system) and wants it ingested and organized into the two-tier Figma`
+Replace with: `existing system) and wants it ingested and organized into the per-category Figma`
+
+- [ ] **Step 3: Verify**
+
+Run: `! grep -n "I can collapse those to keep things lean" references/brainstorm-before-build.md && grep -n "Organize into per-category collections" references/brainstorm-before-build.md`
+Expected: old collapse phrasing gone (exit 0); new heading present.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add references/brainstorm-before-build.md
+git commit -m "brainstorm-before-build: align import mode with structural-consistency doctrine
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Update the sync layer for N collections, single-mode-non-themed, multi-mode primitives, and a name-mapping rule
+
+**Files:**
+- Modify: `skills/token-sync-layer/SKILL.md:74-93`
+- Modify: `references/sync-adapters.md:88-95`
+
+- [ ] **Step 1: Replace the extraction paragraph in `token-sync-layer`**
+
+Anchor (lines 74-79):
+
+```
+Using the active write mechanism (`figma.mechanism`, default Console MCP —
+prefer its full-design-system extraction, which works on any Figma plan), read
+the variable collections and normalize them into **DTCG-format JSON** (`$value`,
+`$type`, with semantic tokens expressed as `{group.token}` references to
+primitives, not flattened literals). Preserve modes (light/dark/brand) as the
+DTCG structure the adapters expect.
+```
+
+New text:
+
+```
+Using the active write mechanism (`figma.mechanism`, default Console MCP —
+prefer its full-design-system extraction, which works on any Figma plan), read
+**every variable collection** (there are now several per tier, e.g.
+`_Color/Primitive`, `Spacing/Primitive`, `Color/Semantic`, …) and normalize them
+into **DTCG-format JSON** (`$value`, `$type`, with semantic tokens expressed as
+`{group.token}` references to primitives, not flattened literals).
+
+Three rules for the multi-collection structure:
+- **Iterate N collections**, not a fixed two. Don't assume one `Primitives` +
+  one `Semantic`.
+- **Single-mode collections are non-themed** — a collection with one mode (e.g.
+  `Spacing/Semantic`) emits flat values, never a phantom `default` theme
+  alongside `:root`/`.dark`.
+- **Primitives can be multi-mode** — `_Color/Primitive` carries a Brand axis, so
+  emit **brand themes from the primitive tier**, not just light/dark from
+  semantics. Preserve modes (light/dark/brand/device) as the DTCG structure the
+  adapters expect.
+- **Name mapping:** collapse the tier/category prefix into clean token names —
+  `_Color/Primitive` + `gray/500` → `color.gray.500` (not
+  `color.primitive.gray.500`); `Color/Semantic` + `text/primary` →
+  `color.text.primary`. The category drives the top-level group; the tier (and
+  the `_`) is dropped from the emitted name.
+```
+
+- [ ] **Step 2: Update the adapter modes note in `sync-adapters.md`**
+
+Anchor (lines 88-91):
+
+```
+- **Web adapters** (`shadcn`, `tailwind`, `mui`, `vanilla-css`): set
+  `outputReferences: true` so `--color-bg-default: var(--color-gray-50)` is
+  emitted, preserving the cascade. Modes map to selectors: primitives in
+  `:root`, semantic mode overrides under `.dark` / `[data-theme="..."]`. The
+```
+
+New text:
+
+```
+- **Web adapters** (`shadcn`, `tailwind`, `mui`, `vanilla-css`): set
+  `outputReferences: true` so `--color-bg-default: var(--color-gray-50)` is
+  emitted, preserving the cascade. Modes map to selectors per axis: theme
+  overrides (from `Color/Semantic`) under `.dark` / `[data-theme="..."]`, and
+  **brand overrides (from the multi-mode `_Color/Primitive`)** under a
+  `[data-brand="..."]` selector. Single-mode collections emit flat values in
+  `:root` with no theme selector. The
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `grep -n "Iterate N collections" skills/token-sync-layer/SKILL.md && grep -n "brand themes from the primitive tier" skills/token-sync-layer/SKILL.md && grep -n "data-brand" references/sync-adapters.md`
+Expected: all three match.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/token-sync-layer/SKILL.md references/sync-adapters.md
+git commit -m "token-sync-layer: handle N collections, multi-mode primitives, name mapping
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Add border-width binding + spacing-tier rule to `component-builder`
+
+**Files:**
+- Modify: `skills/component-builder/SKILL.md:88-92` (the "Bind every visual property" bullet)
+
+- [ ] **Step 1: Replace the binding bullet**
+
+Anchor (lines 88-92):
+
+```
+- **Bind every visual property to the system's tokens/styles** — fills to
+  semantic color variables, padding to spacing variables, corners to radius
+  variables, text to text styles, shadows to effect styles. A component must
+  *consume* the design system, never hardcode values. This is what makes the
+  token cascade reach components.
+```
+
+New text:
+
+```
+- **Bind every visual property to the system's tokens/styles** — fills to
+  `Color/Semantic` variables, corners to `Radius/Semantic` variables, **border
+  width to `Border/Semantic` width variables and border color to `Color/Semantic`
+  border variables** (a button/input/card border needs both), text to text
+  styles, shadows to effect styles. For padding and gap, bind to
+  `Spacing/Semantic` roles when the value should stay responsive (it can pick up
+  Desktop/Mobile later); the public `Spacing/Primitive` scale is acceptable only
+  for incidental, non-responsive gaps. A component must *consume* the design
+  system, never hardcode values. This is what makes the token cascade reach
+  components.
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `grep -n "Border/Semantic" skills/component-builder/SKILL.md && grep -n "non-responsive gaps" skills/component-builder/SKILL.md`
+Expected: both match.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/component-builder/SKILL.md
+git commit -m "component-builder: bind component borders to border-width tokens; spacing-tier rule
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: Update the manifest schema example + low-touch wording
+
+**Files:**
+- Modify: `references/manifest-schema.md:150-151`
+- Modify: `skills/token-sheet-builder/SKILL.md:41-43` (default sections list)
+
+- [ ] **Step 1: Update the `collections` example in the manifest schema**
+
+Anchor (lines 150-151):
+
+```
+- `collections` — names of the Figma variable collections created (e.g.
+  `["Primitives", "Semantic"]`).
+```
+
+New text:
+
+```
+- `collections` — names of the Figma variable collections created. With the
+  per-category structure this is several names per tier, e.g.
+  `["_Color/Primitive", "Spacing/Primitive", "_Typography/Primitive",
+  "_Radius/Primitive", "_Border/Primitive", "Color/Semantic", "Spacing/Semantic",
+  "Typography/Semantic", "Radius/Semantic", "Border/Semantic"]`.
+```
+
+- [ ] **Step 2: Add Border width to the token-sheet default sections**
+
+Anchor (lines 41-43):
+
+```
+itself (the page should feel like the brand it documents). Default to a clean,
+sectioned layout: Color (ramps as rows of swatches), Typography (the type scale
+rendered in the actual text styles), Spacing (visual bars), Radius (sample
+shapes), Elevation (sample cards with the effect styles).
+```
+
+New text:
+
+```
+itself (the page should feel like the brand it documents). Default to a clean,
+sectioned layout, one section per collection/style group: Color (ramps as rows
+of swatches), Typography (the type scale rendered in the actual text styles),
+Spacing (visual bars), Radius (sample shapes), Border width (sample rules at
+each width), Elevation (sample cards with the effect styles).
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `grep -n "_Color/Primitive" references/manifest-schema.md && grep -n "Border width (sample rules" skills/token-sheet-builder/SKILL.md && ! grep -n '"Primitives", "Semantic"' references/manifest-schema.md`
+Expected: new manifest example + border-width section present; old `["Primitives", "Semantic"]` example gone (exit 0).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add references/manifest-schema.md skills/token-sheet-builder/SKILL.md
+git commit -m "manifest + token-sheet: per-category collections example and border-width section
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: Final sweep for stale two-collection assumptions
+
+**Files:**
+- Read-only audit across `skills/`, `references/`, `commands/`
+
+- [ ] **Step 1: Grep for any surviving "two collection" / `["Primitives", "Semantic"]` assumption**
+
+Run:
+```bash
+grep -rniE "two collection|both collections|the primitives collection|the semantic collection|\"Primitives\", ?\"Semantic\"" skills references commands --include="*.md"
+```
+Expected: no matches. If any appear, fix them in place to reference the per-category structure, then re-run until clean.
+
+- [ ] **Step 2: Confirm spec coverage**
+
+Open `docs/superpowers/specs/2026-06-03-figma-variable-collection-structure-design.md` and confirm each of the 7 change targets in its "Files to change" list maps to a task above (token-builder → Tasks 1-5; brainstorm-before-build → Task 6; token-sheet-builder → Tasks 9; token-sync-layer + sync-adapters → Task 7; component-builder → Task 8; manifest-schema → Task 9; low-touch files → Task 10 sweep). Note any gap and add a task.
+
+- [ ] **Step 3: Commit any fixes from Step 1**
+
+```bash
+git add -A
+git commit -m "Sweep: remove residual two-collection assumptions
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+(If Step 1 was already clean and nothing changed, skip the commit.)
+
+---
+
+## Self-Review
+
+**Spec coverage** — every "Files to change" item in the spec maps to a task:
+- `token-builder/SKILL.md` → Tasks 1 (structure), 2 (doctrine), 3 (primitives), 4 (semantics), 5 (notes) ✓
+- `brainstorm-before-build.md` → Task 6 ✓
+- `token-sheet-builder/SKILL.md` → Task 9 (border-width section; N-collection wording already present at line 48) ✓
+- `token-sync-layer/SKILL.md` + `sync-adapters.md` → Task 7 ✓
+- `component-builder/SKILL.md` → Task 8 ✓
+- `manifest-schema.md` → Task 9 ✓
+- low-touch (`figma-component-standards`, `storybook-chromatic-builder`, `component-pipeline`, `design-system-status`) → Task 10 sweep ✓
+
+**Placeholder scan** — no TBD/TODO; every edit step contains the exact replacement prose and exact grep anchors.
+
+**Name consistency** — collection names are spelled identically across tasks: `_Color/Primitive`, `Spacing/Primitive` (public, no underscore), `_Typography/Primitive`, `_Radius/Primitive`, `_Border/Primitive`, `Color/Semantic`, `Spacing/Semantic`, `Typography/Semantic`, `Radius/Semantic`, `Border/Semantic`. Border-width roles: primitive `width/{0,1,2,4}`, semantic `width/{default,focus,emphasis}`.

--- a/docs/superpowers/specs/2026-06-03-figma-variable-collection-structure-design.md
+++ b/docs/superpowers/specs/2026-06-03-figma-variable-collection-structure-design.md
@@ -88,11 +88,21 @@ A frame may now carry up to three independent modes: **Brand** (`_Color/Primitiv
    - Update the checkpoint structure (primitive tier is now several collections; checkpoint still happens before semantics).
    - Update frontmatter description if it implies "two collections."
 
-2. **`skills/token-sheet-builder/SKILL.md`** — iterate **N collections** when rendering the Foundations page (don't assume exactly Primitives + Semantic). Render border-width swatches.
+2. **`references/brainstorm-before-build.md`** — **second copy of the anti-redundancy doctrine.** Lines 60–64 (import-mode intake) tell the model to *collapse* passthrough dimensional semantics (it literally names "semantic border tokens just pass through to single primitives… I can collapse those"). Rewrite to the structural-consistency doctrine so import mode **preserves** per-category passthrough semantics instead of collapsing them. Also update the two-tier/collections framing (lines 53–55) to describe per-category collections. Keep two-tier as the default tier count.
 
-3. **`skills/token-sync-layer/SKILL.md`** (+ `references/sync-adapters.md` as needed) — extraction must iterate N collections and **treat a single-mode collection as non-themed** (no phantom `default` theme emitted alongside `:root`/`.dark`). Border-width tokens flow through to outputs.
+3. **`skills/token-sheet-builder/SKILL.md`** — iterate **N collections** when rendering the Foundations page (don't assume exactly Primitives + Semantic). Render border-width swatches.
 
-4. **`references/manifest-schema.md`** — verify `tokens.collections` is an array that can hold the larger set; adjust any wording that assumes two collections. (`primitivesBuilt`/`semanticBuilt` booleans still make sense as tier-level flags.)
+4. **`skills/token-sync-layer/SKILL.md`** (+ `references/sync-adapters.md` as needed) — three changes:
+   - Extraction iterates **N collections**, not two.
+   - **Single-mode collections are non-themed** (no phantom `default` theme alongside `:root`/`.dark`).
+   - **Primitives can now be multi-mode** (Brand axis on `_Color/Primitive`). The sync layer historically assumes primitives are mode-free; it must now emit **brand themes from the primitive tier**, not only light/dark from the semantic tier.
+   - Define a **collection-name → token-name mapping rule** so the tier/category prefix collapses cleanly (`_Color/Primitive` + `gray/500` → `color.gray.500`, not `color.primitive.gray.500`; `Color/Semantic` + `text/primary` → a clean role name). Border-width tokens flow through to outputs.
+
+5. **`skills/component-builder/SKILL.md`** — add **border-width binding** (button/input/card borders bind to `Border/Semantic` width + `Color/Semantic` border color); currently only color/spacing/radius are covered. Add an explicit **spacing-tier rule**: responsive padding/gaps bind to `Spacing/Semantic`; incidental non-responsive gaps may use the public `Spacing/Primitive`. Binding is by-variable so collection moves don't otherwise break it.
+
+6. **`references/manifest-schema.md`** — update the literal example at lines 150–151 (`["Primitives", "Semantic"]`) to the new per-category set; confirm `tokens.collections` array holds the larger set. `tiers` (2/3) and the `primitivesBuilt`/`semanticBuilt` tier-level flags stay valid.
+
+7. **Low-touch wording (no functional break — bind-by-role):** `references/figma-component-standards.md`, `skills/storybook-chromatic-builder/SKILL.md`, `skills/component-pipeline/SKILL.md`, `commands/design-system-status.md` — remove any "two collections" assumption, report/handle N collections, and fold in border-width awareness where components/status reference borders.
 
 ## Out of scope
 
@@ -105,5 +115,6 @@ A frame may now carry up to three independent modes: **Brand** (`_Color/Primitiv
 - A fresh run of `token-builder` produces per-category collections with correctly scoped modes (color carries Light/Dark; spacing/radius/etc. do not inherit them).
 - Border-width primitives and semantics exist.
 - `Spacing/Primitive` is public; other primitives are private.
-- No contradictory anti-redundancy guidance remains in the skill.
-- `token-sheet-builder` and `token-sync-layer` operate over N collections without assuming two, and don't emit phantom themes for single-mode collections.
+- No contradictory anti-redundancy guidance remains in **any** skill or reference (both `token-builder` and `brainstorm-before-build` import mode).
+- `token-sheet-builder` and `token-sync-layer` operate over N collections without assuming two, don't emit phantom themes for single-mode collections, and **emit brand themes from multi-mode primitive collections**.
+- `component-builder` binds component borders to the new border-width tokens.

--- a/docs/superpowers/specs/2026-06-03-figma-variable-collection-structure-design.md
+++ b/docs/superpowers/specs/2026-06-03-figma-variable-collection-structure-design.md
@@ -1,0 +1,109 @@
+# Figma Variable Collection Structure — Redesign
+
+**Date:** 2026-06-03
+**Scope:** Plugin skill instructions only (fix the defaults that future design systems are built from). Does **not** touch any existing live Figma file.
+**Status:** Approved for planning
+
+## Problem
+
+The `token-builder` skill conflated "two-tier" (two *layers* of tokens: primitive → semantic) with "two *collections*" (one `Primitives`, one `Semantic`). It instructs the model to put every token category — color, spacing, typography, radius, borders — into those two collections.
+
+In Figma, a **mode axis** (Light/Dark, Desktop/Mobile, Density) is a property of a **collection**: every variable in a collection is forced to share its modes. So grouping `space` into the same collection as `color` forces spacing to inherit Light/Dark modes, which is meaningless, and leaves no clean place to give spacing its own Desktop/Mobile axis later.
+
+Two concrete bugs result:
+1. **Mode collision** — non-color categories inherit color's Light/Dark modes.
+2. **Missing border-width tokens** — only border *color* was ever created; there are no variables representing border *width*.
+
+## Decision
+
+Restructure the default into **per-category collections, split by tier** ("full Option B"). Two tiers remain the standard (primitive → semantic). The number of *collections* grows so that each category owns its own independent mode axes.
+
+This reverses the skill's current **anti-redundancy rule**, which must be rewritten (see below), not left to contradict the new doctrine.
+
+### Why per-category primitives (not one shared primitives collection)
+
+Multi-brand is plausible for this system, and per-category primitives is what makes it clean. Figma modes are a **flat list** per collection — they do not stack into dimensions. Putting brand × theme on a single `Color/Semantic` collection needs `BrandA-Light, BrandA-Dark, BrandB-Light, BrandB-Dark` = 4 flat modes, which is exactly the **Professional plan cap (4 modes/collection)**; a third brand or a high-contrast variant breaks it.
+
+Splitting the axes across collections dissolves this:
+
+- **`_Color/Primitive`** carries the **Brand** axis (Brand A, Brand B = raw palettes)
+- **`Color/Semantic`** carries the **Theme** axis (Light, Dark = role mapping)
+
+A frame sets both modes independently; Figma resolves `bg/default` (Light) → `{gray/50}` → Brand A's gray. Each collection stays at ≤2 modes, well under the Professional cap, and brands scale without touching spacing/radius/type. (This works because brands differ in *raw palette*, same role mapping. If a brand ever needed a *different* mapping, that brand would also become a mode on `Color/Semantic`.)
+
+## Target Structure (10 collections: 5 primitive + 5 semantic)
+
+### Primitive tier — mode-free unless noted
+
+| Collection | Privacy | Modes | Contents |
+|-----------|---------|-------|----------|
+| `_Color/Primitive` | private | **Brand A, Brand B** (single *Value* until multi-brand) | `gray/50…900`, `brand/50…900`, `success`·`warning`·`danger` ramps, `white`, `black` |
+| `Spacing/Primitive` | **public** | *Value* | `space/0,2,4,8,12,16,24,32,48,64`; `size/icon/{sm,md,lg}` folded in here |
+| `_Typography/Primitive` | private | *Value* | `family/{sans,serif,mono}`, `size/100…900`, `weight/{regular,medium,semibold,bold}`, `lineHeight/{tight,normal,relaxed}`, `letterSpacing/{tight,normal,wide}` |
+| `_Radius/Primitive` | private | *Value* | `radius/{none,sm,md,lg,xl,full}` |
+| `_Border/Primitive` | private | *Value* | `width/{0,1,2,4}` |
+
+### Semantic tier — published, named by role
+
+| Collection | Modes | Contents |
+|-----------|-------|----------|
+| `Color/Semantic` | **Light, Dark** | `bg/{default,subtle,muted,emphasis,inverse}`, `text/{primary,secondary,disabled,inverse,link}`, `border/{default,subtle,focus,emphasis}`, `status/{success,warning,danger}/{bg,text,border}` |
+| `Spacing/Semantic` | *Default* (→ Desktop/Mobile later) | `inset/{xs,sm,md,lg,xl}`, `stack/{xs…xl}`, `inline/{xs…xl}` |
+| `Typography/Semantic` | *Default* (→ Desktop/Mobile later) | `size/{body,bodyLg,heading/sm…xl,caption}`, role line-heights → feed text styles |
+| `Radius/Semantic` | *Default* | `control`, `card`, `pill`, `field` |
+| `Border/Semantic` | *Default* | `width/{default,focus,emphasis}` |
+
+**`Sizing` is intentionally not created.** `size/icon/*` lives in `Spacing/Primitive`; a dedicated `Sizing` pair is added later only if control heights / avatars become real tokens (they're often derived, not tokenized).
+
+### Not variables
+
+Shadows / elevation remain **Figma effect styles**, created in the styles phase and bound to any primitive numbers they need. Unchanged from today.
+
+## Doctrine change: replace the anti-redundancy rule
+
+The current rule (`skills/token-builder/SKILL.md:85-100`) says *don't* build a semantic mirror for a category with no real mapping decision. Under the new structure, dimensional semantic tiers (`Spacing/Semantic`, `Radius/Semantic`, `Border/Semantic`) are **1:1 passthroughs today**, justified by future mode-axis flexibility. The rule must be **rewritten**, not appended, to:
+
+> **Structural consistency.** Every token concern gets both a primitive and a semantic collection. A dimensional semantic tier is justified by a plausible future mode axis even when it is a passthrough today. *Consistency does not license invented roles* — semantic names must still be real usage roles (`inset/md`, `width/focus`), never just renamed primitive steps (`space/12`).
+
+## Privacy
+
+- Privacy mechanism is the **`_` name prefix** (hides a collection from the published library).
+- **`Spacing/Primitive` is public** (no underscore) — spacing semantics are intentionally minimal, so designers will reach for raw `space/*` for one-off gaps.
+- All other primitives stay private; color/radius/border/type are always consumed via semantics or styles.
+- **Device-mode caveat to document:** a value applied directly from `Spacing/Primitive` is *frozen across device modes* — only the `Spacing/Semantic` layer carries future Desktop/Mobile responsiveness. Rule: grab a raw `space/*` for incidental non-responsive gaps; anything that should shrink on mobile must go through a semantic role.
+
+## Mode-application reality to document
+
+A frame may now carry up to three independent modes: **Brand** (`_Color/Primitive`), **Theme** (`Color/Semantic`), and later **Device** (`Spacing`/`Typography`). This is the cost of the flexibility and should be stated plainly in the skill so it isn't a surprise.
+
+## Files to change
+
+1. **`skills/token-builder/SKILL.md`** — primary rewrite:
+   - Replace the two-collection model (Steps 2–3) with the per-category primitive + semantic structure above.
+   - Rewrite the anti-redundancy rule → structural-consistency doctrine.
+   - Add **border-width** primitives + semantics to the worked examples.
+   - Add the brand-on-primitive / theme-on-semantic multi-brand guidance and the Professional 4-mode cap note.
+   - Add the privacy (`_` prefix), public-spacing-primitive, and device-mode caveats.
+   - Document the up-to-three-modes application reality.
+   - Update the checkpoint structure (primitive tier is now several collections; checkpoint still happens before semantics).
+   - Update frontmatter description if it implies "two collections."
+
+2. **`skills/token-sheet-builder/SKILL.md`** — iterate **N collections** when rendering the Foundations page (don't assume exactly Primitives + Semantic). Render border-width swatches.
+
+3. **`skills/token-sync-layer/SKILL.md`** (+ `references/sync-adapters.md` as needed) — extraction must iterate N collections and **treat a single-mode collection as non-themed** (no phantom `default` theme emitted alongside `:root`/`.dark`). Border-width tokens flow through to outputs.
+
+4. **`references/manifest-schema.md`** — verify `tokens.collections` is an array that can hold the larger set; adjust any wording that assumes two collections. (`primitivesBuilt`/`semanticBuilt` booleans still make sense as tier-level flags.)
+
+## Out of scope
+
+- The user's existing live Figma file (separate future session).
+- Component-tier tokens (third tier) — still only surfaced for multi-brand/large libraries, unchanged.
+- Building a `Sizing` collection now.
+
+## Success criteria
+
+- A fresh run of `token-builder` produces per-category collections with correctly scoped modes (color carries Light/Dark; spacing/radius/etc. do not inherit them).
+- Border-width primitives and semantics exist.
+- `Spacing/Primitive` is public; other primitives are private.
+- No contradictory anti-redundancy guidance remains in the skill.
+- `token-sheet-builder` and `token-sync-layer` operate over N collections without assuming two, and don't emit phantom themes for single-mode collections.

--- a/references/brainstorm-before-build.md
+++ b/references/brainstorm-before-build.md
@@ -50,21 +50,22 @@ behaviors. Ask this first, route accordingly:
   adjectives to decisions (e.g. "rounded" → larger radius scale, "dense" →
   tighter spacing base). Propose values back for sign-off.
 - **Import** — the user already has a token set (a JSON file, a list, an
-  existing system) and wants it ingested and organized into the two-tier Figma
+  existing system) and wants it ingested and organized into the per-category Figma
   structure. Generate as little as possible; preserve their values and names
   where sensible, only adding structure (tiers, collections) and flagging gaps.
   Do not invent values they didn't provide unless they ask.
 
-  **Flag redundancy as a cleanup opportunity.** While ingesting, apply the
-  anti-redundancy test (see token-builder Step 1). If their existing set
-  contains redundant structure — e.g. a "semantic" collection that just mirrors
-  primitives 1:1 with no real mapping decision — don't silently preserve it and
-  don't silently collapse it. Surface it: "Your imported system has a few places
-  that look redundant — for example, your semantic border tokens just pass
-  through to single primitives. I can collapse those to keep things lean, or
-  preserve your structure exactly as-is. Which would you prefer?" Let the user
-  choose per case (or all at once). Cleaning up is often the more valuable
-  service, but it's their system, so it's their call.
+  **Organize into per-category collections.** While ingesting, map their values
+  onto the structural-consistency model (see token-builder Step 1): one
+  primitive and one semantic collection per category, split so each category owns
+  its own mode axis. Passthrough dimensional semantics (e.g. border-width
+  semantics that alias a single primitive) are **expected and kept** — they exist
+  to carry a future mode axis — so do not collapse them. The only thing to flag
+  is a genuine naming problem: a "semantic" token that's just a renamed primitive
+  step with no real role (`space-12` rather than `inset/md`). Surface those:
+  "A few of your semantic names mirror primitive steps rather than naming a role
+  — want me to rename them to usage roles, or keep them as-is?" Let the user
+  choose. Keep structure; fix only fake roles.
 
 Many users are a blend (e.g. "here's my 2 brand colors and a font, fill in the
 rest" is generative with seeds). Identify the dominant mode, confirm it, and

--- a/references/manifest-schema.md
+++ b/references/manifest-schema.md
@@ -147,8 +147,11 @@ bailing or running silently.
 - `primitivesBuilt` / `semanticBuilt` / `stylesBuilt` — phase completion flags.
   The primitive→semantic checkpoint seam depends on the first two; `stylesBuilt`
   covers the text/effect/grid styles phase.
-- `collections` — names of the Figma variable collections created (e.g.
-  `["Primitives", "Semantic"]`).
+- `collections` — names of the Figma variable collections created. With the
+  per-category structure this is several names per tier, e.g.
+  `["_Color/Primitive", "Spacing/Primitive", "_Typography/Primitive",
+  "_Radius/Primitive", "_Border/Primitive", "Color/Semantic", "Spacing/Semantic",
+  "Typography/Semantic", "Radius/Semantic", "Border/Semantic"]`.
 - `styleGroups` — names of Figma style groups created (e.g.
   `["Text", "Elevation"]`). Styles are distinct from variables.
 - `lastSync` — ISO timestamp tokens were last extracted to code (set by skill 6,

--- a/references/sync-adapters.md
+++ b/references/sync-adapters.md
@@ -87,8 +87,11 @@ emit as references to primitive vars rather than flattened literals.
 
 - **Web adapters** (`shadcn`, `tailwind`, `mui`, `vanilla-css`): set
   `outputReferences: true` so `--color-bg-default: var(--color-gray-50)` is
-  emitted, preserving the cascade. Modes map to selectors: primitives in
-  `:root`, semantic mode overrides under `.dark` / `[data-theme="..."]`. The
+  emitted, preserving the cascade. Modes map to selectors per axis: theme
+  overrides (from `Color/Semantic`) under `.dark` / `[data-theme="..."]`, and
+  **brand overrides (from the multi-mode `_Color/Primitive`)** under a
+  `[data-brand="..."]` selector. Single-mode collections emit flat values in
+  `:root` with no theme selector. The
   `shadcn` adapter additionally emits a Tailwind preset mapping the CSS vars to
   Tailwind tokens; the standalone `tailwind` adapter maps tokens into the
   Tailwind theme config directly; `mui` emits a JS theme object whose palette

--- a/skills/component-builder/SKILL.md
+++ b/skills/component-builder/SKILL.md
@@ -86,10 +86,15 @@ deterministic naming):
 - **Use auto layout throughout** so the component resizes correctly and maps to
   clean flex/padding in code — bind padding and gap to spacing tokens.
 - **Bind every visual property to the system's tokens/styles** — fills to
-  semantic color variables, padding to spacing variables, corners to radius
-  variables, text to text styles, shadows to effect styles. A component must
-  *consume* the design system, never hardcode values. This is what makes the
-  token cascade reach components.
+  `Color/Semantic` variables, corners to `Radius/Semantic` variables, **border
+  width to `Border/Semantic` width variables and border color to `Color/Semantic`
+  border variables** (a button/input/card border needs both), text to text
+  styles, shadows to effect styles. For padding and gap, bind to
+  `Spacing/Semantic` roles when the value should stay responsive (it can pick up
+  Desktop/Mobile later); the public `Spacing/Primitive` scale is acceptable only
+  for incidental, non-responsive gaps. A component must *consume* the design
+  system, never hardcode values. This is what makes the token cascade reach
+  components.
 - Implement slots per the slot-contract model below.
 - **Wrap each component in its own documentation card** — a token-styled frame
   with the component name, a short description, a status chip

--- a/skills/token-builder/SKILL.md
+++ b/skills/token-builder/SKILL.md
@@ -163,29 +163,42 @@ Do not proceed to the semantic tier until the user confirms.
 
 ## Step 3 — Build the SEMANTIC tier as aliases
 
-Create the semantic variable collection (e.g. `Semantic`) where every variable
-**references a primitive**, not a literal value. In Figma variable terms, bind
-each semantic variable to its primitive variable so the alias is live.
+Create the **per-category semantic collections**, where every variable
+**references a primitive**, not a literal value. Bind each semantic variable to
+its primitive so the alias is live. Default set and modes:
 
-Organize semantics by role, e.g.:
-- `color.bg.default`, `color.bg.subtle`, `color.bg.emphasis`
-- `color.text.primary`, `color.text.secondary`, `color.text.disabled`
-- `color.border.default`, `color.border.focus`
-- `space.inset.sm/md/lg`, `space.stack.*`
-- `radius.sm/md/lg`, etc.
+- `Color/Semantic` — modes **Light, Dark** (+ a Brand mode only if a brand needs
+  a different *mapping*, not just a different palette). Roles: `bg/{default,
+  subtle,muted,emphasis,inverse}`, `text/{primary,secondary,disabled,inverse,
+  link}`, `border/{default,subtle,focus,emphasis}`, `status/{success,warning,
+  danger}/{bg,text,border}`.
+- `Spacing/Semantic` — single *Default* mode now, structured so Desktop/Mobile
+  can be added later. Roles: `inset/{xs,sm,md,lg,xl}`, `stack/*`, `inline/*`.
+- `Typography/Semantic` — single *Default* mode (room for Desktop/Mobile). Roles:
+  `size/{body,bodyLg,heading/sm…xl,caption}` and role line-heights; these feed
+  the text styles built in Step 4.
+- `Radius/Semantic` — single mode. Roles: `control`, `card`, `pill`, `field`.
+- `Border/Semantic` — single mode. Roles: `width/{default,focus,emphasis}`
+  aliasing `_Border/Primitive` widths.
 
-If the system has light/dark modes, the **semantic** tier is typically where the
-mode switch lives: `color.bg.default` points at `{color.gray.50}` in light mode
-and `{color.gray.900}` in dark mode. The primitives stay fixed; the semantic
-aliases differ per mode. This keeps theming clean and is exactly what lets the
-sync layer emit `:root` / `.dark` (or equivalent) for web adapters later.
+These dimensional semantic tiers are often passthroughs today — that's expected
+under the structural-consistency rule; keep the role names real (`inset/md`, not
+`space/16`).
+
+The **color** semantic tier is where the Light/Dark switch lives:
+`color.bg.default` → `{gray/50}` in Light and `{gray/900}` in Dark. Primitives
+stay fixed; the semantic aliases differ per mode. This is exactly what lets the
+sync layer emit `:root`/`.dark` for web later.
+
+**Mode-application reality (state this to the user):** a frame can now carry up
+to three independent modes — Brand (`_Color/Primitive`), Theme (`Color/Semantic`),
+and later Device (`Spacing`/`Typography`). That's the cost of independent axes.
 
 Verify the aliases resolve (a quick read showing semantic tokens point at
-primitives, not literals). Then checkpoint with the user: show the semantic
-layer and demonstrate the cascade if useful ("if you change `color.gray.50`,
-`color.bg.default` follows automatically").
+primitives, not literals). Then checkpoint: show the semantic layer and
+demonstrate the cascade if useful ("change `gray/50` and `bg/default` follows").
 
-Update the manifest: `tokens.semanticBuilt` = `true`, add the semantic
+Update the manifest: `tokens.semanticBuilt` = `true`, add every semantic
 collection to `tokens.collections`.
 
 ## Step 4 — Build Figma STYLES (the third phase)

--- a/skills/token-builder/SKILL.md
+++ b/skills/token-builder/SKILL.md
@@ -10,13 +10,18 @@ description: Build a modern two-tier (primitive + semantic) design token system 
 > Sonnet is a solid default; Opus helps for large or multi-mode systems. See the
 > model guide in the plugin README.
 
-Creates a two-tier design token system as Figma variables:
+Creates a two-tier design token system as Figma variables. Each tier is split
+into **one collection per category** (color, spacing, type, radius, border) so
+every category owns its own modes — see Step 1 for why. Within a collection,
+Figma variables are grouped with `/` and omit the category prefix (the
+collection already carries it); the sync layer later derives the dotted logical
+name (`color.gray.50`) by prefixing the collection's category.
 
-- **Primitives** — raw values with no meaning attached. `color.gray.50`,
-  `space.4`, `font.size.300`. The full palette of possible values.
-- **Semantic** — meaning-bearing tokens that **alias onto primitives**.
-  `color.bg.default` → `{color.gray.50}`, `color.text.primary` →
-  `{color.gray.900}`. This is the layer the rest of the system consumes.
+- **Primitives** — raw values with no meaning attached: `gray/50`, `space/4`
+  in their category's primitive collection. The full palette of possible values.
+- **Semantic** — meaning-bearing tokens that **alias onto primitives**:
+  `bg/default` → `{gray/50}`, `text/primary` → `{gray/900}`. This is the layer
+  the rest of the system consumes.
 
 The power of two tiers: change a primitive once and every semantic token
 referencing it updates automatically, which cascades through sheets, components,
@@ -67,17 +72,20 @@ user, in readable chunks:
   scale.
 - **Primitive naming convention** — the single most important decision, because
   the semantic tier aliases onto these names and renaming later breaks every
-  alias. Lock it explicitly. Default: `category.subcategory.step`
-  (`color.gray.50`, `space.4`, `font.size.300`). Keep names **neutral and
-  semantic — never framework-specific** (don't name a token `--background` to
-  match shadcn; the adapter sync layer renames per framework later). Figma is
-  framework-agnostic; the adapter absorbs all framework-specific shaping.
+  alias. Lock it explicitly. In Figma, name variables **without the category
+  prefix** (the collection supplies it) and group with `/`: e.g. `gray/50`,
+  `space/4`, `radius/md` inside their category's primitive collection. The sync
+  layer derives the dotted logical identity (e.g. `color.gray.50`) by prefixing
+  the collection's category. Keep names **neutral and semantic — never
+  framework-specific** (don't name a token `--background` to match shadcn; the
+  adapter renames per framework later). Figma is framework-agnostic; the adapter
+  absorbs all framework-specific shaping.
 - **Tiers** — default to **two-tier** (primitive + semantic). Only raise the
   option of a third **component** tier if the user signals multi-brand,
   white-labeling, or a very large/robust component library — for a single-brand
   project it adds complexity without payoff, so don't even surface it. If the
   user opts in, component tokens alias onto semantic tokens (e.g.
-  `button.bg.primary` → `{color.bg.emphasis}`).
+  `bg/primary` → `{bg/emphasis}`).
 - **Collection structure** — two *tiers*, but **one collection per category per
   tier**, never one giant `Primitives` + one giant `Semantic`. In Figma a mode
   axis (Light/Dark, Desktop/Mobile, Brand) belongs to the *collection*, so every
@@ -186,7 +194,7 @@ under the structural-consistency rule; keep the role names real (`inset/md`, not
 `space/16`).
 
 The **color** semantic tier is where the Light/Dark switch lives:
-`color.bg.default` → `{gray/50}` in Light and `{gray/900}` in Dark. Primitives
+`bg/default` → `{gray/50}` in Light and `{gray/900}` in Dark. Primitives
 stay fixed; the semantic aliases differ per mode. This is exactly what lets the
 sync layer emit `:root`/`.dark` for web later.
 

--- a/skills/token-builder/SKILL.md
+++ b/skills/token-builder/SKILL.md
@@ -78,6 +78,26 @@ user, in readable chunks:
   project it adds complexity without payoff, so don't even surface it. If the
   user opts in, component tokens alias onto semantic tokens (e.g.
   `button.bg.primary` → `{color.bg.emphasis}`).
+- **Collection structure** — two *tiers*, but **one collection per category per
+  tier**, never one giant `Primitives` + one giant `Semantic`. In Figma a mode
+  axis (Light/Dark, Desktop/Mobile, Brand) belongs to the *collection*, so every
+  variable in a collection is forced to share its modes. Putting `space` in the
+  same collection as `color` drags spacing into Light/Dark, which is meaningless.
+  Default layout (single-brand): private primitive collections `_Color/Primitive`,
+  `_Typography/Primitive`, `_Radius/Primitive`, `_Border/Primitive`, and a
+  **public** `Spacing/Primitive`; published semantic collections `Color/Semantic`
+  (Light/Dark), `Spacing/Semantic`, `Typography/Semantic`, `Radius/Semantic`,
+  `Border/Semantic`. Privacy is the leading-`_` prefix. `size/icon/*` lives in
+  `Spacing/Primitive`; don't create a `Sizing` collection unless control
+  heights/avatars become real tokens.
+- **Multi-brand** — keep two axes in two collections so they don't multiply.
+  Brand lives on `_Color/Primitive` (modes = Brand A, Brand B = raw palettes);
+  Theme lives on `Color/Semantic` (modes = Light, Dark). A frame sets both
+  independently and Figma resolves `bg/default`(Light) → `{gray/50}` → Brand A's
+  gray. This keeps each collection ≤2 modes — under the Figma **Professional cap
+  of 4 modes/collection**. (Brand-on-primitive assumes brands differ in raw
+  palette, same role mapping; if a brand needs a *different* mapping, it also
+  becomes a mode on `Color/Semantic`.)
 
 Show the proposed full structure back to the user and get sign-off before
 creating anything.

--- a/skills/token-builder/SKILL.md
+++ b/skills/token-builder/SKILL.md
@@ -121,25 +121,43 @@ usage rather than mirroring the primitive scale step-for-step.
 
 ## Step 2 — Build the PRIMITIVE tier, then PAUSE
 
-Create the primitive variable collection (e.g. named `Primitives`) and all
-primitive variables, using a scripted loop via the active write mechanism.
+Create the **per-category primitive collections** and their variables via a
+scripted loop on the active write mechanism. Default set:
 
-Mode handling: create the mode structure the user chose. For light/dark,
-primitives are usually mode-independent raw values (a gray ramp is the same in
-both modes) OR you define both — follow what the brainstorm settled. Keep the
-mode setup consistent with how the semantic tier will use it.
+- `_Color/Primitive` — color ramps (`gray/50…900`, `brand/50…900`,
+  `success`/`warning`/`danger`, `white`, `black`).
+- `Spacing/Primitive` — the spacing scale (`space/0,2,4,8,12,16,24,32,48,64`)
+  **plus** `size/icon/{sm,md,lg}`.
+- `_Typography/Primitive` — `family/*`, `size/*`, `weight/*`, `lineHeight/*`,
+  `letterSpacing/*`.
+- `_Radius/Primitive` — `radius/{none,sm,md,lg,xl,full}`.
+- `_Border/Primitive` — `width/{0,1,2,4}`. **Do not skip border width** — borders
+  need a width primitive, not only a color.
+
+**Privacy:** the leading-`_` prefix hides a collection from the published
+library. Keep color/type/radius/border primitives private (they're always
+consumed through semantics or styles). Make **`Spacing/Primitive` public** (no
+underscore) — spacing semantics are intentionally minimal, so designers will grab
+raw `space/*` for one-off gaps. Note the trade-off in your checkpoint summary: a
+value applied directly from `Spacing/Primitive` is *frozen across device modes*;
+only `Spacing/Semantic` carries future Desktop/Mobile responsiveness.
+
+**Modes at the primitive tier:** primitives are usually mode-free (a single
+*Value* mode). The exception is multi-brand: give `_Color/Primitive` a Brand mode
+axis (Brand A, Brand B) holding each brand's raw palette. All other primitive
+collections stay single-mode.
 
 Then **stop and checkpoint.** This is the critical seam: semantic tokens are
 about to alias onto these primitives, so the primitive names and values must be
-right *before* you build on them. Show the user the created primitive collection
-— summarize the ramps and scales, and if helpful, note that the
-token-sheet-builder skill can render them visually later. Ask for explicit
-confirmation: "Here are your primitives. Once you're happy, I'll build the
-semantic layer on top — and after that, renaming primitives gets disruptive, so
-this is the moment to adjust names or values."
+right *before* you build on them. Show the user the created collections —
+summarize the ramps and scales, note which are public vs private, and if helpful
+mention the token-sheet-builder skill can render them visually later. Ask for
+explicit confirmation: "Here are your primitives. Once you're happy, I'll build
+the semantic layer on top — and after that, renaming primitives gets disruptive,
+so this is the moment to adjust names or values."
 
-Update the manifest: `tokens.primitivesBuilt` = `true`, add the collection name
-to `tokens.collections`.
+Update the manifest: `tokens.primitivesBuilt` = `true`, add every created
+collection name to `tokens.collections`.
 
 Do not proceed to the semantic tier until the user confirms.
 

--- a/skills/token-builder/SKILL.md
+++ b/skills/token-builder/SKILL.md
@@ -102,22 +102,22 @@ user, in readable chunks:
 Show the proposed full structure back to the user and get sign-off before
 creating anything.
 
-### The anti-redundancy rule (prevents the "different every time" problem)
+### The structural-consistency rule (prevents the "different every time" problem)
 
-A semantic token earns its existence **only when it represents a genuine mapping
-decision** — a role that could plausibly point at a different primitive, or that
-changes across modes. Do **not** manufacture a semantic token that is a 1:1
-passthrough to the only primitive that could fill it, and do **not** create a
-parallel semantic collection for a category that has no real mapping choices
-(this is the redundant-borders trap: a "semantic" border layer that just mirrors
-the one primitive border value adds pure overhead).
+Every token concern gets **both** a primitive and a semantic collection, even
+when the semantic tier is a 1:1 passthrough today. A dimensional semantic tier
+(`Spacing/Semantic`, `Radius/Semantic`, `Border/Semantic`) is justified by a
+**plausible future mode axis** — e.g. adding Desktop/Mobile to spacing later —
+which only works if the semantic collection already exists to carry that axis.
+Building every concern the same way is also what makes the output consistent
+run-to-run instead of an arbitrary guess about which categories to duplicate.
 
-Apply this test per category: *"Could this semantic role sensibly point at a
-different primitive, now or in another mode?"* If yes, it's a real semantic
-token. If no, keep that category single-tier — consumers reference the primitive
-directly, and you don't build a mirror collection. This is what makes the output
-consistent run-to-run instead of an arbitrary guess about which categories to
-duplicate.
+The one guardrail: **consistency does not license invented roles.** Semantic
+names must be real usage roles (`inset/md`, `width/focus`, `text/primary`),
+never just renamed primitive steps (`space/12`, `width/1`). A passthrough role
+with a meaningful name is fine; a fake role nobody applies is not. If you can't
+name a genuine role for a category, give it semantic roles that map to actual
+usage rather than mirroring the primitive scale step-for-step.
 
 ## Step 2 — Build the PRIMITIVE tier, then PAUSE
 

--- a/skills/token-builder/SKILL.md
+++ b/skills/token-builder/SKILL.md
@@ -239,6 +239,13 @@ comes later.
 ## Notes that matter
 
 - **Never flatten semantic into literals.** Aliases are the whole point.
+- **One collection per category per tier.** Modes belong to the collection, so
+  splitting by category is what keeps color's Light/Dark from infecting spacing.
+- **Privacy is the `_` prefix.** Only `Spacing/Primitive` is public by default;
+  all other primitives are private.
+- **Primitives can be multi-mode.** Brand lives on `_Color/Primitive`; the sync
+  layer must emit brand themes from the primitive tier, not just light/dark from
+  semantics.
 - **Lock primitive names before building semantics.** The checkpoint between
   tiers exists precisely to prevent rename cascades.
 - **Think in DTCG terms even though you're writing Figma variables.** Each token

--- a/skills/token-sheet-builder/SKILL.md
+++ b/skills/token-sheet-builder/SKILL.md
@@ -13,8 +13,8 @@ utilitarian dump of swatches.
 ## Live vs regenerated — set expectations clearly
 
 Bind to variables wherever Figma allows so the sheet **live-updates** for those
-properties: a color swatch bound to `color.gray.50` re-colors automatically when
-that primitive changes; spacing/radius examples bound to the variables resize
+properties: a color swatch bound to `gray/50` (in `_Color/Primitive`) re-colors
+automatically when that primitive changes; spacing/radius examples bound to the variables resize
 automatically. But labels, hex/value text, token names, descriptions, and the
 set of tokens shown (adding/removing tokens) are **snapshots** — they don't
 auto-update. So tell the user plainly: "The swatches update live when you change

--- a/skills/token-sheet-builder/SKILL.md
+++ b/skills/token-sheet-builder/SKILL.md
@@ -38,9 +38,10 @@ lower-stakes, easily-regenerated artifact. Settle: which collections get their
 own section, how much per-token detail to show (just swatches, or swatches +
 names + values + descriptions), and any brand styling direction for the page
 itself (the page should feel like the brand it documents). Default to a clean,
-sectioned layout: Color (ramps as rows of swatches), Typography (the type scale
-rendered in the actual text styles), Spacing (visual bars), Radius (sample
-shapes), Elevation (sample cards with the effect styles).
+sectioned layout, one section per collection/style group: Color (ramps as rows
+of swatches), Typography (the type scale rendered in the actual text styles),
+Spacing (visual bars), Radius (sample shapes), Border width (sample rules at
+each width), Elevation (sample cards with the effect styles).
 
 ## Step 2 — Build the Foundations page
 

--- a/skills/token-sync-layer/SKILL.md
+++ b/skills/token-sync-layer/SKILL.md
@@ -73,10 +73,26 @@ it.
 
 Using the active write mechanism (`figma.mechanism`, default Console MCP —
 prefer its full-design-system extraction, which works on any Figma plan), read
-the variable collections and normalize them into **DTCG-format JSON** (`$value`,
-`$type`, with semantic tokens expressed as `{group.token}` references to
-primitives, not flattened literals). Preserve modes (light/dark/brand) as the
-DTCG structure the adapters expect.
+**every variable collection** (there are now several per tier, e.g.
+`_Color/Primitive`, `Spacing/Primitive`, `Color/Semantic`, …) and normalize them
+into **DTCG-format JSON** (`$value`, `$type`, with semantic tokens expressed as
+`{group.token}` references to primitives, not flattened literals).
+
+Three rules for the multi-collection structure:
+- **Iterate N collections**, not a fixed two. Don't assume one `Primitives` +
+  one `Semantic`.
+- **Single-mode collections are non-themed** — a collection with one mode (e.g.
+  `Spacing/Semantic`) emits flat values, never a phantom `default` theme
+  alongside `:root`/`.dark`.
+- **Primitives can be multi-mode** — `_Color/Primitive` carries a Brand axis, so
+  emit **brand themes from the primitive tier**, not just light/dark from
+  semantics. Preserve modes (light/dark/brand/device) as the DTCG structure the
+  adapters expect.
+- **Name mapping:** collapse the tier/category prefix into clean token names —
+  `_Color/Primitive` + `gray/500` → `color.gray.500` (not
+  `color.primitive.gray.500`); `Color/Semantic` + `text/primary` →
+  `color.text.primary`. The category drives the top-level group; the tier (and
+  the `_`) is dropped from the emitted name.
 
 This DTCG JSON is the canonical intermediate. Write it to a known location in
 `packages/tokens/` (e.g. `packages/tokens/dtcg/tokens.json`). Do not trust the


### PR DESCRIPTION
## Summary
- Reworks the design-system skills so a generated token system uses **per-category Figma variable collections** (one collection per category per tier) instead of one `Primitives` + one `Semantic` collection — fixing the bug where non-color categories (e.g. spacing) inherited color's Light/Dark modes. Each category now owns its own mode axis.
- Adds **border-width tokens** end to end: primitive `width/{0,1,2,4}` and semantic `width/{default,focus,emphasis}`, with component-builder binding component borders to them and the Foundations sheet rendering a border-width section.
- Reverses the **anti-redundancy rule** in favor of a **structural-consistency doctrine** (every concern gets both tiers; passthrough dimensional semantics are kept to carry a future mode axis; only invented/renamed-primitive roles are flagged). Applied in both `token-builder` and the `brainstorm-before-build` import mode.
- Establishes the **multi-brand model**: Brand axis on `_Color/Primitive`, Theme axis on `Color/Semantic` — two independent axes in two collections, staying under the Professional 4-mode cap.
- Settles the **naming model**: Figma variables are `/`-grouped and omit the category prefix (`gray/50`, `text/primary`); the dotted form (`color.gray.50`) is the logical/code identity the sync layer derives.
- Updates the **sync layer** to iterate N collections, treat single-mode collections as non-themed, emit brand themes from multi-mode primitives, and apply a collection→token-name mapping rule (+ adapter `[data-brand]` selector). Updates the manifest schema example.

Spec: `docs/superpowers/specs/2026-06-03-figma-variable-collection-structure-design.md`
Plan: `docs/superpowers/plans/2026-06-03-figma-variable-collection-structure.md`

## Test Plan
- [ ] No automated suite — these are markdown skill instructions. Verified via per-task grep checks plus independent spec-compliance and code-quality review subagents.
- [ ] Confirm no surviving two-collection (`["Primitives","Semantic"]`) assumptions across skills/references/commands.
- [ ] Confirm border-width tokens appear in token-builder, component-builder, and token-sheet-builder.
- [ ] Sanity-run `token-builder` against a real Figma file to confirm per-category collections build with correctly scoped modes (manual, follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)