### PR TITLE
v0.4.0: Skill 0 intake step (Locate → Scan → Brief)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-04
+
+### Added
+- **Skill 0 intake step (Locate → Scan → Brief).** `figma-environment-setup` now
+  opens by asking where to work — use the current directory, point to an existing
+  project, or create a new folder — then scans for existing tooling (monorepo,
+  Storybook, token pipeline, sync layer) and gives a plain-language situational
+  briefing before taking any action. This replaces the old assumption that the user
+  is always starting from scratch in the current directory.
+- **`workspace.origin` manifest field.** Records how the user's project was
+  configured at intake: `"greenfield"`, `"existing-repo"`,
+  `"existing-monorepo"`, or `"unknown"`. Set once, immutable after intake.
+  Downstream skills will read this to adapt behavior in future brownfield modes.
+- **`workspace.detectedLayers` manifest field.** Snapshot of tooling found at
+  intake time (`monorepo`, `storybook`, `tokens`, `syncLayer`) with three-state
+  semantics (`null` = not yet scanned, `false` = scanned/not found, `true` =
+  found). Distinct from the canonical per-skill flags — records what existed
+  *before* any skill ran.
+- **Manifest schemaVersion 3** — adds the two new workspace fields above and a
+  new immutability rule (rule 6: `workspace.origin` must not be overwritten after
+  intake).
+
 ### Fixed
 - **`token-builder` read-backs now use the dynamic-page-safe APIs.** The Console
   MCP bridge runs in Figma's `dynamic-page` document mode, where the synchronous
@@ -161,6 +183,10 @@ to [Semantic Versioning](https://semver.org).
 - Reference docs for coding level, manifest schema, sync adapters, Figma
   component standards, and brainstorm-before-build.
 
-[Unreleased]: https://github.com/jrpease/throughline/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/jrpease/throughline/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/jrpease/throughline/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/jrpease/throughline/compare/v0.2.3...v0.3.0
+[0.2.3]: https://github.com/jrpease/throughline/compare/v0.2.1...v0.2.3
+[0.2.1]: https://github.com/jrpease/throughline/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/jrpease/throughline/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/jrpease/throughline/releases/tag/v0.1.0

--- a/docs/superpowers/plans/2026-06-04-skill-0-intake-routing.md
+++ b/docs/superpowers/plans/2026-06-04-skill-0-intake-routing.md
@@ -1,0 +1,371 @@
+# Skill 0 Intake & Routing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Locate → Scan → Brief intake step to `figma-environment-setup` so the skill detects what the user is starting from — greenfield, existing repo, or existing monorepo — and sets expectations before taking any action.
+
+**Architecture:** Two file changes: (1) extend `manifest-schema.md` with two new `workspace` fields (`origin`, `detectedLayers`), then (2) rewrite `figma-environment-setup/skill.md` to insert Step 0 and renumber existing steps. No new files. No changes to any other skill in this phase — downstream brownfield adaptation is phase 2.
+
+**Tech Stack:** Markdown instruction files. No executable code. Verification is a structured self-review checklist, not automated tests.
+
+---
+
+## File Map
+
+| Action | File | What changes |
+|---|---|---|
+| Modify | `references/manifest-schema.md` | Add `origin` + `detectedLayers` to JSON block; add field docs; add immutability rule |
+| Modify | `skills/figma-environment-setup/skill.md` | Insert Step 0 (Locate → Scan → Brief); update Step 2 (formerly Step 1) with skip-if-exists note; renumber all steps |
+
+---
+
+## Task 1: Extend the Manifest Schema
+
+**Files:**
+- Modify: `references/manifest-schema.md`
+
+- [ ] **Step 1.1: Read the current manifest schema**
+
+  Open `references/manifest-schema.md` and locate the `workspace` block in the JSON schema (around line 26–29). It currently looks like:
+
+  ```json
+  "workspace": {
+    "name": "my-design-system",
+    "localPath": ".",
+    "stage": "folder"
+  },
+  ```
+
+- [ ] **Step 1.2: Add the two new fields to the JSON schema block**
+
+  Replace that block with:
+
+  ```json
+  "workspace": {
+    "name": "my-design-system",
+    "localPath": ".",
+    "stage": "folder",
+    "origin": null,
+    "detectedLayers": {
+      "monorepo": null,
+      "storybook": null,
+      "tokens": null,
+      "syncLayer": null
+    }
+  },
+  ```
+
+  `null` for both fields at default — `null` means "not yet run" which is distinct from `false` ("run, not found") and `true` ("run, found"). This matters for detecting whether intake has run at all.
+
+- [ ] **Step 1.3: Add field reference documentation**
+
+  In the `### workspace` field reference section, find the entry for `stage` (the last bullet under `workspace`). After that bullet, add:
+
+  ```markdown
+  - `origin` — how the user's project was configured at intake time. Set **once** by
+    `figma-environment-setup` Step 0 and never overwritten by any downstream skill.
+    Values:
+    - `"greenfield"` — empty or newly created folder; no repo or tooling detected
+    - `"existing-repo"` — `package.json` present but no monorepo config; user will need
+      to convert to monorepo before the code phase
+    - `"existing-monorepo"` — both `turbo.json` and `pnpm-workspace.yaml` present; code
+      phase skills should adapt rather than scaffold from scratch
+    - `"unknown"` — scan was inconclusive; treat conservatively (prompt the user)
+    - `null` — intake has not yet run (default)
+
+  - `detectedLayers` — snapshot of tooling found in the working directory at intake time.
+    Written by `figma-environment-setup` Step 0, read by downstream skills to adapt
+    behavior. `null` = not yet scanned. `false` = scanned, not found. `true` = found.
+    - `monorepo` — both `turbo.json` and `pnpm-workspace.yaml` are present
+    - `storybook` — `.storybook/` directory is present
+    - `tokens` — `tokens.json` or a `tokens/` directory is present
+    - `syncLayer` — `style-dictionary.config.js` or `*.style-dictionary.js` files present
+  ```
+
+- [ ] **Step 1.4: Add the immutability rule**
+
+  In the `## Rules for skills touching the manifest` section, add a sixth rule after the existing five:
+
+  ```markdown
+  6. **`workspace.origin` is immutable after intake.** Written once by
+     `figma-environment-setup` Step 0 and must not be overwritten by any downstream
+     skill. Skills read it to adapt behavior — they do not modify it.
+  ```
+
+- [ ] **Step 1.5: Verify the changes are internally consistent**
+
+  Read through the modified `manifest-schema.md` and check:
+  - [ ] The JSON schema block contains `origin: null` and `detectedLayers` with four `null` keys
+  - [ ] The field reference for `origin` lists all four string values plus `null`
+  - [ ] The field reference for `detectedLayers` lists all four keys (`monorepo`, `storybook`, `tokens`, `syncLayer`) matching the JSON block exactly
+  - [ ] The immutability rule is rule 6 (not a duplicate of an existing rule)
+  - [ ] No existing content was accidentally deleted
+
+- [ ] **Step 1.6: Commit**
+
+  ```bash
+  git add references/manifest-schema.md
+  git commit -m "feat(manifest): add workspace.origin and detectedLayers fields"
+  ```
+
+---
+
+## Task 2: Rewrite figma-environment-setup/skill.md
+
+**Files:**
+- Modify: `skills/figma-environment-setup/skill.md`
+
+This task has two parts: insert the new Step 0 content, then renumber the existing steps.
+
+---
+
+### Part A — Insert Step 0
+
+- [ ] **Step 2.1: Read the current skill file**
+
+  Open `skills/figma-environment-setup/skill.md`. The first step heading is currently:
+
+  ```
+  ## Step 1 — Create the working folder and manifest
+  ```
+
+  Step 0 is inserted immediately before this heading, after the `Read references/manifest-schema.md...` line.
+
+- [ ] **Step 2.2: Insert Step 0 — Phase 1 (Locate)**
+
+  Insert the following content before the current `## Step 1` heading:
+
+  ````markdown
+  ## Step 0 — Intake (Locate → Scan → Brief)
+
+  This step runs before everything else. Establish where you're working, read
+  what's already there, and set the user's expectations before taking any action.
+  It has three phases in sequence.
+
+  ### Phase 1: Locate
+
+  Open by surfacing the user's current working directory and presenting three
+  explicit options — no assumptions made about where they want to work or whether
+  they have started anything already:
+
+  > "Before we get started, I want to make sure we're working in the right place.
+  > You're currently in: `[current working directory path]`
+  >
+  > Where should we set up?
+  > - **Here** — this directory is where the design system should live
+  > - **Somewhere else** — I have a project at a different path
+  > - **A new folder** — create a fresh folder somewhere"
+
+  **"Here":** Proceed to the existing manifest check below.
+
+  **"Somewhere else":** Ask for the path. Verify it exists on disk (`ls` or
+  equivalent — just check the directory is real). If it doesn't exist, ask them
+  to double-check the spelling. Once confirmed, proceed to the existing manifest
+  check.
+
+  **"A new folder":** Ask what they'd like to name it and where it should live
+  (suggest the current directory as the default). Create it. Confirm where it was
+  created: "I've created `[name]` at `[full path]`." Proceed to the existing
+  manifest check.
+
+  **Existing manifest check:** Before scanning, check whether `design-system.json`
+  already exists in the confirmed directory.
+
+  - **If it exists:** Read it. If `schemaVersion` is out of date, migrate forward
+    (add missing fields with defaults, bump `schemaVersion` — do not delete
+    unrecognised fields). Tell the user:
+    > "Looks like we've worked here before — I'll pick up where we left off."
+    Skip Phases 2 and 3. Continue into Step 2 with the existing manifest loaded.
+
+  - **If it does not exist:** Proceed to Phase 2.
+  ````
+
+- [ ] **Step 2.3: Insert Step 0 — Phase 2 (Scan)**
+
+  Immediately after the Phase 1 content, insert:
+
+  ````markdown
+  ### Phase 2: Scan
+
+  Scan the confirmed directory for the following signals. Check in priority order
+  — monorepo status is the most consequential and is checked first.
+
+  | Signal | What it means |
+  |---|---|
+  | `turbo.json` **and** `pnpm-workspace.yaml` both present | Already a monorepo |
+  | `package.json` present, no `turbo.json` or `pnpm-workspace.yaml` | Repo exists, not yet a monorepo |
+  | `.storybook/` directory present | Storybook already installed |
+  | `tokens.json` or `tokens/` directory present | Existing token pipeline |
+  | `style-dictionary.config.js` or `*.style-dictionary.js` files present | Existing sync layer |
+
+  After scanning, write the findings to `design-system.json` (creating it if it
+  does not exist, using schema defaults for all other fields):
+
+  ```json
+  "workspace": {
+    "origin": "<greenfield|existing-repo|existing-monorepo|unknown>",
+    "detectedLayers": {
+      "monorepo": <true|false>,
+      "storybook": <true|false>,
+      "tokens": <true|false>,
+      "syncLayer": <true|false>
+    }
+  }
+  ```
+
+  **Setting `origin`:**
+  - No `package.json` found → `"greenfield"`
+  - `package.json` found, no `turbo.json`/`pnpm-workspace.yaml` → `"existing-repo"`
+  - Both `turbo.json` and `pnpm-workspace.yaml` found → `"existing-monorepo"`
+  - Signals present but contradictory or incomplete → `"unknown"`
+
+  **Setting `detectedLayers`:** set each boolean independently from the table
+  above. A directory can have `origin: "existing-monorepo"` and
+  `detectedLayers.storybook: false` — they are independent fields.
+
+  **Do not overwrite `workspace.origin` on subsequent runs.** If it is already
+  set to a non-null value, skip the scan and proceed to Phase 3.
+  ````
+
+- [ ] **Step 2.4: Insert Step 0 — Phase 3 (Brief)**
+
+  Immediately after the Phase 2 content, insert:
+
+  ````markdown
+  ### Phase 3: Brief
+
+  Produce a short, warm, plain-language situational summary. The goal is to set
+  expectations so nothing downstream feels like a surprise. No jargon. No alarm.
+  If something requires action before a later skill can run, say so as a
+  heads-up, not a warning.
+
+  **Format:**
+
+  > "Here's what I found in `[path]`:
+  > [plain-language bullet list of detected signals and what they mean]
+  >
+  > Here's what that means for us:
+  > [brief tailored roadmap: what works the same, what will be different, what
+  > to know before we hit it]
+  >
+  > Ready to continue?"
+
+  **By scenario:**
+
+  *Greenfield (no signals detected):*
+  > "Clean slate — we're building everything fresh. Ready to continue?"
+
+  *Existing single repo (`origin: "existing-repo"`):*
+  > "Here's what I found in `[path]`:
+  > - You have an existing repo, but it's not yet set up as a monorepo
+  > [any additional detected layers, one bullet each]
+  >
+  > Here's what that means for us: everything in the Figma phase — tokens,
+  > components, variables — works exactly the same. When we get to the code
+  > phase, you'll need to convert this repo to a monorepo first. I'll walk you
+  > through that step-by-step when we get there — it's a one-time setup.
+  > [one line per additional detected layer, e.g.: 'Storybook is already installed
+  > — we'll build on top of what you have rather than starting fresh.']
+  >
+  > Ready to continue?"
+
+  *Existing monorepo (`origin: "existing-monorepo"`):*
+  > "Here's what I found in `[path]`:
+  > - Your repo is already set up as a monorepo ✓
+  > [any additional detected layers, one bullet each]
+  >
+  > Here's what that means for us: you're already in great shape for the code
+  > phase. We'll build the Figma side first, then work inside your existing
+  > monorepo structure when we get to code.
+  > [one line per additional detected layer]
+  >
+  > Ready to continue?"
+
+  *Unknown:*
+  > "Here's what I found in `[path]`:
+  > - I can see some project files but I'm not sure of the full setup
+  >
+  > Before we continue: do you have an existing git repo here? And is it already
+  > set up as a monorepo (does it have a `turbo.json` or `pnpm-workspace.yaml`)?"
+  >
+  > Wait for the user to clarify, then update `workspace.origin` manually based
+  > on their answer before proceeding.
+
+  Once the user confirms they're ready, proceed to Step 2.
+  ````
+
+---
+
+### Part B — Renumber Existing Steps
+
+- [ ] **Step 2.5: Renumber all existing step headings**
+
+  Find and replace every existing step heading in the file. The old heading text and the exact new heading text:
+
+  | Find (exact) | Replace with (exact) |
+  |---|---|
+  | `## Step 1 — Create the working folder and manifest` | `## Step 2 — Create the working folder and manifest` |
+  | `## Step 1.5 — Calibrate the coding level` | `## Step 2.5 — Calibrate the coding level` |
+  | `## Step 2 — Choose the Figma write mechanism` | `## Step 3 — Choose the Figma write mechanism` |
+  | `## Step 3 — Connect to Figma (Console MCP path)` | `## Step 4 — Connect to Figma (Console MCP path)` |
+  | `### 3a.` | `### 4a.` |
+  | `### 3b.` | `### 4b.` |
+  | `### 3c.` | `### 4c.` |
+  | `### 3d.` | `### 4d.` |
+  | `## Step 3 (alt) — Connect to Figma (official plugin path)` | `## Step 4 (alt) — Connect to Figma (official plugin path)` |
+  | `## Step 4 — Capture the file key` | `## Step 5 — Capture the file key` |
+  | `## Step 5 — Liveness check` | `## Step 6 — Liveness check` |
+  | `## Step 5.5 — Create the Cover page` | `## Step 6.5 — Create the Cover page` |
+  | `## Step 6 — Hand off` | `## Step 7 — Hand off` |
+
+  Also find any **inline references** to old step numbers in the body text (e.g. "the repository-builder skill handles that" and similar step cross-references) and update those too.
+
+- [ ] **Step 2.6: Update Step 2 (formerly Step 1) with skip-if-exists note**
+
+  At the top of the `## Step 2 — Create the working folder and manifest` section, add this note before the existing content:
+
+  ```markdown
+  **When Step 0 already handled this:** if the user chose "Here" or "Somewhere
+  else" in Step 0 Phase 1, the directory already exists and `design-system.json`
+  has already been created or loaded. In that case, skip folder creation and
+  manifest initialization — the only thing to confirm here is that
+  `workspace.name` is set. If it is `null` or `"my-design-system"` (the
+  placeholder default), ask the user what they'd like to name their design system
+  and update the field. Otherwise proceed to Step 2.5.
+  ```
+
+- [ ] **Step 2.7: Update the "What this skill must NOT do" list**
+
+  Find `## What this skill must NOT do` at the bottom of the file. Add one item to the list:
+
+  ```markdown
+  - Never overwrite `workspace.origin` once it has been set — it is immutable
+    after intake.
+  ```
+
+- [ ] **Step 2.8: Verify the full skill file**
+
+  Read through the modified `skill.md` and check:
+  - [ ] Step 0 appears before Step 2 with no Step 1 heading in between
+  - [ ] All three phases (Locate, Scan, Brief) are present in Step 0
+  - [ ] The existing manifest check is in Phase 1 (before the scan runs)
+  - [ ] The scan table has 5 rows, no duplicate signals
+  - [ ] All four `origin` values are listed in Phase 2 (`"greenfield"`, `"existing-repo"`, `"existing-monorepo"`, `"unknown"`)
+  - [ ] The briefing has examples for all four scenarios (greenfield, existing-repo, existing-monorepo, unknown)
+  - [ ] No old step number (Step 1, Step 2, Step 3, Step 4, Step 5, Step 6 in the old numbering) appears as a heading — verify with a search
+  - [ ] Subsection headings `### 3a` through `### 3d` are now `### 4a` through `### 4d`
+  - [ ] The "must NOT do" list includes the `workspace.origin` immutability rule
+  - [ ] No existing content was accidentally deleted
+
+- [ ] **Step 2.9: Commit**
+
+  ```bash
+  git add skills/figma-environment-setup/skill.md
+  git commit -m "feat(skill-0): add intake step (Locate → Scan → Brief)"
+  ```
+
+---
+
+## Done
+
+Both files updated, both committed. The intake step is live in skill 0. Downstream skill brownfield modes (reading `workspace.origin` to adapt behavior) are phase 2 — tracked separately.

--- a/docs/superpowers/specs/2026-06-04-skill-0-intake-routing-design.md
+++ b/docs/superpowers/specs/2026-06-04-skill-0-intake-routing-design.md
@@ -1,0 +1,172 @@
+# Skill 0 Intake & Routing Design
+
+**Date:** 2026-06-04
+**Status:** Approved
+**Scope:** `figma-environment-setup` (skill 0)
+
+## Problem
+
+Skill 0 currently assumes the user is starting from scratch and in the correct directory when they trigger it. In practice:
+
+- Greenfield users may have already created their project folder and simply want to use it — skill 0 currently creates a nested folder inside it
+- Brownfield users (existing repo, existing monorepo, partial design systems) have no detection or routing — they hit confusing failures mid-flow when downstream skills assume a fresh setup
+- The "existing repo → needs monorepo conversion" gap is the single biggest routing failure, but it surfaces late and without warning
+
+## Solution
+
+Add a new **Step 0 (Intake)** to `figma-environment-setup`, inserted before all existing steps. It runs three phases in sequence — **Locate → Scan → Brief** — then hands off to the existing skill 0 flow, adapted based on findings.
+
+## What This Does NOT Do
+
+- Does not add brownfield capability to individual downstream skills (that is phase 2)
+- Does not automate monorepo conversion (that stays as a guided walkthrough, triggered by downstream skills when they detect `workspace.origin = "existing-repo"`)
+- Does not change anything after the intake — all existing skill 0 steps (Figma connection, coding level calibration, cover page, etc.) are unchanged
+
+---
+
+## Design
+
+### Step 0 — Intake
+
+#### Phase 1: Locate
+
+Skill 0 opens by surfacing the current working directory and offering three explicit options — no assumptions made:
+
+> *"Before we get started, I want to make sure I'm working in the right place. Here's where you currently are: `[current path]`"*
+>
+> - **Use this directory** — this is where the design system should live
+> - **My project is somewhere else** — I'll provide the path
+> - **Create a new folder** — I want a fresh folder somewhere
+
+**"Use this directory":** proceed directly to the scan.
+
+**"My project is somewhere else":** ask for the path, verify it exists on disk, confirm with the user, then proceed to scan. If the path doesn't exist, ask them to double-check.
+
+**"Create a new folder":** ask for a name and where it should live (defaulting to current directory), create it, confirm its location in plain language, then proceed to scan.
+
+**Existing manifest check:** before scanning, check if `design-system.json` already exists in the confirmed directory. If it does, read it, migrate if needed (`schemaVersion` mismatch), and tell the user:
+
+> *"Looks like we've worked here before — I'll pick up where we left off."*
+
+Skip the rest of the intake and continue into skill 0's normal flow with the existing manifest loaded.
+
+---
+
+#### Phase 2: Scan
+
+Once the directory is confirmed, scan for the following signals in priority order:
+
+| Signal | Interpretation |
+|---|---|
+| `turbo.json` + `pnpm-workspace.yaml` | Already a monorepo ✅ |
+| `package.json` (no turbo/pnpm-workspace) | Repo exists, not yet a monorepo ⚠️ |
+| `.storybook/` directory | Storybook already installed |
+| `tokens.json`, `tokens/` directory | Existing token pipeline |
+| `style-dictionary.config.js`, custom transform files | Existing sync layer |
+
+Monorepo status is checked first — it is the most consequential signal and determines the primary routing fork.
+
+---
+
+#### Phase 3: Situational Briefing
+
+After scanning, produce a short, warm, plain-language summary before any action is taken. Format:
+
+> *"Here's what I found in `[path]`:"*
+> *(plain-language list of detected signals and what they mean)*
+>
+> *"Here's what that means for us:"*
+> *(brief tailored roadmap — what will work the same, what will be different, what the user needs to know before we hit it)*
+>
+> *"Ready to continue?"*
+
+**Tone:** reassuring, not alarming. No jargon. The goal is to set expectations so nothing downstream feels like a surprise.
+
+**Greenfield (empty or new folder):** the briefing collapses to a single confirming line:
+> *"Clean slate — we're building everything fresh."*
+
+**Existing single repo example:**
+> *"Here's what I found in `~/Dev/my-app`:"*
+> *- You have an existing repo, but it's not yet set up as a monorepo*
+> *- Storybook is already installed*
+> *- No existing token pipeline detected*
+>
+> *"Here's what that means for us: everything in the Figma phase (tokens, components, variables) works exactly the same. When we get to the code phase, you'll need to convert this to a monorepo — I'll walk you through that step by step when we get there. Storybook is already here so we'll build on top of what you have rather than starting fresh."*
+
+---
+
+### Routing Outcomes
+
+Three primary states after the scan:
+
+**Greenfield**
+Nothing changes in the existing skill 0 flow. Folder creation is skipped if they're already in the right place. Normal flow continues.
+
+**Existing single repo (`package.json`, no monorepo config)**
+Skill 0 continues unchanged — Figma connection, coding level calibration, cover page all work fine. Downstream code skills (`token-sync-layer`, `storybook-chromatic-builder`) do not change in this phase — their brownfield modes are phase 2 work. What changes is the user has already been warned by the briefing, so when those skills surface the monorepo requirement, it is expected rather than surprising.
+
+**Existing monorepo (`turbo.json` + `pnpm-workspace.yaml`)**
+Skill 0 continues normally. The briefing confirms the user is already set up for the code phase. Downstream skill adaptation (skipping scaffolding, reading existing structure) is phase 2 work — the manifest fields written here give those skills the data they need when the time comes.
+
+Storybook and token pipeline detections do not change routing in this phase — they are recorded in the manifest for downstream skills to read. The briefing surfaces them as context.
+
+---
+
+### Manifest Changes
+
+Two new fields added to the `workspace` block in `design-system.json`:
+
+```json
+"workspace": {
+  "name": "my-design-system",
+  "localPath": ".",
+  "stage": "folder",
+  "origin": "greenfield",
+  "detectedLayers": {
+    "monorepo": false,
+    "storybook": false,
+    "tokens": false,
+    "syncLayer": false
+  }
+}
+```
+
+**`workspace.origin`**
+Set once at intake, never overwritten by downstream skills. Values:
+- `"greenfield"` — empty or new folder
+- `"existing-repo"` — has `package.json`, not yet a monorepo
+- `"existing-monorepo"` — has `turbo.json` + `pnpm-workspace.yaml`
+- `"unknown"` — scan was inconclusive
+
+**`workspace.detectedLayers`**
+Snapshot of what was found at intake time. Boolean flags. Skills read these to adapt behavior. This is the foundation for brownfield skill modes in phase 2.
+
+**`workspace.localPath`**
+No change — stays `"."`. The manifest always lives at the root of the confirmed working directory regardless of where Claude Code was opened from.
+
+**Schema rule:** `workspace.origin` is set once at intake and treated as immutable. Skills read it, never overwrite it.
+
+---
+
+### Skill 0 Step Renumbering
+
+With the intake inserted as Step 0, existing steps shift:
+
+| Before | After |
+|---|---|
+| Step 1 — Create the working folder and manifest | Step 2 — Create the working folder and manifest *(skipped if directory already exists)* |
+| Step 1.5 — Calibrate the coding level | Step 2.5 — Calibrate the coding level |
+| Step 2 — Choose the Figma write mechanism | Step 3 — Choose the Figma write mechanism |
+| Step 3 — Connect to Figma | Step 4 — Connect to Figma |
+| Step 4 — Capture the file key | Step 5 — Capture the file key |
+| Step 5 — Liveness check | Step 6 — Liveness check |
+| Step 5.5 — Create the Cover page | Step 6.5 — Create the Cover page |
+| Step 6 — Hand off | Step 7 — Hand off |
+
+---
+
+## Out of Scope
+
+- **Brownfield capability in individual skills** — downstream skills (`repository-builder`, `token-sync-layer`, `storybook-chromatic-builder`) will read `workspace.origin` and `detectedLayers` but their brownfield modes are a separate phase of work
+- **Monorepo conversion automation** — the guided walkthrough for converting an existing repo stays as manual steps surfaced by downstream skills, not automated by the intake
+- **Production Figma file migration** — not addressable by throughline; handled by Figma's native Swap Library feature

--- a/references/manifest-schema.md
+++ b/references/manifest-schema.md
@@ -11,11 +11,11 @@ what changed. Gating decisions are made by reading this file: if a prerequisite
 field is unset, the skill **offers** to run the prerequisite skill rather than
 bailing or running silently.
 
-## Schema (schemaVersion 2)
+## Schema (schemaVersion 3)
 
 ```json
 {
-  "schemaVersion": 2,
+  "schemaVersion": 3,
   "user": {
     "codingLevel": "new"
   },
@@ -127,7 +127,7 @@ bailing or running silently.
   - `"greenfield"` — empty or newly created folder; no repo or tooling detected
   - `"existing-repo"` — `package.json` present but no monorepo config; user will need
     to convert to monorepo before the code phase
-  - `"existing-monorepo"` — both `turbo.json` and `pnpm-workspace.yaml` present; code
+  - `"existing-monorepo"` — `detectedLayers.monorepo` is `true` (see detection criteria there); code
     phase skills should adapt rather than scaffold from scratch
   - `"unknown"` — scan was inconclusive; treat conservatively (prompt the user)
   - `null` — intake has not yet run (default)
@@ -135,10 +135,11 @@ bailing or running silently.
 - `detectedLayers` — snapshot of tooling found in the working directory at intake time.
   Written by `figma-environment-setup` Step 0, read by downstream skills to adapt
   behavior. `null` = not yet scanned. `false` = scanned, not found. `true` = found.
+  `detectedLayers` records pre-existing tooling found before any skill ran; it does not replace the canonical per-skill flags (`storybook.initialized`, `repo.monorepo`, etc.) which track whether this project's skills have set those layers up.
   - `monorepo` — both `turbo.json` and `pnpm-workspace.yaml` are present
   - `storybook` — `.storybook/` directory is present
   - `tokens` — `tokens.json` or a `tokens/` directory is present
-  - `syncLayer` — `style-dictionary.config.js` or `*.style-dictionary.js` files present
+  - `syncLayer` — `style-dictionary.config.js` or `*.style-dictionary.js` files present at the project root or within immediate subdirectories
 
 ### `figma`
 - `mechanism` — which write mechanism is active. One of `"console-mcp"`

--- a/references/manifest-schema.md
+++ b/references/manifest-schema.md
@@ -25,7 +25,14 @@ bailing or running silently.
   "workspace": {
     "name": "my-design-system",
     "localPath": ".",
-    "stage": "folder"
+    "stage": "folder",
+    "origin": null,
+    "detectedLayers": {
+      "monorepo": null,
+      "storybook": null,
+      "tokens": null,
+      "syncLayer": null
+    }
   },
   "figma": {
     "mechanism": null,
@@ -113,6 +120,25 @@ bailing or running silently.
   Advancing stages is the job of the repository-builder skill (5). Downstream
   skills that need a later stage (e.g. token-sync wants at least `local-git`)
   read this field and offer to advance it.
+
+- `origin` — how the user's project was configured at intake time. Set **once** by
+  `figma-environment-setup` Step 0 and never overwritten by any downstream skill.
+  Values:
+  - `"greenfield"` — empty or newly created folder; no repo or tooling detected
+  - `"existing-repo"` — `package.json` present but no monorepo config; user will need
+    to convert to monorepo before the code phase
+  - `"existing-monorepo"` — both `turbo.json` and `pnpm-workspace.yaml` present; code
+    phase skills should adapt rather than scaffold from scratch
+  - `"unknown"` — scan was inconclusive; treat conservatively (prompt the user)
+  - `null` — intake has not yet run (default)
+
+- `detectedLayers` — snapshot of tooling found in the working directory at intake time.
+  Written by `figma-environment-setup` Step 0, read by downstream skills to adapt
+  behavior. `null` = not yet scanned. `false` = scanned, not found. `true` = found.
+  - `monorepo` — both `turbo.json` and `pnpm-workspace.yaml` are present
+  - `storybook` — `.storybook/` directory is present
+  - `tokens` — `tokens.json` or a `tokens/` directory is present
+  - `syncLayer` — `style-dictionary.config.js` or `*.style-dictionary.js` files present
 
 ### `figma`
 - `mechanism` — which write mechanism is active. One of `"console-mcp"`
@@ -242,3 +268,6 @@ bailing or running silently.
 5. **Never store secrets.** No Figma tokens, no Chromatic tokens, no
    credentials of any kind. The manifest is committed to the repo once
    `workspace.stage` advances — treat it as public.
+6. **`workspace.origin` is immutable after intake.** Written once by
+   `figma-environment-setup` Step 0 and must not be overwritten by any downstream
+   skill. Skills read it to adapt behavior — they do not modify it.

--- a/skills/figma-environment-setup/SKILL.md
+++ b/skills/figma-environment-setup/SKILL.md
@@ -6,11 +6,13 @@ model: haiku
 
 # Figma environment setup
 
-This skill does two foundational jobs, in order:
+This skill does three foundational jobs, in order:
 
-1. **Create the local working folder** and write the `design-system.json`
-   manifest into it. This is the user's anchor — it exists from minute one.
-2. **Connect Claude to Figma** so later skills can read and write the file,
+1. **Discover where you're working** — find or create the project directory,
+   scan what's already there, and set expectations.
+2. **Create the local working folder** and write the `design-system.json`
+   manifest into it (if not already present from step 1).
+3. **Connect Claude to Figma** so later skills can read and write the file,
    then verify the connection works.
 
 It is the required first step. Every other Figma skill does a cheap liveness
@@ -28,7 +30,160 @@ website), give the exact click path, not a vague instruction.
 Read `${CLAUDE_PLUGIN_ROOT}/references/manifest-schema.md` before writing the manifest so you use the
 correct field names and defaults.
 
-## Step 1 — Create the working folder and manifest
+## Step 0 — Intake (Locate → Scan → Brief)
+
+This step runs before everything else. Establish where you're working, read
+what's already there, and set the user's expectations before taking any action.
+It has three phases in sequence.
+
+### Phase 1: Locate
+
+Open by surfacing the user's current working directory and presenting three
+explicit options — no assumptions made about where they want to work or whether
+they have started anything already:
+
+> "Before we get started, I want to make sure we're working in the right place.
+> You're currently in: `[current working directory path]`
+>
+> Where should we set up?
+> - **Here** — this directory is where the design system should live
+> - **Somewhere else** — I have a project at a different path
+> - **A new folder** — create a fresh folder somewhere"
+
+**"Here":** Proceed to the existing manifest check below.
+
+**"Somewhere else":** Ask for the path. Verify it exists on disk (`ls` or
+equivalent — just check the directory is real). If it doesn't exist, ask them
+to double-check the spelling. Once confirmed, proceed to the existing manifest
+check.
+
+**"A new folder":** Ask what they'd like to name it and where it should live
+(suggest the current directory as the default). Create it. Confirm where it was
+created: "I've created `[name]` at `[full path]`." Proceed to the existing
+manifest check.
+
+**Existing manifest check:** Before scanning, check whether `design-system.json`
+already exists in the confirmed directory.
+
+- **If it exists:** Read it. If `schemaVersion` is out of date, migrate forward
+  (add missing fields with defaults, bump `schemaVersion` — do not delete
+  unrecognised fields). Tell the user:
+  > "Looks like we've worked here before — I'll pick up where we left off."
+  Skip Phases 2 and 3. Continue into Step 2 with the existing manifest loaded.
+
+- **If it does not exist:** Proceed to Phase 2.
+
+### Phase 2: Scan
+
+Scan the confirmed directory for the following signals. Check in priority order
+— monorepo status is the most consequential and is checked first.
+
+| Signal | What it means |
+|---|---|
+| `turbo.json` **and** `pnpm-workspace.yaml` both present | Already a monorepo |
+| `package.json` present, no `turbo.json` or `pnpm-workspace.yaml` | Repo exists, not yet a monorepo |
+| `.storybook/` directory present | Storybook already installed |
+| `tokens.json` or `tokens/` directory present | Existing token pipeline |
+| `style-dictionary.config.js` or `*.style-dictionary.js` files present | Existing sync layer |
+
+After scanning, write the findings to `design-system.json` (creating it if it
+does not exist, using schema defaults for all other fields):
+
+```json
+"workspace": {
+  "origin": "<greenfield|existing-repo|existing-monorepo|unknown>",
+  "detectedLayers": {
+    "monorepo": <true|false>,
+    "storybook": <true|false>,
+    "tokens": <true|false>,
+    "syncLayer": <true|false>
+  }
+}
+```
+
+**Setting `origin`:**
+- No `package.json` found → `"greenfield"`
+- `package.json` found, no `turbo.json`/`pnpm-workspace.yaml` → `"existing-repo"`
+- Both `turbo.json` and `pnpm-workspace.yaml` found → `"existing-monorepo"`
+- Signals present but contradictory or incomplete → `"unknown"`
+
+**Setting `detectedLayers`:** set each boolean independently from the table
+above. A directory can have `origin: "existing-monorepo"` and
+`detectedLayers.storybook: false` — they are independent fields.
+
+**Do not overwrite `workspace.origin` on subsequent runs.** If it is already
+set to a non-null value, skip the scan and proceed to Phase 3.
+
+### Phase 3: Brief
+
+Produce a short, warm, plain-language situational summary. The goal is to set
+expectations so nothing downstream feels like a surprise. No jargon. No alarm.
+If something requires action before a later skill can run, say so as a
+heads-up, not a warning.
+
+**Format:**
+
+> "Here's what I found in `[path]`:
+> [plain-language bullet list of detected signals and what they mean]
+>
+> Here's what that means for us:
+> [brief tailored roadmap: what works the same, what will be different, what
+> to know before we hit it]
+>
+> Ready to continue?"
+
+**By scenario:**
+
+*Greenfield (no signals detected):*
+> "Clean slate — we're building everything fresh. Ready to continue?"
+
+*Existing single repo (`origin: "existing-repo"`):*
+> "Here's what I found in `[path]`:
+> - You have an existing repo, but it's not yet set up as a monorepo
+> [any additional detected layers, one bullet each]
+>
+> Here's what that means for us: everything in the Figma phase — tokens,
+> components, variables — works exactly the same. When we get to the code
+> phase, you'll need to convert this repo to a monorepo first. I'll walk you
+> through that step-by-step when we get there — it's a one-time setup.
+> [one line per additional detected layer, e.g.: 'Storybook is already installed
+> — we'll build on top of what you have rather than starting fresh.']
+>
+> Ready to continue?"
+
+*Existing monorepo (`origin: "existing-monorepo"`):*
+> "Here's what I found in `[path]`:
+> - Your repo is already set up as a monorepo ✓
+> [any additional detected layers, one bullet each]
+>
+> Here's what that means for us: you're already in great shape for the code
+> phase. We'll build the Figma side first, then work inside your existing
+> monorepo structure when we get to code.
+> [one line per additional detected layer]
+>
+> Ready to continue?"
+
+*Unknown:*
+> "Here's what I found in `[path]`:
+> - I can see some project files but I'm not sure of the full setup
+>
+> Before we continue: do you have an existing git repo here? And is it already
+> set up as a monorepo (does it have a `turbo.json` or `pnpm-workspace.yaml`)?"
+>
+> Wait for the user to clarify, then update `workspace.origin` manually based
+> on their answer before proceeding.
+
+Once the user confirms they're ready, proceed to Step 2.
+
+## Step 2 — Create the working folder and manifest
+
+**When Step 0 already handled this:** if the user chose "Here" or "Somewhere
+else" in Step 0 Phase 1, the directory already exists and `design-system.json`
+has already been created or loaded. In that case, skip folder creation and
+manifest initialization — the only thing to confirm here is that
+`workspace.name` is set. If it is `null` or `"my-design-system"` (the
+placeholder default), ask the user what they'd like to name their design system
+and update the field. Otherwise proceed to Step 2.5.
 
 Ask the user what they'd like to name their design system (suggest something
 like `my-design-system` if they're unsure). Then:
@@ -51,7 +206,7 @@ Right now everything in it says 'not done yet', which is exactly right."
 folder. Git arrives later, only when there's code to version (the
 repository-builder skill handles that).
 
-## Step 1.5 — Calibrate the coding level
+## Step 2.5 — Calibrate the coding level
 
 Establish how much to explain code/git/terminal concepts in the later
 code-touching skills. Read `${CLAUDE_PLUGIN_ROOT}/references/coding-level.md` and follow its
@@ -69,7 +224,7 @@ Make clear it changes only how much detail they get, never what they can build.
 This is set now because it colors every later interaction. The Figma phase
 itself doesn't lean on it much, but the code phase (repo, sync, Storybook) does.
 
-## Step 2 — Choose the Figma write mechanism
+## Step 3 — Choose the Figma write mechanism
 
 Explain there are two ways to connect Claude to Figma, and recommend the first:
 
@@ -90,12 +245,12 @@ The MCP server configuration ships **bundled with this plugin** (in the plugin's
 bundle can't contain is their personal access token — that's a per-user secret,
 handled in the next step.
 
-## Step 3 — Connect to Figma (Console MCP path)
+## Step 4 — Connect to Figma (Console MCP path)
 
 Walk through these one at a time, confirming each before moving on. Never rush
 the user past a step.
 
-### 3a. The golden rule: use the Figma **desktop app**, not the browser
+### 4a. The golden rule: use the Figma **desktop app**, not the browser
 
 State this up front and clearly: **the Figma desktop app must be installed,
 open, and signed in, with the file you want to work in open in it.** The
@@ -103,7 +258,7 @@ browser version of Figma causes connection and token errors that are painful to
 debug. If they don't have the desktop app, point them to figma.com/downloads to
 install it first. Desktop app, every time.
 
-### 3b. Create a Figma access token
+### 4b. Create a Figma access token
 
 A token is like a password that lets Claude talk to Figma on your behalf. Walk
 them through it:
@@ -124,7 +279,7 @@ themselves, following the plugin's setup notes. If they're unsure where that is,
 walk them to it, but you never see or handle the token. Reassure them this is
 normal and good — their password-like token stays theirs.
 
-### 3c. Run the desktop bridge plugin and pair
+### 4c. Run the desktop bridge plugin and pair
 
 The Console MCP talks to Figma through a small "bridge" plugin running inside
 the desktop app.
@@ -141,12 +296,12 @@ Explain the shape of it plainly: "Figma needs to know it's really you allowing
 this. The little plugin window shows a short code; you'll confirm it, and then
 Claude and Figma are linked for this session."
 
-### 3d. Restart the MCP client if needed
+### 4d. Restart the MCP client if needed
 
 If the config was just added (token placed for the first time), the MCP client
 may need a restart to load it. Tell them how, simply, and confirm they're back.
 
-## Step 3 (alt) — Connect to Figma (official plugin path)
+## Step 4 (alt) — Connect to Figma (official plugin path)
 
 If the user chose the official plugin, the flow is lighter: install the official
 Figma plugin for Claude Code per its setup, ensure the desktop app is open with
@@ -154,14 +309,14 @@ the file, and authenticate through the desktop app (again: desktop, not
 browser). The same secret-handling rule applies — any token goes into config by
 the user, never through the chat.
 
-## Step 4 — Capture the file key
+## Step 5 — Capture the file key
 
 Ask the user for the URL of the Figma file they want to build the design system
 in. Extract the file key from it (the segment after `/file/` or `/design/`) and
 store it in `figma.fileKey`. Explain: "This just tells Claude which of your
 Figma files to work in, so I don't have to ask every time."
 
-## Step 5 — Liveness check (prove it actually works)
+## Step 6 — Liveness check (prove it actually works)
 
 Don't declare success on faith. Run one trivial **read** against Figma to prove
 the connection is live — for example, fetch a quick summary of the file's
@@ -214,7 +369,7 @@ client need a restart? Walk them back through the relevant sub-step.
 
 Do not move on until the liveness check passes.
 
-## Step 5.5 — Create the Cover page
+## Step 6.5 — Create the Cover page
 
 Now that writes are proven to work, make the file's first impression: a **Cover**
 page. This is the first thing Claude writes into Figma.
@@ -244,7 +399,7 @@ page. This is the first thing Claude writes into Figma.
 Keep this lightweight and skippable — if the user would rather jump straight to
 tokens, note the Cover can be generated anytime and move on.
 
-## Step 6 — Hand off
+## Step 7 — Hand off
 
 Once live, tell the user what comes next without forcing it: "The natural next
 step is building your color, spacing, and type tokens — just say something like
@@ -259,3 +414,5 @@ skill.
 - Never hand-edit MCP config on the user's behalf in a way that embeds a secret.
 - Never skip the liveness check.
 - Never assume the browser version of Figma will work — always require desktop.
+- Never overwrite `workspace.origin` once it has been set — it is immutable
+  after intake.

--- a/skills/figma-environment-setup/SKILL.md
+++ b/skills/figma-environment-setup/SKILL.md
@@ -52,10 +52,10 @@ they have started anything already:
 
 **"Here":** Proceed to the existing manifest check below.
 
-**"Somewhere else":** Ask for the path. Verify it exists on disk (`ls` or
-equivalent — just check the directory is real). If it doesn't exist, ask them
-to double-check the spelling. Once confirmed, proceed to the existing manifest
-check.
+**"Somewhere else":** Ask for the path. Expand it to an absolute path (resolve
+`~`, relative segments like `../`, etc.) and verify it exists on disk as a
+directory. If it doesn't exist, ask them to double-check the spelling. Once
+confirmed, proceed to the existing manifest check.
 
 **"A new folder":** Ask what they'd like to name it and where it should live
 (suggest the current directory as the default). Create it. Confirm where it was
@@ -86,8 +86,9 @@ Scan the confirmed directory for the following signals. Check in priority order
 | `tokens.json` or `tokens/` directory present | Existing token pipeline |
 | `style-dictionary.config.js` or `*.style-dictionary.js` files present | Existing sync layer |
 
-After scanning, write the findings to `design-system.json` (creating it if it
-does not exist, using schema defaults for all other fields):
+After scanning, write a full `design-system.json` using all schema defaults
+from `${CLAUDE_PLUGIN_ROOT}/references/manifest-schema.md`, then populate the
+`workspace.origin` and `workspace.detectedLayers` fields with the scan results:
 
 ```json
 "workspace": {
@@ -134,7 +135,7 @@ heads-up, not a warning.
 
 **By scenario:**
 
-*Greenfield (no signals detected):*
+*Greenfield (no signals detected) — condensed, no need for the full format:*
 > "Clean slate — we're building everything fresh. Ready to continue?"
 
 *Existing single repo (`origin: "existing-repo"`):*
@@ -177,13 +178,15 @@ Once the user confirms they're ready, proceed to Step 2.
 
 ## Step 2 — Create the working folder and manifest
 
-**When Step 0 already handled this:** if the user chose "Here" or "Somewhere
-else" in Step 0 Phase 1, the directory already exists and `design-system.json`
-has already been created or loaded. In that case, skip folder creation and
-manifest initialization — the only thing to confirm here is that
-`workspace.name` is set. If it is `null` or `"my-design-system"` (the
+**When Step 0 already set the directory:** if the user chose "Here" or
+"Somewhere else" in Step 0, or an existing `design-system.json` was loaded,
+the directory already exists and the manifest has been created or loaded. In
+that case, skip folder creation below. The only thing to confirm is that
+`workspace.name` is set — if it is `null` or `"my-design-system"` (the
 placeholder default), ask the user what they'd like to name their design system
-and update the field. Otherwise proceed to Step 2.5.
+and update the field. Then proceed directly to Step 2.5.
+
+---
 
 Ask the user what they'd like to name their design system (suggest something
 like `my-design-system` if they're unsure). Then:


### PR DESCRIPTION
## Summary

- **New Step 0 in `figma-environment-setup`** — asks where to work (current dir / different path / new folder), scans for existing tooling, gives a plain-language situational briefing before taking action
- **New manifest fields** — `workspace.origin` (greenfield / existing-repo / existing-monorepo / unknown) and `workspace.detectedLayers` (monorepo, storybook, tokens, syncLayer) with three-state semantics
- **Manifest schemaVersion bumped to 3** with immutability rule for `workspace.origin`
- **token-builder fix** — read-backs now use dynamic-page-safe APIs (batched from unreleased)

## Test plan

- [ ] Run `figma-environment-setup` in an empty directory — should get "Clean slate" briefing
- [ ] Run in a directory with `package.json` only — should detect "existing-repo" and warn about monorepo conversion
- [ ] Run in a directory with `turbo.json` + `pnpm-workspace.yaml` — should detect "existing-monorepo"
- [ ] Run in a directory with existing `design-system.json` — should skip scan and load existing manifest
- [ ] Verify all downstream steps (Figma connection, liveness check, cover page) still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)