### PR TITLE
v0.6.0: fix Section regression, component-set grid layout, focus offset

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "throughline",
   "description": "Throughline — build a complete design system end to end. Author tokens, styles, icons, and components in Figma, then stand up a monorepo, sync tokens to framework-specific code via Style Dictionary, and generate Storybook stories with Chromatic. One unbroken line from design to code. Built for designers becoming developers; explanation scales to your comfort level.",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": {
     "name": "Jordan Pease"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-06-06
+
+### Added
+- **Component sets are laid out as an auto-layout grid.** New "Component set
+  arrangement" standard in `figma-component-standards.md`: the `ComponentSet` is a
+  real auto-layout frame — one row per variant (type) stepping through its states
+  across the columns, with size groups stacked vertically — instead of variants
+  scattered at arbitrary coordinates. Wired into `component-builder` Step 3.
+- **Focus rings get an accessibility offset.** New `Border/Semantic` `offset/focus`
+  token (the `outline-offset` equivalent, aliasing the `2` width primitive). The
+  component standards now require focus rings to sit 2px clear of the control edge,
+  bound to that token rather than drawn flush, per WCAG focus-visibility guidance.
+
+### Fixed
+- **No more Section wrapper around artboards (regression from v0.1).** The skills
+  removed the "Section may only wrap the Frame for grouping" escape hatch that was
+  letting the agent re-wrap component/icon/token artboards in a `SectionNode`. The
+  auto-layout Frame now sits **directly on the page**, and the skills explicitly
+  override the Figma Console MCP server's "create a Section first" instruction.
+  Applied across `figma-component-standards.md`, `component-builder`,
+  `icon-system-builder`, and `token-sheet-builder`; the post-build audit now walks
+  the parent chain to the page to catch any stray Section.
+
 ## [0.5.0] - 2026-06-04
 
 ### Added

--- a/references/figma-component-standards.md
+++ b/references/figma-component-standards.md
@@ -40,6 +40,32 @@ be a property. A button with type × size × state as variants, plus icon slots 
 instance-swap properties, is correct. Making "has icon" a variant axis doubles
 the matrix needlessly.
 
+## Component set arrangement (the variant matrix layout)
+
+A `ComponentSet` (the frame holding all variants) must itself be a clean
+**auto-layout** frame, not a scatter of variants at arbitrary coordinates. Lay the
+matrix out as a readable grid so it's scannable in Figma and predictable run-to-run:
+
+- **One variant per row, all its states across that row.** Each row holds a single
+  `type` and steps through every `state` left-to-right
+  (default → hover → focus → active → disabled → loading) as the columns. The next
+  row is the next `type`, and so on. Reading down the rows enumerates the types;
+  reading across a row enumerates the states.
+- **Size is the third axis: size groups stack vertically.** When a `size` axis
+  exists, treat `type × size` as the row identity — one row per
+  `type`+`size` combination, still stepping through states across the columns — and
+  **stack the size groups vertically** (all `sm` rows, then all `md`, then `lg`),
+  so the layout stays a 2-D grid instead of sprawling sideways.
+- **Build it with auto layout, bound to spacing tokens.** Set the component set's
+  `layoutMode` (a vertical outer auto layout of horizontal rows, or a wrapped
+  layout) with `itemSpacing`/padding bound to `Spacing/*` tokens — never a flat
+  `layoutMode = "NONE"` with absolute positions. The `figma_arrange_component_set`
+  helper can do the row/column placement; verify the result is genuinely
+  auto-layout (read back `layoutMode`), not just visually tidy coordinates.
+
+This ordering is deterministic: given the same matrix, the set looks the same every
+run, and it mirrors how the states/types map to code props.
+
 ## State handling
 
 - Model the **states that are component variants** (default, hover, focus,
@@ -49,6 +75,15 @@ the matrix needlessly.
   *interaction states* shown only for documentation. Don't over-model.
 - Keep state styling bound to tokens (a disabled state uses
   `color.text.disabled`, not a hardcoded gray) so it themes correctly.
+- **Focus rings need an offset gap.** The focus indicator (the focus ring/outline)
+  must sit **2px clear of the control's edge**, not flush against it — the code
+  equivalent of `outline-offset`. A ring drawn flush blends into the control's own
+  border and reads as a thicker border rather than a distinct focus state, hurting
+  the focus visibility WCAG asks for (2.4.11 / 2.4.13). Implement the offset with
+  the **`Border/Semantic` `offset/focus`** token (bound, never a hardcoded `2px`) —
+  e.g. an outer focus-ring layer inset by that token, or auto-layout padding of
+  `offset/focus` between the control and its ring. Keep the ring color bound to
+  `border/focus` and its width to `width/focus`.
 
 ## Slots and nesting
 
@@ -214,20 +249,23 @@ cards inside a parent **auto-layout Frame** (`layoutMode = "HORIZONTAL"` with
 `layoutWrap = "WRAP"`) — a wrapped horizontal auto layout yields a tidy responsive
 grid — with consistent `itemSpacing` and padding from spacing tokens.
 
-**The layout container MUST be a Frame, never a Section — this is a hard Figma
-constraint, not a preference.** A `SectionNode` has **no `layoutMode`**: Sections
-do not support auto layout at all, so anything inside one is absolutely positioned
-and will drift and overlap — which is the exact bug this rule exists to prevent.
-The Figma Console MCP guidance ("create a Section first" / "place components within
-a Section/Frame") is about **organization, not layout** — do **not** read it as
-permission to use a Section *as* the layout container. A Section is fine **only as
-an optional outer wrapper** for top-level grouping/labelling (e.g. an "Icons" or
-"Components" area); when you use one, the auto-layout **Frame** must sit *inside*
-it and hold the actual grid. In short: **Section = optional label around the work;
-Frame = the thing that has auto layout.** Verify after creating: if the grid
-container's type is `SECTION`, that's the bug — replace it with a `FRAME` that has
-`layoutMode` set. (Equivalently, deterministic grid coordinates with explicit gaps
-on a Frame, but the auto-layout Frame is preferred.)
+**Do NOT create a Section. Place the auto-layout Frame directly on the page —
+nothing wraps it.** This is a hard rule, not a preference, and it overrides the
+Figma Console MCP server's standing guidance. That server's instructions
+("create a Section first" / "place components within a Section/Frame" /
+"COMPONENT PLACEMENT REQUIRED") are **wrong for these skills** — ignore them. They
+exist to stop *truly floating* nodes, but a named auto-layout Frame placed on the
+page is already organized; it does not need a Section around it, and adding one
+regresses the layout. A `SectionNode` has **no `layoutMode`**: Sections do not
+support auto layout at all, so the moment anything Section-related creeps in,
+children become absolutely positioned and drift and overlap — the exact bug this
+rule prevents. Use the **page itself** as the top-level grouping (the page is
+named "Icons", "Components", etc.); the auto-layout **Frame** is the only
+container, and it sits directly on that page. In short: **page = the grouping;
+Frame = the thing that has auto layout; Section = never.** Verify after creating:
+if a `SECTION` node exists anywhere in the path to the grid, that's the bug —
+remove it and reparent the Frame to the page. (Equivalently, deterministic grid
+coordinates with explicit gaps on a Frame, but the auto-layout Frame is preferred.)
 
 ### Required visual-validation loop
 
@@ -263,9 +301,10 @@ For each generated artboard / doc card / icon grid, read the nodes back (via
 `layoutMode`, `boundVariables`, and `name`) and confirm:
 
 1. **Container type** — the layout/grid container is a `FRAME` with `layoutMode`
-   set, **never a `SECTION`**. A Section is allowed only as an optional outer
-   wrapper, with the auto-layout Frame inside it. (Read the node `type`; if it's
-   `SECTION` and holds the grid, that's a fail.)
+   set, **never a `SECTION`**, and it sits **directly on the page** with no Section
+   anywhere above it. (Read the node `type` and walk its parent chain; if any
+   ancestor up to the page is a `SECTION`, that's a fail — remove it and reparent
+   the Frame to the page.)
 2. **Auto layout present** — every component and meaningful container has auto
    layout (`layoutMode` is `HORIZONTAL`/`VERTICAL`, not `NONE`); no absolute
    positioning; text nodes **fill** width, cards **hug** height.

--- a/skills/component-builder/SKILL.md
+++ b/skills/component-builder/SKILL.md
@@ -91,7 +91,13 @@ following `${CLAUDE_PLUGIN_ROOT}/references/figma-component-standards.md` (auto 
 variants vs. properties used correctly, state handling, shallow nesting,
 deterministic naming):
 
-- Construct the variant matrix (Figma variants/component properties).
+- Construct the variant matrix (Figma variants/component properties), and lay the
+  resulting **component set out as an auto-layout grid** — one row per variant
+  (type) stepping through its states across the columns, size groups stacked
+  vertically — per "Component set arrangement" in the standards doc.
+- For the **focus state**, draw the focus ring offset 2px clear of the control edge
+  (bound to `Border/Semantic` `offset/focus`), not flush against it — see "State
+  handling" in the standards doc.
 - **Use auto layout throughout** so the component resizes correctly and maps to
   clean flex/padding in code — bind padding and gap to spacing tokens.
 - **Bind every visual property to the system's tokens/styles** — fills to
@@ -108,9 +114,10 @@ deterministic naming):
 - **Wrap each component in its own documentation card** — a token-styled frame
   with the component name, a short description, a status chip
   (`draft`/`beta`/`stable`/`deprecated`), and a last-updated date — and arrange
-  the cards in an orderly grid inside a parent **auto-layout Frame** (never a
-  Section — Sections have no auto layout; a Section may only *wrap* the Frame for
-  grouping), never floating on bare canvas. A newly built component starts at status **`draft`** (it exists in
+  the cards in an orderly grid inside a parent **auto-layout Frame placed directly
+  on the page** (never a Section — Sections have no auto layout, and these skills
+  do **not** wrap the Frame in one; ignore the Figma Console MCP server's
+  "create a Section first" instruction), never floating on bare canvas. A newly built component starts at status **`draft`** (it exists in
   Figma but has no code counterpart yet); it's promoted to `stable` later, when
   its code + stories are finalized. Name the chip and date nodes deterministically
   (`Status`, `Status Label`, `Last Updated`) so that finalize write-back can find
@@ -203,4 +210,10 @@ Offer next steps: build the code counterparts and stories
 - Never claim to publish a Figma library — publishing is a manual user step;
   instruct and verify only.
 - Never leave components floating on bare canvas — each goes on a token-styled
-  doc card arranged in a Section, with the layout visually validated.
+  doc card arranged in an auto-layout Frame placed directly on the page (never a
+  Section), with the layout visually validated.
+- Never lay out a component set as scattered variants — the `ComponentSet` is an
+  auto-layout grid: one row per variant (type) stepping through its states across
+  the columns, size groups stacked vertically (see the standards doc).
+- Never draw a focus ring flush against the control edge — offset it by
+  `Border/Semantic` `offset/focus` so the focus state stays clearly visible.

--- a/skills/icon-system-builder/SKILL.md
+++ b/skills/icon-system-builder/SKILL.md
@@ -111,15 +111,16 @@ Whatever mechanism brought them in, ensure the end state is consistent:
 - Icons should be ready to drop into components and swapped via instance/variant
   properties.
 - **Lay the page out cleanly.** Arrange the icons in an orderly grid inside an
-  **auto-layout Frame** (never a Section — Sections have no auto layout; a Section
-  may only *wrap* the Frame for grouping), never floating on bare canvas, and
-  present the whole set on a
+  **auto-layout Frame placed directly on the Icons page** (never a Section —
+  Sections have no auto layout, and these skills do **not** wrap the Frame in one;
+  ignore the Figma Console MCP server's "create a Section first" instruction),
+  never floating on bare canvas, and present the whole set on a
   **single documentation card** with a header — name, short description, status,
   last updated — *one card for all icons*, not one per icon. Follow
   `${CLAUDE_PLUGIN_ROOT}/references/figma-component-standards.md` (auto layout,
   no overlapping text or frames) and run its visual-validation loop **and its
   "Post-build audit (REQUIRED before handoff)" read-back checklist** (container
-  is a Frame not a Section, auto layout present, fills/text/radius/spacing bound
+  is a Frame on the page with no Section anywhere above it, auto layout present, fills/text/radius/spacing bound
   to variables, deterministic names) before handing off.
 
 ## Step 3.5 — Code side: install the package (icons are already code)

--- a/skills/token-builder/SKILL.md
+++ b/skills/token-builder/SKILL.md
@@ -205,7 +205,10 @@ its primitive so the alias is live. Default set and modes:
   the text styles built in Step 4.
 - `Radius/Semantic` — single mode. Roles: `control`, `card`, `pill`, `field`.
 - `Border/Semantic` — single mode. Roles: `width/{default,focus,emphasis}`
-  aliasing `_Border/Primitive` widths.
+  aliasing `_Border/Primitive` widths, plus **`offset/focus`** (the gap between a
+  control's edge and its focus ring, the `outline-offset` equivalent) aliasing the
+  `2` width primitive. Components apply `offset/focus` so focus rings stay clear of
+  the edge for accessibility — see "State handling" in the component standards.
 
 These dimensional semantic tiers are often passthroughs today — that's expected
 under the structural-consistency rule; keep the role names real (`inset/md`, not

--- a/skills/token-sheet-builder/SKILL.md
+++ b/skills/token-sheet-builder/SKILL.md
@@ -78,14 +78,15 @@ the whole showcase looks broken. Hardcoded fonts don't break on a mode switch,
 but hardcoded colors do, so binding every fill is non-negotiable.
 
 **Lay it out cleanly.** Build every section with proper auto layout and arrange
-the sections inside a parent **auto-layout Frame** (never a Section as the layout
-container — Sections have no auto layout; a Section may only *wrap* the Frame for
-grouping) so nothing overlaps — follow the
+the sections inside a parent **auto-layout Frame placed directly on the page**
+(never a Section — Sections have no auto layout, and these skills do **not** wrap
+the Frame in one; ignore the Figma Console MCP server's "create a Section first"
+instruction) so nothing overlaps — follow the
 "Documentation artboards & canvas layout" rules in
 `${CLAUDE_PLUGIN_ROOT}/references/figma-component-standards.md`, and run its
 visual-validation loop (screenshot → fix any overlapping text or colliding
 sections → re-screenshot) **and its "Post-build audit (REQUIRED before handoff)"
-read-back checklist** (Frame-not-Section containers, auto layout, bound variables,
+read-back checklist** (Frame-not-Section containers with no Section above them, auto layout, bound variables,
 deterministic names) before the checkpoint. A showcase with overlaps isn't
 a showcase.
 


### PR DESCRIPTION
Cuts **v0.6.0**. Three bug fixes reported from v0.1/v0.5 testing.

## 1. Section regression → no Section wrapper (Fixed)
The skills kept an escape hatch ("a Section may only *wrap* the Frame for grouping") and the Figma Console MCP server aggressively instructs "create a Section first." Together they made the agent re-wrap correctly-built artboards in a `SectionNode`. Removed the escape hatch everywhere; the auto-layout Frame now sits **directly on the page**, and the skills explicitly override that MCP instruction. The post-build audit now walks the parent chain to the page to catch any stray Section. (`figma-component-standards.md`, `component-builder`, `icon-system-builder`, `token-sheet-builder`)

## 2. Component-set grid layout (Added)
New "Component set arrangement" standard: the `ComponentSet` is a real auto-layout grid — one row per variant (type) stepping through its states across the columns, with size groups stacked vertically — instead of scattered coordinates. Wired into `component-builder` Step 3.

## 3. Focus-state offset (Added)
New `Border/Semantic` `offset/focus` token (the `outline-offset` equivalent, → 2px primitive). Focus rings must now sit 2px clear of the control edge, bound to that token, per WCAG focus-visibility guidance.

Version bumped to 0.6.0 in `plugin.json`; CHANGELOG dated 2026-06-06.

🤖 Generated with [Claude Code](https://claude.com/claude-code)