### PR TITLE
v0.7.0 — Harden Figma-writing skills from build-session testing

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "throughline",
   "description": "Throughline — build a complete design system end to end. Author tokens, styles, icons, and components in Figma, then stand up a monorepo, sync tokens to framework-specific code via Style Dictionary, and generate Storybook stories with Chromatic. One unbroken line from design to code. Built for designers becoming developers; explanation scales to your comfort level.",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "author": {
     "name": "Jordan Pease"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,67 @@ to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-06-08
+
+Hardening pass from real build-session testing (token → foundations → icons →
+components → Storybook on a pnpm + Turborepo + Next.js 16 + Tailwind v4 monorepo).
+
+### Added
+- **New `references/figma-scripting.md` — one home for every `figma_execute`
+  gotcha.** A shared reference, wired into `token-builder`, `component-builder`,
+  `icon-system-builder`, `token-sheet-builder`, and the status write-back routine.
+  Covers: the single-bridge-instance preflight (concurrent writes corrupt the
+  file), the `dynamic-page` async APIs (reads, setters, and `getNodeByIdAsync`),
+  the `resize()` axis-lock trap, the explicit-`timeout` rule for batch writes
+  (`node_count * 3000`), and why large `layoutWrap = "WRAP"` builds time out.
+- **Opacity token category (`token-builder`).** First-class `_Opacity/Primitive` +
+  `Opacity/Semantic` (disabled, muted, overlay/scrim, hover) on the **0–100 scale**.
+- **`text/onEmphasis` color role.** The label/icon color that contrasts a
+  `bg/emphasis` fill in every mode — emitted by `token-builder`, consumed by
+  `component-builder` for primary/filled controls (distinct from `text/inverse`).
+- **"Clip content — off by default" standard.** New section in
+  `figma-component-standards.md` and a post-build audit gate: component/layout
+  frames set `clipsContent = false` so outer strokes, focus rings, and shadows
+  aren't sliced; clipping is reserved for deliberate cutoffs (scroll/crop frames).
+
+### Changed
+- **Figma write-back now confirms once, up front.** The status-promotion routine
+  and `storybook-chromatic-builder` Step 6 surface a single batched confirmation
+  before writing to Figma ("update N doc cards…"), matching the user's mental model
+  and pre-empting the safety classifier instead of eating a forced round-trip.
+- **Figma scripts default to the async APIs** (`getNodeByIdAsync`,
+  `setCurrentPageAsync`, `setTextStyleIdAsync`, …) — the synchronous forms throw
+  under the Console MCP's `dynamic-page` document mode.
+
+### Fixed
+- **Opacity rendered everything invisible.** Opacity tokens stored `0.1–0.9` were
+  divided again by Figma's 0–100 `opacity` binding (→ ~0.004), blanking every
+  disabled/overlay state. Primitives are now authored 0–100; `token-sync-layer`
+  normalizes ÷100 on extraction so CSS/native get correct 0–1 values. The two
+  skills are documented as a matched pair.
+- **`resize()` silently collapsed auto-layout frames.** Calling `resize()` on an
+  auto-layout frame pinned the opposite axis to `FIXED` (frames stuck at ~10px).
+  Documented the re-assert pattern; the post-build audit now reads sizing modes back.
+- **Storybook Controls panel was dead.** Generated stories used
+  `render: () => …`, so control changes never re-rendered. Step 3 now mandates
+  `render: (args) => <Component {...args} />`, and `ReactElement` slot props get
+  `control: false` plus a boolean helper arg (e.g. `showAvatar`) instead of a
+  broken `[object Object]` control.
+- **Typography `@utility` rules were duplicated into Storybook and drifted.**
+  Step 1 now checks the app's global stylesheet first and wires a single shared
+  `@import` (extracted to the UI package), keeping Storybook-only concerns in a
+  separate layer.
+- **Storybook wouldn't start on fresh pnpm installs.** Documented adding `esbuild`
+  to the root `onlyBuiltDependencies` allowlist when installing
+  `@storybook/react-vite` in a pnpm workspace.
+- **Icon subset names weren't validated against the package version.** Names
+  removed between versions (e.g. `lucide-react` 1.x dropping brand icons) would
+  build Figma components with no code counterpart. `icon-system-builder` now
+  resolves every subset name against the installed/published library before
+  building and reports unavailable ones.
+- **Large `WRAP` grids timed out.** Skills now chunk big swatch/variant/icon grids
+  into manual rows instead of one wrapped-auto-layout `figma_execute` call.
+
 ## [0.6.0] - 2026-06-06
 
 ### Added

--- a/references/figma-component-standards.md
+++ b/references/figma-component-standards.md
@@ -19,6 +19,33 @@ non-negotiable:
 - Bind padding and gap to **spacing tokens**, not hardcoded numbers, so the
   token cascade reaches layout.
 
+## Clip content — off by default
+
+Figma creates every new frame with **`clipsContent = true`**, so if you don't set
+it, your layout and component frames silently clip. That clipping cuts off anything
+a child draws **at or past the frame's edge**, which is exactly the stuff that makes
+a component read as polished:
+
+- **Outer strokes / borders.** A child with `strokeAlign = "OUTSIDE"` (or a flush-to-
+  edge border) gets the outer half of its stroke sliced away — borders look thin,
+  uneven, or missing on one side.
+- **Focus rings.** The focus indicator deliberately sits **2px clear of the control's
+  edge** (see *State handling* — the `offset/focus` rule), so it extends *beyond* the
+  control frame by design. A clipping parent eats it, defeating the focus-visibility
+  requirement.
+- **Shadows / elevation.** Drop shadows on a child near the edge get cut at the frame
+  boundary instead of feathering out.
+
+**The rule:** explicitly set **`clipsContent = false`** on component frames, variant
+rows, component sets, and the layout frames that hold them. Don't rely on the default —
+set it, and read it back.
+
+**Turn clipping ON only for a deliberate cutoff** — a frame whose *job* is to crop its
+contents to a fixed window: a scroll container, an image/media crop frame, an
+avatar/thumbnail masked to its bounds, or anything emulating CSS `overflow: hidden`.
+These are the viewport-level cases; everywhere else, leave content unclipped so strokes,
+focus rings, and shadows render in full.
+
 ## Variants vs. component properties — use the right tool
 
 Figma offers variants (a matrix of discrete options) and component properties
@@ -175,11 +202,22 @@ or the card lies — it keeps showing `draft` after the component is actually do
 This is the canonical routine; the finalize step references it rather than
 re-describing it:
 
+0. **Confirm the Figma write-back first (single batched checkpoint).** A doc-card
+   write is an external-system write, so get explicit consent before it — both
+   because the user's "I approve the component" is *not* the same as "write to my
+   Figma file," and because an unannounced external write trips the safety
+   classifier and forces an extra round-trip anyway. State the concrete change in
+   one line and proceed on confirmation — e.g. *"I'll update the 9 doc cards in
+   Figma: flip the status chips amber → green and set Last Updated to today.
+   Confirm?"* One confirmation covers the whole batch; don't ask per card.
 1. Set `components.meta[name].status` to the new status (`stable` on finalize) and
    `components.meta[name].updatedAt` to today (ISO date). The manifest is the
    source of truth.
 2. If Figma is connected (use `figma.mechanism`), locate the component's doc card
-   by its deterministic name, then inside it:
+   by its deterministic name (script the write-back per
+   `${CLAUDE_PLUGIN_ROOT}/references/figma-scripting.md` — `getNodeByIdAsync`, and
+   an explicit `timeout` since multi-card font-loading writes blow past the default
+   ~5s budget), then inside it:
    - set the `Status Label` text to the new status (e.g. `stable`);
    - re-bind the `Status` chip fill to the matching semantic color variable
      (`stable` → success, `draft`/`beta` → warning, `deprecated` → neutral/danger)
@@ -305,9 +343,13 @@ For each generated artboard / doc card / icon grid, read the nodes back (via
    anywhere above it. (Read the node `type` and walk its parent chain; if any
    ancestor up to the page is a `SECTION`, that's a fail — remove it and reparent
    the Frame to the page.)
-2. **Auto layout present** — every component and meaningful container has auto
-   layout (`layoutMode` is `HORIZONTAL`/`VERTICAL`, not `NONE`); no absolute
-   positioning; text nodes **fill** width, cards **hug** height.
+2. **Auto layout present and not axis-locked** — every component and meaningful
+   container has auto layout (`layoutMode` is `HORIZONTAL`/`VERTICAL`, not `NONE`);
+   no absolute positioning; text nodes **fill** width, cards **hug** height. **Read
+   back `primaryAxisSizingMode`/`counterAxisSizingMode`** (or `layoutSizing*`): a
+   `resize()` call silently flips the opposite axis to `FIXED`, collapsing a frame
+   to ~10px — invisible in a screenshot. See the `resize()` trap in
+   `${CLAUDE_PLUGIN_ROOT}/references/figma-scripting.md`.
 3. **Variables bound** — every fill, stroke, text color, corner radius,
    `itemSpacing`, and padding resolves to a **bound variable** (`boundVariables`
    present), not a raw hex/px. No hardcoded values anywhere in the doc-card chrome.
@@ -318,11 +360,15 @@ For each generated artboard / doc card / icon grid, read the nodes back (via
 5. **Scope / status correct** — icons are the curated subset (not the full 1,700),
    and each doc card's status value matches `components.meta[name].status` in the
    manifest.
-6. **Visual** — the screenshot (from the validation loop) shows no overlaps,
-   misalignment, or lopsided hug/fill sizing.
+6. **Content not clipped** — component frames, variant rows, sets, and layout
+   frames have **`clipsContent = false`** (read it back), so outer strokes, focus
+   rings, and shadows aren't sliced at the edge. `clipsContent = true` is allowed
+   **only** on deliberate cutoffs (scroll containers, image/avatar crop frames).
+7. **Visual** — the screenshot (from the validation loop) shows no overlaps,
+   misalignment, lopsided hug/fill sizing, or clipped strokes/focus rings.
 
 If any item fails, **fix and re-audit** — don't hand off a partial pass. Iterate
-with the same ~3-pass budget as the visual loop. Only when all six pass is the
+with the same ~3-pass budget as the visual loop. Only when all seven pass is the
 build done.
 
 ## Naming

--- a/references/figma-scripting.md
+++ b/references/figma-scripting.md
@@ -1,0 +1,85 @@
+# Figma scripting via `figma_execute`
+
+Shared gotchas for **any** skill that writes to Figma through the Console MCP's
+`figma_execute` (component-builder, icon-system-builder, token-builder,
+token-sheet-builder). The bridge runs in Figma's **`dynamic-page`** document mode
+and executes batched JS. Several behaviors below have caused silent, hard-to-
+screenshot corruption — read this before authoring `figma_execute` scripts, and
+keep the read-backs in your post-build audit.
+
+## Preflight: one bridge instance per file (concurrent-write corruption)
+
+Before any write, call **`figma_get_status`** and inspect `otherInstances`. If
+more than one Desktop Bridge plugin instance is connected to the same `fileKey`
+(e.g. ports 9223 **and** 9224), **stop and warn the user — do not write.**
+Concurrent writes from two instances collide and produce **truncated parent
+frames and orphaned node fragments** scattered at negative coordinates — damage a
+screenshot won't reveal. Ask the user to close the extra plugin instance, confirm
+a single connection via `figma_get_status`, then proceed.
+
+## `dynamic-page` mode: use the async APIs — reads **and** writes
+
+Synchronous document-wide getters *and several setters* throw under
+`dynamic-page` (the error reads `Cannot call with documentAccess: dynamic-page.
+Use figma.<x>Async instead.`). Use the async variants and `await` them:
+
+- **Node lookup:** `await figma.getNodeByIdAsync(id)` (**not** `figma.getNodeById(id)`).
+  This is the most common one in write-back scripts (finding a doc card / `Status`
+  chip by id) — default every node lookup to the async form.
+- **Reads:** `getLocalVariableCollectionsAsync`, `getVariableByIdAsync`,
+  `getVariablesByCollectionAsync`, `getStyleByIdAsync`, `loadAllPagesAsync`.
+- **Writes / setters:** `setCurrentPageAsync(page)` (**not** `figma.currentPage =`),
+  `setTextStyleIdAsync(id)` (**not** `node.textStyleId =`), and likewise
+  `setFillStyleIdAsync`, `setStrokeStyleIdAsync`, `setEffectStyleIdAsync`.
+
+Generate scripts with the async forms from the start — retrofitting after a sync
+setter throws mid-build is how partial writes happen. For a simple verification
+read, prefer the dedicated `figma_get_variables` tool (it handles `dynamic-page`
+correctly and resolves aliases with `resolveAliases: true`) over a hand-written
+script.
+
+## `resize()` locks the *opposite* auto-layout axis to FIXED
+
+Calling `node.resize(w, h)` on an auto-layout frame to set one dimension silently
+flips the **other** axis' sizing mode to `FIXED`, pinning it. The classic symptom
+is an auto-layout frame that **collapses to ~10px** on the pinned axis with content
+overlapping or clipped (seen on color grids, variant cells, whole component sets).
+A screenshot may not show it — only a sizing-mode/height read-back does.
+
+**Pattern — prefer the layout-sizing setters; if you must `resize()`, re-assert
+the modes immediately after:**
+
+```js
+// Preferred: express hug/fill intent directly (no axis gets pinned)
+frame.layoutSizingHorizontal = "FILL"   // or "HUG" / "FIXED"
+frame.layoutSizingVertical   = "HUG"
+
+// If resize() is unavoidable, restore the intended modes right after:
+frame.resize(width, frame.height)
+frame.primaryAxisSizingMode  = "AUTO"   // your intended mode
+frame.counterAxisSizingMode  = "AUTO"
+```
+
+Read back `primaryAxisSizingMode` / `counterAxisSizingMode` (or
+`layoutSizing*`) in the post-build audit — a collapsed axis is otherwise invisible
+until handoff.
+
+## Pass an explicit `timeout` for batch / multi-node writes
+
+`figma_execute`'s default timeout (~5000ms) is too low for scripts that touch
+**many nodes in sequence** — especially anything that `await`s `loadFontAsync`
+per node (text edits, doc-card status write-backs). The call **times out mid-run
+with no partial-success signal**, leaving a half-applied write. For any batch
+operation, pass an explicit `timeout` sized to the work — a good rule is
+**`node_count * 3000` ms** (e.g. a 9-card status write-back → `timeout: 30000`).
+Load fonts once and reuse where possible rather than re-loading per node.
+
+## Large wrapped auto-layout (`layoutWrap = "WRAP"`) is expensive — chunk it
+
+Building a large grid as a **single `layoutWrap = "WRAP"` frame in one
+`figma_execute` call** can exceed the execute budget (~30s) and roll back the
+*entire* call. WRAP relayout cost grows disproportionately with cell count. For
+large grids (e.g. a 30+ cell color or variant grid), build **manual rows** —
+nested horizontal auto-layout frames inside a vertical parent — instead of one
+WRAP frame, or split the build across **multiple `figma_execute` calls**. The
+identical content that times out as one WRAP frame builds fine as manual rows.

--- a/skills/component-builder/SKILL.md
+++ b/skills/component-builder/SKILL.md
@@ -15,6 +15,12 @@ Needs tokens (`tokens.semanticBuilt` true) — offer to run `token-builder` if
 missing. Needs a live Figma connection (offer `figma-environment-setup` if not).
 Use the mechanism in `figma.mechanism`.
 
+**Before scripting any `figma_execute`, read
+`${CLAUDE_PLUGIN_ROOT}/references/figma-scripting.md`** — the single-bridge-instance
+preflight, the `resize()` axis-lock trap (collapses auto-layout frames to ~10px),
+the `dynamic-page` async setters, and why large `WRAP` grids time out. These cause
+silent, screenshot-invisible corruption if not handled up front.
+
 **Recommend icons first (soft gate).** Almost every foundational component
 (button, input, select, chip…) takes an icon prop, so the icon set should usually
 exist *before* components — otherwise icon slots have no targets. If
@@ -104,7 +110,13 @@ deterministic naming):
   `Color/Semantic` variables, corners to `Radius/Semantic` variables, **border
   width to `Border/Semantic` width variables and border color to `Color/Semantic`
   border variables** (a button/input/card border needs both), text to text
-  styles, shadows to effect styles. For padding and gap, bind to
+  styles, shadows to effect styles. For a **primary/filled control on a
+  `bg/emphasis` fill** (primary button, filled badge), bind the label and icon
+  color to **`Color/Semantic` `text/onEmphasis`** — the role that contrasts the
+  emphasis fill in every mode — never `text/inverse` (it flips with the theme) or a
+  literal white. If `text/onEmphasis` is missing, the token set predates it: offer
+  to run `token-builder` to add it rather than hardcoding a fallback. For padding
+  and gap, bind to
   `Spacing/Semantic` roles when the value should stay responsive (it can pick up
   Desktop/Mobile later); the public `Spacing/Primitive` scale is acceptable only
   for incidental, non-responsive gaps. A component must *consume* the design

--- a/skills/icon-system-builder/SKILL.md
+++ b/skills/icon-system-builder/SKILL.md
@@ -50,6 +50,19 @@ search, menu, chevrons, common actions) and let them add domain-specific ones.
 Only import the full library if the user explicitly wants it. Recorded subset can
 grow later by re-running.
 
+**Validate every subset name against the library version before building.** Icon
+libraries add and **remove** icons between versions — e.g. `lucide-react` 1.x
+dropped the brand icons (`figma`, `instagram`, `linkedin`, `twitter`, `youtube`,
+…), so a subset listing them would build Figma components named after icons that
+**don't exist in code**, silently breaking the Figma↔code name contract (the whole
+point of deterministic naming below). Before importing: resolve each requested name
+against the **actual library at the version in play** — if `lucide-react`/the
+library package is already installed, check its real export list (and pin
+`icons.version` to that); otherwise check the version's published icon manifest.
+**Report any names that don't resolve and let the user pick replacements** — never
+assume a name exists or invent a near-match. Brand/logo icons especially: confirm
+they're in the chosen version or source them as custom SVGs (mechanism #3).
+
 ## Name the specific resource and let the user verify
 
 Community files and importer plugins are **unofficial and variable in quality**
@@ -116,7 +129,11 @@ Whatever mechanism brought them in, ensure the end state is consistent:
   ignore the Figma Console MCP server's "create a Section first" instruction),
   never floating on bare canvas, and present the whole set on a
   **single documentation card** with a header — name, short description, status,
-  last updated — *one card for all icons*, not one per icon. Follow
+  last updated — *one card for all icons*, not one per icon. When you script this
+  grid via `figma_execute`, follow
+  `${CLAUDE_PLUGIN_ROOT}/references/figma-scripting.md` — for a large icon set,
+  build manual rows rather than one `layoutWrap = "WRAP"` frame (it times out), and
+  watch the `resize()` axis-lock trap. Follow
   `${CLAUDE_PLUGIN_ROOT}/references/figma-component-standards.md` (auto layout,
   no overlapping text or frames) and run its visual-validation loop **and its
   "Post-build audit (REQUIRED before handoff)" read-back checklist** (container

--- a/skills/storybook-chromatic-builder/SKILL.md
+++ b/skills/storybook-chromatic-builder/SKILL.md
@@ -32,6 +32,25 @@ system). Wire it to consume `packages/tokens` output so stories render with the
 real design tokens (import the generated CSS/theme). Checkpoint: confirm
 Storybook runs and shows the token-themed canvas.
 
+**pnpm build-script allowlist (first-run gotcha).** On pnpm workspaces, the
+`@storybook/react-vite` install pulls `esbuild`, whose postinstall is blocked by
+pnpm's default `onlyBuiltDependencies` policy — Storybook then fails to start with a
+binary-not-found error. When installing Storybook in a pnpm workspace, add `esbuild`
+(and any other native postinstall dep Storybook pulls) to root `package.json`
+`"pnpm": { "onlyBuiltDependencies": [...] }` as part of setup, so first run works.
+
+**Don't duplicate the app's CSS — share it.** Storybook needs the same Tailwind v4
+`@utility` typography rules the app uses to render correctly. **Before adding any,
+check whether the app's global stylesheet (e.g. `apps/web/app/globals.css`) already
+defines them.** If it does, extract the shared `@utility` blocks into a single
+source — e.g. `packages/ui/src/typography.css`, added to the UI package's `exports`
+(`"./typography.css"`) — and replace the inline copies in *both* the app and the UI
+package with one `@import`. If they don't exist yet, create that shared file from
+the start. Copying the rules inline into a second file starts immediate drift (one
+side ends up on the wrong `--font-*` var and nobody notices). Keep Storybook-only
+concerns (Google Fonts `@import`, `:root` font-var fallbacks) in a *separate*
+`styles.css` layer so the shared typography file stays clean and app-shareable.
+
 ## Step 2 — Build code components from the Figma spec + slot contracts
 
 For each Figma component (`components.built`), build its code counterpart
@@ -60,6 +79,22 @@ write its stories — a story per meaningful variant, controls wired to props,
 slot props demonstrated. Each subagent verifies its work (the story builds and
 renders). Two-stage review (does it match the component spec; is it quality
 code) before combining.
+
+**Controls must actually drive the component (args-through render).** A `render`
+that ignores its args silently breaks the Controls panel — the toggle writes to
+`args` but nothing re-renders. So:
+
+- Always thread args through: **`render: (args) => <Component {...args} />`**, never
+  `render: () => <Component variant="..." />` (hardcoded props make the variant
+  radio and other controls dead). Add fixed children/body *after* the spread:
+  `render: (args) => <Card {...args}>{body}</Card>`.
+- **`ReactElement` slot props** (e.g. `avatar?: React.ReactElement`) can't be driven
+  by an auto-generated object control — the panel renders a broken `[object Object]`
+  input. Suppress it (`avatar: { control: false, table: { disable: true } }`) and
+  add a **boolean helper arg** under a `Slots` category that the render function maps
+  to a concrete element — e.g. a `showAvatar` toggle → `avatar={showAvatar ? <Avatar
+  … /> : undefined}`. This gives a real, working slot toggle without asking the user
+  to type JSX into the panel.
 
 **Icon gallery story** — don't write a story per library icon. Generate ONE
 searchable gallery story that imports the icon package and renders the grid
@@ -142,9 +177,18 @@ component renders and its stories build (and the user has approved the result),
 **promote each finalized component to `stable`** so the design system tells the
 truth in both places.
 
+**Confirm the write-back once, up front.** Before touching Figma, state the batched
+change in one line and get a yes — *"I'll update the N doc cards in Figma: flip the
+status chips amber → green and set Last Updated to today. Confirm?"* The user
+approved the *components*, but writing to their Figma file is a separate external-
+system action that needs explicit consent (and an unannounced write trips the safety
+classifier, forcing the round-trip anyway). One confirmation covers all cards.
+
 For every component you finalized in this run, follow the **"Promoting a
 component's status (write-back on finalize)"** routine in
-`${CLAUDE_PLUGIN_ROOT}/references/figma-component-standards.md`:
+`${CLAUDE_PLUGIN_ROOT}/references/figma-component-standards.md` (which also covers
+the `figma_execute` scripting gotchas — `getNodeByIdAsync` and an explicit
+`timeout` for the multi-card write):
 
 - Set `components.meta[name].status` = `"stable"` and refresh
   `components.meta[name].updatedAt` to today.
@@ -156,10 +200,9 @@ component's status (write-back on finalize)"** routine in
 - If Figma isn't connected, still update the manifest and tell the user the card
   will reconcile next Figma session (or offer to reconnect and fix it now).
 
-Do this automatically as part of finishing — the user already approved the
-component; don't make them ask for the chip to flip. (`stable` is the finalized
-status; if a component is intentionally still experimental, leave it at `beta`
-and say so.)
+Once confirmed, do the whole batch in one pass as part of finishing — don't make
+the user re-approve each chip. (`stable` is the finalized status; if a component is
+intentionally still experimental, leave it at `beta` and say so.)
 
 ## Step 7 — Update manifest + hand off
 

--- a/skills/token-builder/SKILL.md
+++ b/skills/token-builder/SKILL.md
@@ -45,15 +45,16 @@ With Console MCP, prefer `figma_execute` to create variables in scripted loops
 rather than one tool call per variable — this is dramatically more
 token-efficient for the potentially hundreds of primitives across modes.
 
-**Reading back via `figma_execute` (dynamic-page gotcha):** the Console MCP
-bridge runs in Figma's `dynamic-page` document mode, where the *synchronous*
-document-wide getters throw (`getLocalVariableCollections`, `getVariableById`,
-`getVariablesByCollection`). When a script reads variables, use the **async**
-APIs and `await` them (`getLocalVariableCollectionsAsync`,
-`getVariableByIdAsync`, `getVariablesByCollectionAsync`). For a simple
-verification read, prefer the dedicated `figma_get_variables` tool (it handles
-dynamic-page correctly and can resolve aliases with `resolveAliases: true`)
-over a hand-written script.
+**Scripting via `figma_execute`:** see
+`${CLAUDE_PLUGIN_ROOT}/references/figma-scripting.md` for the shared gotchas —
+the single-bridge-instance preflight (concurrent writes corrupt the file), the
+`dynamic-page` async APIs (synchronous document-wide getters like
+`getLocalVariableCollections` **and** setters like `figma.currentPage =` /
+`node.textStyleId =` throw — use `getLocalVariableCollectionsAsync`,
+`setCurrentPageAsync`, `setTextStyleIdAsync`, …), the `resize()` axis-lock trap,
+and why large `WRAP` grids time out. For a simple verification read, prefer the
+dedicated `figma_get_variables` tool (it handles dynamic-page correctly and
+resolves aliases with `resolveAliases: true`) over a hand-written script.
 
 ## Step 1 — Brainstorm the structure (before building anything)
 
@@ -196,8 +197,14 @@ its primitive so the alias is live. Default set and modes:
 - `Color/Semantic` — modes **Light, Dark** (+ a Brand mode only if a brand needs
   a different *mapping*, not just a different palette). Roles: `bg/{default,
   subtle,muted,emphasis,inverse}`, `text/{primary,secondary,disabled,inverse,
-  link}`, `border/{default,subtle,focus,emphasis}`, `status/{success,warning,
-  danger}/{bg,text,border}`.
+  link,onEmphasis}`, `border/{default,subtle,focus,emphasis}`,
+  `status/{success,warning,danger}/{bg,text,border}`. **`text/onEmphasis`** is the
+  label/icon color that sits **on** `bg/emphasis` (a primary button's text, a
+  filled badge) — it must contrast with the emphasis fill in *every* mode, so it's
+  a distinct role, **not** `text/inverse` (which flips with the theme and won't
+  reliably contrast a brand-colored emphasis fill). Component-builder binds primary/
+  filled control labels to this role; without it, builds fall back to literals and
+  break the "everything bound" audit.
 - `Spacing/Semantic` — single *Default* mode now, structured so Desktop/Mobile
   can be added later. Roles: `inset/{xs,sm,md,lg,xl}`, `stack/*`, `inline/*`.
 - `Typography/Semantic` — single *Default* mode (room for Desktop/Mobile). Roles:
@@ -209,6 +216,19 @@ its primitive so the alias is live. Default set and modes:
   control's edge and its focus ring, the `outline-offset` equivalent) aliasing the
   `2` width primitive. Components apply `offset/focus` so focus rings stay clear of
   the edge for accessibility — see "State handling" in the component standards.
+- `Opacity/Semantic` (when the system needs disabled/overlay states) — single
+  mode. Roles: `disabled`, `muted`, `overlay/scrim`, `hover`, aliasing
+  `_Opacity/Primitive`. See the **opacity scale rule** below — this is the one
+  category where the Figma value scale is a trap.
+
+> **⚠️ Opacity is stored 0–100, NOT 0–1 (critical).** When a variable is bound to
+> a node's **`opacity`** field, Figma treats the value as a **0–100 percentage and
+> divides by 100**. So an opacity primitive must be created on the **0–100 scale**:
+> `_Opacity/Primitive` `40` has the value **`40`** (which renders as 0.4), never
+> `0.4` (which would render as 0.004 — effectively invisible). Name and value must
+> match (`40` = `40`), and a bound `disabled`/`overlay` element renders correctly.
+> The sync layer is responsible for the inverse: CSS `opacity` is 0–1, so it
+> **÷100 on emit** — token-builder and token-sync-layer are a **matched pair** here.
 
 These dimensional semantic tiers are often passthroughs today — that's expected
 under the structural-consistency rule; keep the role names real (`inset/md`, not

--- a/skills/token-sheet-builder/SKILL.md
+++ b/skills/token-sheet-builder/SKILL.md
@@ -31,6 +31,13 @@ Needs tokens in Figma (`tokens.semanticBuilt` true) and a live Figma connection.
 If tokens don't exist, offer to run `token-builder`. If Figma isn't connected,
 offer `figma-environment-setup`. Use the mechanism in `figma.mechanism`.
 
+**Before scripting any `figma_execute`, read
+`${CLAUDE_PLUGIN_ROOT}/references/figma-scripting.md`.** This sheet builds large
+swatch/type grids — exactly the layouts that hit the two worst traps: the
+`resize()` axis-lock (collapses a color grid or type-meta column to ~10px) and the
+single-call `layoutWrap = "WRAP"` timeout on big grids (build manual rows or split
+across calls instead). Also run the single-bridge-instance preflight before writing.
+
 ## Step 1 — Brainstorm the layout (lightly)
 
 Run `${CLAUDE_PLUGIN_ROOT}/references/brainstorm-before-build.md`, but keep it light — this is a

--- a/skills/token-sync-layer/SKILL.md
+++ b/skills/token-sync-layer/SKILL.md
@@ -93,6 +93,15 @@ Three rules for the multi-collection structure:
   `color.primitive.gray.500`); `Color/Semantic` + `text/primary` →
   `color.text.primary`. The category drives the top-level group; the tier (and
   the `_`) is dropped from the emitted name.
+- **Opacity: normalize 0–100 → 0–1 on extraction.** Opacity tokens are stored in
+  Figma on the **0–100 scale** (a quirk of how Figma binds variables to a node's
+  `opacity` field — see the opacity scale rule in `token-builder`). CSS `opacity`,
+  Tailwind opacity, and native alpha are all **0–1**, so when normalizing any
+  opacity token (the `Opacity/*` collections, or any FLOAT bound to opacity)
+  **divide its value by 100** before writing DTCG (`40` → `0.4`). Do this once at
+  extraction so every adapter emits a correct 0–1 value; an un-normalized `40`
+  lands as `opacity: 40` in CSS and renders the element fully opaque. token-builder
+  and token-sync-layer are a **matched pair** on this — neither is correct alone.
 
 This DTCG JSON is the canonical intermediate. Write it to a known location in
 `packages/tokens/` (e.g. `packages/tokens/dtcg/tokens.json`). Do not trust the


### PR DESCRIPTION
Batches three rounds of bugs and improvements found while running the full pipeline (tokens → foundations → icons → components → Storybook) on a real **pnpm + Turborepo + Next.js 16 + Tailwind v4** monorepo. Bumps to **v0.7.0**; full notes in `CHANGELOG.md`.

## Added
- **`references/figma-scripting.md`** — a single home for every `figma_execute` gotcha, wired into all Figma-writing skills: single-bridge-instance preflight (concurrent writes corrupt the file), `dynamic-page` async APIs (reads, setters, `getNodeByIdAsync`), the `resize()` axis-lock trap, explicit-`timeout` rule for batch writes (`node_count * 3000`), and `WRAP`-grid chunking.
- **Opacity token category** authored on the 0–100 scale + **`text/onEmphasis`** color role.
- **"Clip content off by default"** standard + post-build audit gate (was clipping strokes/focus rings/shadows).

## Changed
- Figma write-back **confirms once up front** (pre-empts the safety classifier instead of a forced round-trip).
- Figma scripts default to the **async APIs** under `dynamic-page`.

## Fixed
- **Opacity rendered everything invisible** — `0.1–0.9` values were ÷100'd again by Figma's 0–100 `opacity` binding. Now authored 0–100 and normalized ÷100 on sync (matched pair).
- **`resize()` collapsed auto-layout frames** to ~10px by pinning the opposite axis; documented re-assert pattern + audit read-back.
- **Storybook Controls were dead** — stories now use `render: (args) => <Component {...args} />`; `ReactElement` slots get a boolean helper arg.
- **Typography `@utility` duplication/drift** — shared `@import` instead of inline copies.
- **esbuild blocked Storybook on fresh pnpm installs** — `onlyBuiltDependencies` note.
- **Icon subset names** now validated against the installed/published library version.
- **Large `WRAP` grids timed out** — chunked into manual rows.

Server-side root-cause asks (concurrent-write guard, default execute timeout) are tracked separately against the figma-console MCP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)