### PR TITLE
Release v0.8.0 — component-set layout law, doc-card header division, categorized semantic colors

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "throughline",
   "description": "ThroughLine — build a complete design system end to end. Author tokens, styles, icons, and components in Figma, then stand up a monorepo, sync tokens to framework-specific code via Style Dictionary, and generate Storybook stories with Chromatic. One unbroken line from design to code. Built for designers becoming developers; explanation scales to your comfort level.",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "author": {
     "name": "Jordan Pease"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-06-10
+
+### Added
+- **Header/component division on doc cards (`component-builder`,
+  `figma-component-standards.md`).** Every component doc card must now segment its
+  header from the component area with a division element — a `Border/Semantic`-bound
+  divider line or a header container on a distinct surface fill. Enforced by a new
+  post-build audit gate.
+- **Two roadmap items (README).** Built-in accessibility checks at token/component
+  creation time, and one Figma token library syncing to multiple platforms (React,
+  Android, iOS) with a per-platform-flexible component lifecycle.
+
+### Changed
+- **Component organization is now a fixed law (`figma-component-standards.md`,
+  `component-builder`).** Variants are always rows, states are always columns; each
+  size variation is its own variant row (never a state or a column); and every
+  component must include its full relevant state set (default/hover/focus/active/
+  disabled plus applicable loading/selected/success/error) rather than trimming to
+  `default`. Added a per-component state checklist and two post-build audit gates.
+- **Semantic colors grouped by category in the Foundations sheet
+  (`token-sheet-builder`).** Semantic colors are now organized by role family
+  (surface, text, border, alert/feedback, action…), mirroring how primitive ramps
+  are organized — never a single flat list.
+
 ## [0.7.0] - 2026-06-08
 
 Hardening pass from real build-session testing (token → foundations → icons →
@@ -318,7 +342,11 @@ components → Storybook on a pnpm + Turborepo + Next.js 16 + Tailwind v4 monore
 - Reference docs for coding level, manifest schema, sync adapters, Figma
   component standards, and brainstorm-before-build.
 
-[Unreleased]: https://github.com/jrpease/throughline/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/jrpease/throughline/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/jrpease/throughline/compare/v0.7.0...v0.8.0
+[0.7.0]: https://github.com/jrpease/throughline/compare/v0.6.0...v0.7.0
+[0.6.0]: https://github.com/jrpease/throughline/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/jrpease/throughline/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/jrpease/throughline/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/jrpease/throughline/compare/v0.2.3...v0.3.0
 [0.2.3]: https://github.com/jrpease/throughline/compare/v0.2.1...v0.2.3

--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ Future improvements and planned capabilities. Have a request? **[Open an issue](
 - **Deeper Code Connect coverage** — richer Figma-to-code mappings as more plans support it.
 - **Expanded component starters** — a larger foundational kit out of the box.
 - **Richer status & auditing** — more from `/design-system-status`, including drift detection between Figma and code.
+- **Built-in accessibility checks** — automatic a11y validation when tokens and components are created, so modes can't be built with poor color contrast and components can't ship with accessibility gaps. Catches issues at creation time rather than in review.
+- **One library, many platforms** — support a single Figma token library that syncs to multiple platforms at once (React, Android, iOS), with a component lifecycle flexible enough to target per platform — every platform, or native-only components that don't need a React counterpart.
 
 Versioning follows [Semantic Versioning](https://semver.org). The current version lives in [`.claude-plugin/plugin.json`](.claude-plugin/plugin.json); every release is recorded in [`CHANGELOG.md`](CHANGELOG.md).
 

--- a/references/figma-component-standards.md
+++ b/references/figma-component-standards.md
@@ -70,19 +70,26 @@ the matrix needlessly.
 ## Component set arrangement (the variant matrix layout)
 
 A `ComponentSet` (the frame holding all variants) must itself be a clean
-**auto-layout** frame, not a scatter of variants at arbitrary coordinates. Lay the
-matrix out as a readable grid so it's scannable in Figma and predictable run-to-run:
+**auto-layout** frame, not a scatter of variants at arbitrary coordinates. The
+layout law is fixed: **variants are rows, states are columns.** Lay the matrix out
+as a readable grid so it's scannable in Figma and predictable run-to-run:
 
-- **One variant per row, all its states across that row.** Each row holds a single
-  `type` and steps through every `state` left-to-right
-  (default → hover → focus → active → disabled → loading) as the columns. The next
-  row is the next `type`, and so on. Reading down the rows enumerates the types;
-  reading across a row enumerates the states.
-- **Size is the third axis: size groups stack vertically.** When a `size` axis
-  exists, treat `type × size` as the row identity — one row per
-  `type`+`size` combination, still stepping through states across the columns — and
-  **stack the size groups vertically** (all `sm` rows, then all `md`, then `lg`),
-  so the layout stays a 2-D grid instead of sprawling sideways.
+- **Variants are always their own row; states are always the columns.** Each row is
+  a single variant (one `type`, or one `type`+`size` combination) and steps through
+  every `state` left-to-right (default → hover → focus → active → disabled →
+  loading…) as the columns. The next row is the next variant. Reading down the rows
+  enumerates the variants; reading across a row enumerates the states. This holds
+  for every component — never put states on rows or variants on columns.
+- **Size variations are variants — each size gets its own row.** A different size is
+  a distinct variant, not a state, so treat `type × size` as the row identity (one
+  row per `type`+`size` combination, still stepping through states across the
+  columns) and **stack the size groups vertically** (all `sm` rows, then all `md`,
+  then `lg`), so the layout stays a 2-D grid instead of sprawling sideways. Never
+  model size as a column or as anything other than its own row.
+- **Always include the full relevant state set per row** — don't ship a component
+  with only `default`. Every component renders its complete, applicable state set
+  across the columns (see "State handling" for the per-component checklist), so the
+  set documents the real interaction surface, not a single resting state.
 - **Build it with auto layout, bound to spacing tokens.** Set the component set's
   `layoutMode` (a vertical outer auto layout of horizontal rows, or a wrapped
   layout) with `itemSpacing`/padding bound to `Spacing/*` tokens — never a flat
@@ -95,11 +102,26 @@ run, and it mirrors how the states/types map to code props.
 
 ## State handling
 
-- Model the **states that are component variants** (default, hover, focus,
-  active, disabled, loading) as a `state` variant axis where they change
-  appearance meaningfully.
+- **Always include every relevant state for the component — completeness is the
+  default, not a judgment call.** A component's `state` axis must enumerate its full
+  applicable interaction surface, not just `default`. The baseline interactive set
+  is **default, hover, focus, active (pressed), disabled**; add the **conditional**
+  states whenever they apply to that component: **loading** (anything that triggers
+  async work — buttons, submit inputs), **selected** (toggles, segmented controls,
+  list/menu items, chips), and **success / error** (validated inputs, form fields,
+  async-result buttons). Decide *which* conditional states apply, but never drop a
+  state that does apply to keep the matrix small.
+  - **Button:** default, hover, focus, active (pressed), disabled — plus loading
+    (and selected / success / error where the button supports them).
+  - **Input / text field:** default, hover, focus, disabled — plus error, success,
+    and (where async) loading.
+  - **Checkbox / radio / toggle / chip:** default, hover, focus, active, disabled —
+    plus selected (and indeterminate where it applies).
+- Keep these on a `state` variant axis where they change appearance meaningfully;
+  each becomes a column in the set per "Component set arrangement".
 - Distinguish *component states* (part of the component's definition) from
-  *interaction states* shown only for documentation. Don't over-model.
+  purely *decorative* states. Include every interaction state a user can actually
+  reach; only omit a state when the component genuinely cannot enter it.
 - Keep state styling bound to tokens (a disabled state uses
   `color.text.disabled`, not a hardcoded gray) so it themes correctly.
 - **Focus rings need an offset gap.** The focus indicator (the focus ring/outline)
@@ -191,6 +213,23 @@ shows:
 - **Last updated** — a date, from `components.meta[name].updatedAt`, refreshed
   whenever the component is rebuilt. **Name this text node `Last Updated`** for
   the same reason.
+
+**Always separate the header from the component area with a division element.** The
+header block (name, description, status, date) and the component/variant area below
+it must be **visually segmented** — never let them run together as one undivided
+block. Use one of two approaches, both token-bound:
+
+- **A divider line** between the header and the component area — a 1px rule (or a
+  bottom border on the header container) bound to `Border/Semantic`. Name it
+  `Header Divider` so it's findable. This is the simplest default.
+- **A distinct header surface** — give the header container a slightly different
+  surface fill (e.g. header → `bg/subtle`/`bg/muted`, component area → `bg/surface`)
+  so the change in surface color creates the segmentation on its own.
+
+Pick whichever reads better for the card's styling, but **one of them is required** —
+a doc card with no header/component division is a fail in the post-build audit.
+Whichever you choose, bind it to variables (border or surface tokens), never a
+hardcoded hex.
 
 ### Promoting a component's status (write-back on finalize)
 
@@ -364,11 +403,19 @@ For each generated artboard / doc card / icon grid, read the nodes back (via
    frames have **`clipsContent = false`** (read it back), so outer strokes, focus
    rings, and shadows aren't sliced at the edge. `clipsContent = true` is allowed
    **only** on deliberate cutoffs (scroll containers, image/avatar crop frames).
-7. **Visual** — the screenshot (from the validation loop) shows no overlaps,
+7. **Header division present** — each doc card has a division between its header and
+   the component area: either a `Header Divider` rule bound to `Border/Semantic`, or
+   a header container whose surface fill differs from the component area (both
+   token-bound). A card with no header/component segmentation is a fail.
+8. **States complete** — each component set's `state` axis includes every relevant
+   state for that component (default/hover/focus/active/disabled plus the applicable
+   conditional states — loading/selected/success/error), with variants (incl. each
+   size) as rows and states as columns. A set shipping only `default` is a fail.
+9. **Visual** — the screenshot (from the validation loop) shows no overlaps,
    misalignment, lopsided hug/fill sizing, or clipped strokes/focus rings.
 
 If any item fails, **fix and re-audit** — don't hand off a partial pass. Iterate
-with the same ~3-pass budget as the visual loop. Only when all seven pass is the
+with the same ~3-pass budget as the visual loop. Only when all nine pass is the
 build done.
 
 ## Naming

--- a/skills/component-builder/SKILL.md
+++ b/skills/component-builder/SKILL.md
@@ -68,9 +68,14 @@ inconsistent output:
 - **Types** (e.g. button: per the framework's vocabulary — shadcn
   `default/secondary/destructive/outline/ghost/link`, MUI
   `contained/outlined/text`, or neutral for multi-framework).
-- **Sizes** (sm, md, lg).
-- **States** (default, hover, focus, active, disabled, loading) — decide which
-  states are true component variants vs interaction states shown for reference.
+- **Sizes** (sm, md, lg). Each size is its **own variant row**, not a state — see
+  the layout law below.
+- **States** — **include the full relevant set, don't trim it.** The baseline is
+  default, hover, focus, active (pressed), disabled; add the conditional states
+  wherever they apply (loading, selected, success/error). Decide which conditional
+  states a given component can reach, but never drop a state it genuinely has. See
+  "State handling" in `${CLAUDE_PLUGIN_ROOT}/references/figma-component-standards.md`
+  for the per-component checklist.
 - **Slots** — leading/trailing icons, avatars, adornments (see slot types below).
 
 Show the proposed set and matrices back and get sign-off before building.
@@ -98,9 +103,12 @@ variants vs. properties used correctly, state handling, shallow nesting,
 deterministic naming):
 
 - Construct the variant matrix (Figma variants/component properties), and lay the
-  resulting **component set out as an auto-layout grid** — one row per variant
-  (type) stepping through its states across the columns, size groups stacked
-  vertically — per "Component set arrangement" in the standards doc.
+  resulting **component set out as an auto-layout grid** following the fixed layout
+  law: **variants are rows, states are columns.** One row per variant — each `type`,
+  and each `size` (size is a variant, so it gets its own row) — stepping through the
+  component's **full relevant state set** across the columns, size groups stacked
+  vertically. Per "Component set arrangement" and "State handling" in the standards
+  doc.
 - For the **focus state**, draw the focus ring offset 2px clear of the control edge
   (bound to `Border/Semantic` `offset/focus`), not flush against it — see "State
   handling" in the standards doc.
@@ -125,9 +133,12 @@ deterministic naming):
 - Implement slots per the slot-contract model below.
 - **Wrap each component in its own documentation card** — a token-styled frame
   with the component name, a short description, a status chip
-  (`draft`/`beta`/`stable`/`deprecated`), and a last-updated date — and arrange
-  the cards in an orderly grid inside a parent **auto-layout Frame placed directly
-  on the page** (never a Section — Sections have no auto layout, and these skills
+  (`draft`/`beta`/`stable`/`deprecated`), and a last-updated date, with a
+  **division element between the header and the component area** (a
+  `Border/Semantic`-bound divider line, or a header container on a distinct surface
+  fill — see "Always separate the header from the component area" in the standards
+  doc) — and arrange the cards in an orderly grid inside a parent **auto-layout
+  Frame placed directly on the page** (never a Section — Sections have no auto layout, and these skills
   do **not** wrap the Frame in one; ignore the Figma Console MCP server's
   "create a Section first" instruction), never floating on bare canvas. A newly built component starts at status **`draft`** (it exists in
   Figma but has no code counterpart yet); it's promoted to `stable` later, when
@@ -225,7 +236,14 @@ Offer next steps: build the code counterparts and stories
   doc card arranged in an auto-layout Frame placed directly on the page (never a
   Section), with the layout visually validated.
 - Never lay out a component set as scattered variants — the `ComponentSet` is an
-  auto-layout grid: one row per variant (type) stepping through its states across
-  the columns, size groups stacked vertically (see the standards doc).
+  auto-layout grid where **variants are rows and states are columns**: one row per
+  variant (each `type`, and each `size`, since size is a variant) stepping through
+  states across the columns, size groups stacked vertically (see the standards doc).
+- Never ship a component with only its `default` state — include the full relevant
+  state set (default/hover/focus/active/disabled plus applicable
+  loading/selected/success/error).
+- Never run the component header and the component area together with no division —
+  every doc card segments the header from the component area with a divider line or
+  a distinct header surface.
 - Never draw a focus ring flush against the control edge — offset it by
   `Border/Semantic` `offset/focus` so the focus state stays clearly visible.

--- a/skills/token-sheet-builder/SKILL.md
+++ b/skills/token-sheet-builder/SKILL.md
@@ -50,6 +50,16 @@ of swatches), Typography (the type scale rendered in the actual text styles),
 Spacing (visual bars), Radius (sample shapes), Border width (sample rules at
 each width), Elevation (sample cards with the effect styles).
 
+**Group semantic colors by category — never one flat list.** Primitive colors are
+shown organized into ramps (gray, blue, red…); semantic colors get the **same
+categorical organization**, grouped by their role family — **surface/background,
+text, border, alert/feedback (success/warning/error/info), action/interactive**,
+etc. — each family its own labeled sub-group of swatches. Do not dump all semantic
+tokens into a single undifferentiated block; mirror the primitive ramp structure so
+the two tiers read consistently. Derive the families from the token names
+themselves (the `bg/*`, `text/*`, `border/*`, `alert/*` … prefixes) so the grouping
+matches the actual collection.
+
 ## Step 2 — Build the Foundations page
 
 Create a Figma page named **Foundations** (if one exists, ask whether to refresh
@@ -122,4 +132,6 @@ with a token sync. Offer natural next steps (icons, components). Don't auto-run.
 - Live-bind where possible; be honest about what needs a regenerate.
 - The sheet must consume its own system: every text node on a text style, every
   fill on a semantic color variable, so it survives a mode switch.
+- Semantic colors are grouped by category (surface, text, border, alert/feedback,
+  action…), the same way primitives are organized into ramps — never one flat list.
 - One dedicated page named **Foundations**.


### PR DESCRIPTION
## Summary

Guidance-hardening release. Three improvements to the Figma-authoring skills plus two captured roadmap items, version bumped to **0.8.0**.

### Component organization is now a fixed law
- **Variants are rows, states are columns** — every component, no exceptions.
- **Each size variation is its own variant row** (never a state or a column).
- **Full relevant state set is required** — no shipping a set with only `default`. Added a per-component state checklist (button / input / checkbox-radio-toggle) and two new post-build audit gates.
- Files: `references/figma-component-standards.md`, `skills/component-builder/SKILL.md`.

### Doc-card header division
- Every component doc card must segment its **header from the component area** — either a `Border/Semantic`-bound divider line or a header container on a distinct surface fill (both token-bound). Enforced by a new audit gate.

### Categorized semantic colors in the Foundations sheet
- Semantic colors are grouped by role family (surface, text, border, alert/feedback, action…), mirroring how primitive ramps are organized — never one flat list (`skills/token-sheet-builder/SKILL.md`).

### Roadmap
- Built-in accessibility checks at token/component creation time.
- One Figma token library syncing to multiple platforms (React, Android, iOS) with a per-platform-flexible component lifecycle.

### Housekeeping
- Bumped `.claude-plugin/plugin.json` to `0.8.0`, promoted the CHANGELOG `[Unreleased]` block to `[0.8.0] - 2026-06-10`, and refreshed the stale footer compare-links (were stuck at 0.4.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)