### PR TITLE
feat: start command, deferred cover, mode-aware elevations, official Lucide fetch (v0.9.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "throughline",
   "description": "ThroughLine — build a complete design system end to end. Author tokens, styles, icons, and components in Figma, then stand up a monorepo, sync tokens to framework-specific code via Style Dictionary, and generate Storybook stories with Chromatic. One unbroken line from design to code. Built for designers becoming developers; explanation scales to your comfort level.",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "author": {
     "name": "Jordan Pease"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@ to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-06-10
+
+### Added
+- **`/throughline:start` command — the deterministic entry point.** A slash
+  command that routes straight into `figma-environment-setup`, bypassing
+  natural-language skill competition. The README now leads with it. This fixes
+  cases where another installed plugin (e.g. superpowers' `brainstorming`) would
+  intercept "let's build my design system"–style phrases and run ahead of
+  environment setup.
+
+### Changed
+- **Lucide icons now fetched directly from the official source repo
+  (`icon-system-builder`).** The skill previously defaulted to duplicating a
+  community Figma file — "cheapest" in Claude tokens but it pushed manual work
+  onto the user (find file, duplicate, copy components). For Lucide, which
+  publishes every icon as a uniform 24px SVG at a deterministic repo path, the new
+  default is to batch-fetch the curated subset from
+  `raw.githubusercontent.com/lucide-icons/lucide/<tag>/icons/<name>.svg` and
+  componentize via `figma.createNodeFromSvg` in one scripted pass — fully
+  automated, official source-of-truth, deterministic naming, and a 404 doubles as
+  the name-validation check. Community file / importer plugin are now fallbacks.
+  Material (variant axes, no clean per-icon file) and custom SVGs are unchanged.
+
+### Fixed
+- **Cover page no longer built before tokens/styles exist (`figma-environment-setup`,
+  `token-sheet-builder`, `manifest-schema.md`).** Setup used to build the branded
+  Cover page during environment setup — before any tokens or styles existed — so
+  it could never be on-brand. Setup now does a throwaway write test only; the
+  real, fully token-bound Cover page is built by `token-sheet-builder` alongside
+  the Foundations page, where it can consume the system and survive mode switches.
+  `figma.coverPageBuilt` is now owned by `token-sheet-builder`.
+- **Elevations are now dark-mode-aware (`token-builder`).** Elevation effect
+  styles baked in a literal shadow color, so toggling Light/Dark never recolored
+  shadows. Shadow color now lives in mode-aware `shadow/*` semantic color
+  variables, and the effect styles **bind** their shadow color to those variables
+  (only the offset/blur/spread composition stays in the style). Toggling modes now
+  recolors every elevation automatically.
+
 ## [0.8.0] - 2026-06-10
 
 ### Added
@@ -342,7 +380,8 @@ components → Storybook on a pnpm + Turborepo + Next.js 16 + Tailwind v4 monore
 - Reference docs for coding level, manifest schema, sync adapters, Figma
   component standards, and brainstorm-before-build.
 
-[Unreleased]: https://github.com/jrpease/throughline/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/jrpease/throughline/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/jrpease/throughline/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/jrpease/throughline/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/jrpease/throughline/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/jrpease/throughline/compare/v0.5.0...v0.6.0

--- a/README.md
+++ b/README.md
@@ -76,9 +76,13 @@ Install from this repo's plugin marketplace:
 /plugin install throughline@throughline-marketplace
 ```
 
-Then just tell Claude Code:
+Then start with:
 
-> **"let's set up my design system"**
+```
+/throughline:start
+```
+
+This is the reliable entry point — it runs environment setup first, ahead of anything else. (You can also just say *"let's set up my design system"*, but if you have other plugins installed that grab "let's build…" style phrases, the slash command guarantees ThroughLine takes the wheel.)
 
 From there, Claude walks you through executing its **9 skills powered by 7 reference documents**, sequenced based on your unique needs and goals. The plugin is built to provide consistent checkpoints for human review and guidance — letting you make the big decisions while it does the dirty work.
 

--- a/commands/start.md
+++ b/commands/start.md
@@ -1,0 +1,22 @@
+---
+description: Start building your design system — the deterministic entry point. Runs environment setup first, before anything else.
+---
+
+This is the **first step** for building a design system with ThroughLine. The
+user invoked it explicitly, so begin immediately — do **not** invoke any
+brainstorming or planning skill first. There is nothing to brainstorm until the
+environment exists: the local working folder must be created and Figma must be
+connected before any design work can happen.
+
+Invoke the `figma-environment-setup` skill now and follow it exactly. It will:
+
+1. Locate or create the project directory and scan what's already there.
+2. Create the local working folder and write the `design-system.json` manifest.
+3. Connect Claude to Figma and verify the connection.
+
+If `design-system.json` already exists in this folder, the setup skill will
+detect it and route the user to the right next step rather than starting over —
+let it make that call.
+
+Scale all explanation to the user's coding level. Assume they may be
+design-fluent but new to developer tooling, terminals, and API tokens.

--- a/references/manifest-schema.md
+++ b/references/manifest-schema.md
@@ -153,8 +153,10 @@ bailing or running silently.
   verified live each run (see skill 0's liveness check).
 - `lastVerified` — ISO timestamp of the last successful liveness check.
 - `coverPageBuilt` — whether the branded **Cover** page has been generated in the
-  file (set by `figma-environment-setup`). The plugin cannot set the file
-  thumbnail via the API, so "set as thumbnail" stays a one-time manual user step.
+  file (set by `token-sheet-builder`, *not* `figma-environment-setup` — the Cover
+  is built after tokens and styles exist so it can be on-brand). The plugin cannot
+  set the file thumbnail via the API, so "set as thumbnail" stays a one-time manual
+  user step.
 - `canPublish` — whether the user can publish a Figma **team library** (requires
   a paid plan, Professional+). `true` / `false` / `null` (unknown / not yet
   asked). Asked once and recorded; gates the typed instance-swap dropdown path.

--- a/skills/figma-environment-setup/SKILL.md
+++ b/skills/figma-environment-setup/SKILL.md
@@ -372,35 +372,21 @@ client need a restart? Walk them back through the relevant sub-step.
 
 Do not move on until the liveness check passes.
 
-## Step 6.5 — Create the Cover page
+## Step 6.5 — Prove writes work (throwaway)
 
-Now that writes are proven to work, make the file's first impression: a **Cover**
-page. This is the first thing Claude writes into Figma.
+The liveness check above is a *read*. Before handing off, confirm Claude can also
+**write** to the file — but do **not** leave a permanent artifact behind. The
+file's branded **Cover** page is built later, by `token-sheet-builder`, once
+tokens and styles actually exist, so it can be genuinely on-brand instead of a
+neutral placeholder built against nothing.
 
-- Find the file's first page. If it's the default empty "Page 1" (no meaningful
-  content), **rename it to `Cover`** and use it. If it has content, create a new
-  page named `Cover` and move it to the **top** of the page list. Don't clobber a
-  page the user has already worked in.
-- On that page, build one clean, on-brand **Cover** frame with:
-  - the design system name (`workspace.name`),
-  - the author/owner name (ask once if you don't have it, or use the file owner),
-  - "Last updated" with the current date,
-  - a simple, tasteful branded graphic — keep it clean and token-friendly (a
-    bold wordmark, a few shapes, generous spacing), not an elaborate
-    illustration. If tokens already exist, bind colors/spacing to them; this
-    early they usually don't, so a restrained neutral layout is fine and can be
-    refreshed later.
-- Use proper **vertical auto layout** and place the content inside the frame (no
-  floating, no overlapping text) per
-  `${CLAUDE_PLUGIN_ROOT}/references/figma-component-standards.md`.
-- **Setting it as the file thumbnail is a manual step** — the plugin API can't do
-  it. Tell the user plainly: "To make this the file's cover image, right-click the
-  Cover frame and choose **Set as thumbnail**." Offer it; don't block on it.
-- Record `figma.coverPageBuilt` = `true`. On later runs, refresh the "Last
-  updated" date rather than creating a second Cover page.
+- Create one trivial throwaway node (e.g. a small frame or text node named
+  `__throughline write test`) on any page.
+- Confirm it landed with a quick read or `figma_capture_screenshot`.
+- **Delete it.** If both the write and the delete succeed, writes are proven.
 
-Keep this lightweight and skippable — if the user would rather jump straight to
-tokens, note the Cover can be generated anytime and move on.
+Leave `figma.coverPageBuilt` = `false` here — that flag is set later, when the
+real Cover page is built. Keep this step quick; it's plumbing, not design.
 
 ## Step 7 — Hand off
 

--- a/skills/icon-system-builder/SKILL.md
+++ b/skills/icon-system-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: icon-system-builder
-description: Build an icon system in Figma — a dedicated "Icons" page populated with the user's chosen icon library (Lucide, Material, or custom SVGs) as well-named, scalable components — using the fastest and cheapest mechanism (duplicating a vetted community component file or running an importer plugin) rather than hand-generating icons. Use this when the user wants to set up icons, add an icon library, import Lucide or Material icons, create icon components, or build an icon set in Figma. Also trigger when the user mentions iconography, an icon page, or needs icons for their components. Make sure to use this whenever someone needs a managed set of icon components in their Figma design system.
+description: Build an icon system in Figma — a dedicated "Icons" page populated with the user's chosen icon library (Lucide, Material, or custom SVGs) as well-named, scalable components — using the fastest, most-automated mechanism per library (for Lucide, batch-fetching the curated subset's official SVGs from the source repo and componentizing them hands-off; for Material, the official community file or importer plugin) rather than hand-generating icons or making the user copy components by hand. Use this when the user wants to set up icons, add an icon library, import Lucide or Material icons, create icon components, or build an icon set in Figma. Also trigger when the user mentions iconography, an icon page, or needs icons for their components. Make sure to use this whenever someone needs a managed set of icon components in their Figma design system.
 ---
 
 # Icon system builder
@@ -11,33 +11,66 @@ and swapped via instance properties.
 
 ## Core principle: don't make Claude draw 1,700 icons
 
-The expensive, wrong path is Claude generating icon components one by one via the
-write mechanism — slow and token-hungry. The icon libraries already publish Figma
-resources. **Get to the end state via the cheapest mechanism that produces clean,
-well-named components**, in this preference order:
+The expensive, wrong path is Claude generating icon components one by one, by
+hand, via the write mechanism — slow and token-hungry. Get to the end state via
+the **cheapest mechanism that is also fully automated and produces clean,
+well-named components.** "Cheapest" is not just Claude tokens: a mechanism that
+burns near-zero tokens but makes the *user* hunt down a community file, duplicate
+it, and copy components by hand isn't actually cheap — it just moves the cost onto
+them. **The library determines the mechanism, deterministically** — same library,
+same path every run.
 
-1. **Duplicate a vetted community component file** (cheapest — near-zero Claude
-   tokens; the user copies a Figma Community resource where icons are already
-   components). Lucide and Material both have community files with the icons as
-   publishable components.
-2. **Run a reputable importer plugin** inside Figma (builds the component set
-   from the library source, sometimes the latest release; can often import a
-   subset). Use when no suitable community file fits, or when the user wants the
-   latest/source-of-truth set.
-3. **Generate from source SVGs (last resort)** — only for genuinely **custom**
-   icons the user brings, or when neither above works. Even then, batch the
-   import; never hand-draw.
+### Lucide → fetch the official SVGs directly (default)
 
-**This order is a hard gate, not a vibe — the library determines the path.** For
-a known library (Lucide, Material), the answer is **#1**, falling back to **#2**
-only if no community file fits. **Never #3 for a known library.** In particular:
-**fetching a library's SVGs from its website (e.g. lucide.dev) and hand-prepping
-them into components IS mechanism #3 wearing a disguise** — it is the slow,
-last-resort path, not a reasonable default. Do not take it for Lucide or Material;
-they always have a community file (#1) or importer plugin (#2). Reserve SVG import
-for custom icon sets only. Choosing a *different* mechanism on different runs for
-the *same* library is a bug: the library fixes the choice, so it must be
-deterministic.
+**Default for Lucide: fetch the curated subset straight from the official source
+repo and batch-componentize it.** Lucide publishes every icon as a uniform 24px
+SVG at a deterministic path (`github.com/lucide-icons/lucide`, `icons/<name>.svg`),
+and the filename *is* the canonical name (`arrow-right` ↔ `ArrowRight` in
+`lucide-react`). So the agent can do the whole thing hands-off:
+
+1. Resolve the subset to kebab-case icon names (see name validation below) and
+   pin a release **tag** — ideally the tag matching the installed `lucide-react`
+   version, so the Figma mirror and the code package are the same generation.
+2. Batch-fetch each
+   `https://raw.githubusercontent.com/lucide-icons/lucide/<tag>/icons/<name>.svg`.
+   A **404 means that icon doesn't exist at that version** — report it and let the
+   user pick a replacement. (This *is* the name-validation gate, for free.)
+3. In one scripted pass, turn each SVG into a component via
+   `figma.createNodeFromSvg(svg)`, convert to a component, name it per the naming
+   contract (Step 3), and set the base size.
+
+This is **fully automated, official source-of-truth, deterministic-named, and
+needs no manual user steps** — strictly better than a community-file copy for a
+library shaped like this. This is **not** the old "fetch SVGs off a website and
+hand-prep them" anti-pattern: that meant a human manually downloading and cleaning
+files. Batch-grabbing the official repo by deterministic path and scripting
+`createNodeFromSvg` is cheap *and* hands-off.
+
+**Fallbacks (only if the fetch path is blocked or the user prefers):** a vetted
+Lucide community component file, or the official Lucide importer plugin — e.g. if
+GitHub is unreachable, the user is on a restricted network, or they explicitly
+want the community file. Name the specific resource and surface its license first
+(see below).
+
+### Material → official community file / importer (default)
+
+Material has **variant axes** (outlined / rounded / sharp × fill / weight / grade /
+optical size), so there is no single clean per-icon file to grab — a direct repo
+fetch isn't the clean default it is for Lucide. **Default to the official Material
+Symbols community file or the official Material importer plugin** (Apache-2.0):
+name the specific vetted resource, say why, surface the license, and get the
+user's confirmation (see below). Only consider a direct fetch if the user pins one
+specific style, and even then prefer the importer. Never hand-draw or generate
+one-by-one.
+
+### Custom → batched SVG import
+
+The user's own SVGs, brought in via **batched import + componentize** (never
+hand-drawn, never one at a time). The sync layer later turns these into code via
+its SVGR pipeline — see Step 3.5.
+
+**Choosing a *different* mechanism on different runs for the *same* library is a
+bug:** the library fixes the choice, so it must be deterministic.
 
 ## Default to a CURATED SUBSET, not the whole library
 
@@ -63,49 +96,61 @@ library package is already installed, check its real export list (and pin
 assume a name exists or invent a near-match. Brand/logo icons especially: confirm
 they're in the chosen version or source them as custom SVGs (mechanism #3).
 
-## Name the specific resource and let the user verify
+## Name the resource and license (community-file / importer paths)
 
-Community files and importer plugins are **unofficial and variable in quality**
-(some popular plugins are reported buggy/slow). So: name the *specific* vetted
-resource you intend to use, briefly say why, and let the user confirm or pick
-another before proceeding. Don't silently grab whatever's first. Prefer
-well-maintained, clearly-licensed resources; surface the license for commercial
-use.
+When a path uses an **unofficial** community file or importer plugin — Material's
+default, or a Lucide *fallback* — those resources are variable in quality (some
+popular plugins are reported buggy/slow). So: name the *specific* vetted resource
+you intend to use, briefly say why, surface its license for commercial use, and
+let the user confirm or pick another before proceeding. Don't silently grab
+whatever's first. Verify the link is still live — don't assume a stale URL/file
+key works; if the named resource has moved, search Figma Community for the
+official/most-installed equivalent and confirm before using.
 
-**Start from these default candidates so the choice is consistent across runs**
-(verify the current link with the user — don't assume a stale URL/file key is
-still live; if the named resource has moved, search Figma Community for the
-official/most-installed equivalent and confirm before using):
+Default candidates for these paths, so the choice is consistent across runs:
 
-- **Lucide** → prefer Lucide's **official Figma resource** (the Lucide-team
-  community file, or the official "Lucide Icons" importer plugin for a subset/
-  latest set). MIT-licensed. This is mechanism #1/#2 — never fall back to
-  fetching SVGs off lucide.dev.
-- **Material** → prefer the **official Material Symbols** community file, or the
-  official Material icon importer plugin. Apache-2.0.
-- **Custom** → the user's own SVGs via batched import (mechanism #3).
+- **Lucide fallback** → Lucide's **official Figma resource** (the Lucide-team
+  community file, or the official "Lucide Icons" importer plugin). MIT-licensed.
+  Only used if the official-SVG fetch (the Lucide default, above) is blocked.
+- **Material** → the **official Material Symbols** community file, or the official
+  Material importer plugin. Apache-2.0.
+- **Custom** → the user's own SVGs via batched import.
 
-If you genuinely cannot confirm a community file or importer plugin for a known
-library, **say so and ask the user** which resource to use — do **not** silently
-drop to fetching website SVGs.
+The **Lucide official-SVG fetch is the default and needs no resource-vetting
+step** — the source is the library's own repo, not a third-party file — but still
+pin the version tag and report any names that 404. If you genuinely cannot reach
+the Lucide repo *and* cannot confirm a community file or importer, **say so and
+ask the user** which resource to use — never invent a source.
 
 ## Step 1 — Choose library + mechanism
 
 - Ask which library: **Lucide** (the shadcn default; outline only),
   **Material**, or **custom** (user brings SVGs). Record in `icons.library`.
 - Determine the subset (brainstorm, above).
-- Pick the mechanism cheapest-first, name the specific resource, get the user's
-  confirmation. For custom, plan a batched SVG import.
+- The library fixes the mechanism (Core principle): **Lucide → fetch official
+  SVGs from the repo; Material → official community file / importer; custom →
+  batched SVG import.** Pin the version tag for Lucide. Only name + confirm a
+  specific community-file/importer resource for the paths that use one (Material,
+  or a Lucide fallback).
 
 ## Step 2 — Bring icons in
 
-Execute the chosen mechanism. If duplicating a community file, guide the user
-through copying it (or the relevant components) into their file's **Icons** page.
-If using an importer plugin, walk the install/run and the subset selection. If
-custom SVGs, batch-import and componentize them.
+Execute the library's mechanism:
+
+- **Lucide (default):** batch-fetch the subset's SVGs from
+  `raw.githubusercontent.com/lucide-icons/lucide/<tag>/icons/<name>.svg`, then in
+  one scripted pass build each into a named component via
+  `figma.createNodeFromSvg`. Report any 404s and let the user pick replacements
+  before finishing. No manual user steps. (If the fetch is blocked, fall back to
+  the community file / importer and guide the copy.)
+- **Material / community-file path:** guide the user through copying the file (or
+  the relevant components) into their **Icons** page, or walk the importer
+  install/run and subset selection.
+- **Custom SVGs:** batch-import and componentize them.
 
 This is a Figma-authoring step — sequential, with the user in the loop; no
-subagents.
+subagents. When scripting the SVG-to-component pass, follow
+`${CLAUDE_PLUGIN_ROOT}/references/figma-scripting.md`.
 
 ## Step 3 — Normalize: page, naming, sizing, variants
 
@@ -190,8 +235,12 @@ icons; the sync layer handles custom-icon code and version-drift checks).
 
 ## What this skill must NOT do
 
-- Never hand-generate the full icon set via the write mechanism when a community
-  file or importer plugin can do it far cheaper.
+- Never **hand-draw** icons or generate them one-by-one. (Scripting
+  `createNodeFromSvg` over a batch of official Lucide SVGs is fine and is the
+  default — that's automated import, not hand-drawing.)
 - Never import 1,700 icons by default — curate to what's needed.
-- Never grab an unnamed/unvetted resource silently — name it, surface the
-  license, let the user verify.
+- Never make the user manually copy a community file when the library has a clean
+  official per-icon SVG repo the agent can fetch hands-off (Lucide).
+- Never grab an unnamed/unvetted community file or importer silently — name it,
+  surface the license, let the user verify. (The Lucide official-repo fetch is
+  exempt — it's the library's own source.)

--- a/skills/token-builder/SKILL.md
+++ b/skills/token-builder/SKILL.md
@@ -198,7 +198,14 @@ its primitive so the alias is live. Default set and modes:
   a different *mapping*, not just a different palette). Roles: `bg/{default,
   subtle,muted,emphasis,inverse}`, `text/{primary,secondary,disabled,inverse,
   link,onEmphasis}`, `border/{default,subtle,focus,emphasis}`,
-  `status/{success,warning,danger}/{bg,text,border}`. **`text/onEmphasis`** is the
+  `status/{success,warning,danger}/{bg,text,border}`,
+  `shadow/{ambient,key}`. The **`shadow/*`** roles are the colors the elevation
+  effect styles consume (Step 4) — they carry alpha and are **mode-aware**: a
+  low-alpha near-black in Light, and a darker/higher-alpha value in Dark, so
+  toggling modes recolors every elevation. They live here in `Color/Semantic`
+  (rather than as part of the effect style) precisely so the Light/Dark switch
+  reaches them; alias a near-black primitive where the alpha allows, otherwise
+  set the rgba per mode directly. **`text/onEmphasis`** is the
   label/icon color that sits **on** `bg/emphasis` (a primary button's text, a
   filled badge) — it must contrast with the emphasis fill in *every* mode, so it's
   a distinct role, **not** `text/inverse` (which flips with the theme and won't
@@ -266,8 +273,17 @@ they can **bind to the tokens you just built** rather than duplicating values:
   primitive updates the text styles. A type scale is NOT just variables — these
   composed text styles are what designers actually apply to text layers.
 - **Effect styles** — drop shadows and elevation levels (e.g. `Elevation/1`
-  through `Elevation/5`). These can't be variables; create them as effect
-  styles, driven by the shadow scale from the brainstorm.
+  through `Elevation/5`), driven by the shadow scale from the brainstorm. The
+  *composition* (offset, blur, spread) is what makes this a style rather than a
+  variable — but the shadow **color must be bound to the `shadow/*`
+  `Color/Semantic` variables**, never hardcoded. Figma supports binding the color
+  of a drop shadow inside an effect style to a color variable; do that for every
+  shadow in every elevation level. This is what makes elevations **mode-aware**:
+  because the bound `shadow/*` variable carries different values per mode, toggling
+  Light/Dark recolors all elevations automatically. A style with a literal shadow
+  color is the bug — it stays the same color in dark mode. (Heavier elevations may
+  layer two shadows, e.g. an ambient + a key shadow; bind each to `shadow/ambient`
+  and `shadow/key` respectively.)
 - **Grid styles** — layout grids if the user wants them (column/row grids for
   their breakpoints). Optional; only if requested.
 

--- a/skills/token-sheet-builder/SKILL.md
+++ b/skills/token-sheet-builder/SKILL.md
@@ -114,12 +114,41 @@ stays legible — no invisible titles, no stranded backgrounds. Then clear the
 explicit mode to restore the default. If anything breaks, the culprit is a fill
 that isn't bound to a semantic variable — bind it and re-check.
 
+## Step 2.5 — Build the Cover page
+
+Now that tokens and styles exist, build the file's first impression: a branded
+**Cover** page. (Environment setup deliberately skips this — there was nothing
+on-brand to build it from yet. If `figma.coverPageBuilt` is already `true`, just
+refresh the "Last updated" date instead of creating a second Cover.)
+
+- Find the file's first page. If it's the default empty "Page 1" (no meaningful
+  content), **rename it to `Cover`** and use it. If it has content, create a new
+  page named `Cover` and move it to the **top** of the page list. Don't clobber a
+  page the user has already worked in.
+- On that page, build one clean **Cover** frame with:
+  - the design system name (`workspace.name`),
+  - the author/owner name (ask once if you don't have it, or use the file owner),
+  - "Last updated" with the current date,
+  - a tasteful branded graphic — a bold wordmark, a few shapes, generous spacing,
+    not an elaborate illustration.
+- **Bind everything to the system you just documented** — text to text styles,
+  fills to `Color/Semantic` variables (page background → `bg/default`, etc.) — so
+  the Cover survives a mode switch exactly like the Foundations page. This is the
+  whole reason it's built here and not at setup. Validate both modes the same way.
+- Use proper **vertical auto layout** and place content inside the frame (no
+  floating, no overlapping text) per
+  `${CLAUDE_PLUGIN_ROOT}/references/figma-component-standards.md`.
+- **Setting it as the file thumbnail is a manual step** — the plugin API can't do
+  it. Tell the user plainly: "To make this the file's cover image, right-click the
+  Cover frame and choose **Set as thumbnail**." Offer it; don't block on it.
+- Record `figma.coverPageBuilt` = `true`.
+
 ## Step 3 — Checkpoint
 
-Show the user the Foundations page. Sequential review (this is a Figma-authoring
-skill — no subagents). Iterate on layout/styling if they want changes. Then
-update the manifest: `sheets.built` = `true`, append `token-sheet-builder` to
-`completedSkills`.
+Show the user the Foundations page and the Cover page. Sequential review (this is
+a Figma-authoring skill — no subagents). Iterate on layout/styling if they want
+changes. Then update the manifest: `sheets.built` = `true`, append
+`token-sheet-builder` to `completedSkills`.
 
 ## Step 4 — Hand off
 


### PR DESCRIPTION
## v0.9.0

### Added
- **`/throughline:start`** — a deterministic entry-point command that routes straight into `figma-environment-setup`, bypassing natural-language skill competition. Fixes cases where another installed plugin (e.g. superpowers' `brainstorming`) intercepted "let's build my design system"–style phrases and ran ahead of environment setup. README now leads with it.

### Changed
- **Lucide icons fetched from the official source repo.** Previously defaulted to duplicating a community Figma file — cheap in tokens but it pushed manual work onto the user. Lucide now batch-fetches the curated subset from `raw.githubusercontent.com/lucide-icons/lucide/<tag>/icons/<name>.svg` and componentizes via `figma.createNodeFromSvg` in one scripted pass: fully automated, official source-of-truth, deterministic naming, and a 404 doubles as the name-validation check. Community file / importer are now fallbacks. Material (variant axes) and custom SVGs unchanged.

### Fixed
- **Cover page no longer built before tokens/styles exist.** Setup used to build the branded Cover during environment setup, before any tokens existed, so it could never be on-brand. Setup now does a throwaway write test only; the real, fully token-bound Cover is built by `token-sheet-builder` alongside Foundations. `figma.coverPageBuilt` is now owned by `token-sheet-builder`.
- **Elevations are now dark-mode-aware.** Effect styles baked in a literal shadow color, so toggling Light/Dark never recolored shadows. Shadow color now lives in mode-aware `shadow/*` semantic variables that the effect styles bind to; only offset/blur/spread stays in the style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)