### PR TITLE
Brownfield retrofit (Plans 1–3) + plugin CI follow-on

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Run test suite
+        run: node --test
+      - name: Validate plugin manifests
+        run: node ci/validate-plugin.mjs
+      - name: Validate skill/command frontmatter
+        run: node ci/validate-skills.mjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,14 @@ to [Semantic Versioning](https://semver.org).
   added to `references/figma-scripting.md`.
 - **`/design-system-status` + `/start`** now surface the `audit`, `tokenCrosswalk`, and
   `retrofit` state and route brownfield/in-progress systems to the right next step.
+- **Plugin CI (first GitHub Actions workflow).** `.github/workflows/ci.yml` runs
+  on every pull request and on pushes to `main`: the full `node --test` suite
+  plus two zero-dependency structural validators in `ci/` — `validate-plugin.mjs`
+  (plugin.json / marketplace.json: valid JSON, required fields, semver, name
+  match) and `validate-skills.mjs` (every SKILL.md `name` matches its directory
+  and has a ≤1024-char description; every command has a description; the
+  manifest-doc example JSON parses with an integer `schemaVersion`). Closes the
+  "no plugin CI" carry-forward from the brownfield retrofit effort.
 
 ### Fixed
 - **Read discipline: never report "empty" without a verified read (bugs B1/B2).**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,25 @@ to [Semantic Versioning](https://semver.org).
 - **`token-crosswalk-builder` skill** — builds the new-token ↔ old-Figma ↔ old-code
   crosswalk, installs the vetted scripts into `packages/tokens/`, wires
   `tokens:validate`, and owns the `tokenCrosswalk` manifest section.
+- **Brownfield retrofit skills (Plan 3 of 3).** Completes the brownfield path end to end.
+  - **`design-system-audit` skill** — the brownfield front door: sizes the code-side
+    color surface (via the new color-usage grep), inventories the Figma file with verified
+    per-class reads, computes `percentSemantic`, and owns the `audit` manifest section
+    (sets `tokens.intakeMode: "retrofit"`).
+  - **`retrofit-planner` skill** — the orchestrator: sequences the safe 7-phase retrofit
+    (audit → refine → rebind → sync → baseline → code → cleanup) with a human gate per
+    phase, offers a decision journal default-on, and owns the `retrofit` manifest section.
+  - **`scripts/grep-color-usage.mjs`** — the repo-shaped color-usage grep scaffold
+    (ships default patterns, logs assumed-vs-detected coverage).
+- **Brownfield branches in existing skills.** `figma-environment-setup` gains brownfield
+  detection + routing to the audit, retrofit resume, and a pre-mutation rollback baseline;
+  `token-builder` gains refine-in-place (rename preserving IDs, binding-survival audit);
+  `token-sync-layer` gains the brownfield transforms (channel alpha, float32 rounding at
+  the export boundary, `/opacity`→`color-mix`); `storybook-chromatic-builder` gains
+  baseline-before-retrofit + the verification triad. The binding-survival audit snippet is
+  added to `references/figma-scripting.md`.
+- **`/design-system-status` + `/start`** now surface the `audit`, `tokenCrosswalk`, and
+  `retrofit` state and route brownfield/in-progress systems to the right next step.
 
 ### Fixed
 - **Read discipline: never report "empty" without a verified read (bugs B1/B2).**
@@ -48,6 +67,11 @@ to [Semantic Versioning](https://semver.org).
   B4).** `references/figma-scripting.md` now distinguishes *live* from *stale*
   Desktop Bridge instances, blocks only on two or more confirmed-live instances,
   and gives actionable remediation instead of a bare "close the other instance."
+- **Publish-state detection is now behavioral, not assumed (bug B3).** `component-builder`
+  and `references/figma-publishing.md` treat a default/`false` `figma.libraryPublished` as
+  *unverified*: they detect first (`figma_get_library_components` /
+  `figma_get_library_variables`), ask once only if inconclusive, persist the answer, and
+  frame the unpublished path as a graceful choice. No new manifest field.
 
 ## [0.9.0] - 2026-06-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Added
+- **Brownfield retrofit foundation (Plan 1 of 3).** Groundwork for retrofitting a
+  design system onto a mature codebase *and* an already-populated Figma file,
+  drawn from a production Next.js retrofit case study. Design spec and plan live
+  under `docs/superpowers/`.
+- **`references/brownfield-retrofit.md`** — canonical reference for the
+  retrofit read-discipline principle, the 7 "DON'T" guardrails, the safe retrofit
+  sequence, and the verification triad.
+- **Manifest schemaVersion 4** — adds three new sections (`audit`,
+  `tokenCrosswalk`, `retrofit`) consumed by the forthcoming brownfield skills, a
+  `"retrofit"` value for `tokens.intakeMode`, and clarified publish-state field
+  docs (`figma.libraryPublished` default `false` now means *unverified*, not
+  "definitely not published"). Additive only; existing manifests migrate forward.
+
+### Fixed
+- **Read discipline: never report "empty" without a verified read (bugs B1/B2).**
+  `figma-environment-setup`'s Step 6 liveness check now proves *connectivity only*
+  and never reports an inventory ("0 variables" / "no text styles") off a cheap or
+  early read that can be falsely empty before pages load. `references/figma-scripting.md`
+  gains a read-discipline section directing per-class reads
+  (`figma_get_variables` / `figma_get_text_styles` / `figma_get_styles`) after
+  `loadAllPagesAsync`. *(Behavioral fixes in the consuming brownfield skills land
+  in later plans.)*
+- **Bridge-instance preflight no longer hard-blocks on phantom/stale ports (bug
+  B4).** `references/figma-scripting.md` now distinguishes *live* from *stale*
+  Desktop Bridge instances, blocks only on two or more confirmed-live instances,
+  and gives actionable remediation instead of a bare "close the other instance."
+
 ## [0.9.0] - 2026-06-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,21 @@ to [Semantic Versioning](https://semver.org).
   `"retrofit"` value for `tokens.intakeMode`, and clarified publish-state field
   docs (`figma.libraryPublished` default `false` now means *unverified*, not
   "definitely not published"). Additive only; existing manifests migrate forward.
+- **`scripts/` directory** — the plugin's first executable code: canonical,
+  zero-dependency Node (ESM) scripts for brownfield retrofits, tested with
+  `node --test`.
+  - `validate-crosswalk.mjs` — the `tokens:validate` CI gate (resolved value ==
+    new value, N/N).
+  - `build-reverse-index.mjs` — code symbol → new token map for semi-automated
+    SCSS/Tailwind swaps.
+  - `guard-token-removal.mjs` — repo-wide zero-reference grep that blocks cleanup
+    while any reference to an about-to-be-deleted symbol remains.
+  - `lib/crosswalk.mjs` — shared loader + structural validation.
+- **`crosswalk.json` schema** — finalized contract: `references/crosswalk-schema.md`
+  (prose) + `scripts/crosswalk.schema.json` (JSON Schema).
+- **`token-crosswalk-builder` skill** — builds the new-token ↔ old-Figma ↔ old-code
+  crosswalk, installs the vetted scripts into `packages/tokens/`, wires
+  `tokens:validate`, and owns the `tokenCrosswalk` manifest section.
 
 ### Fixed
 - **Read discipline: never report "empty" without a verified read (bugs B1/B2).**

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **A Claude Code plugin packed with every skill you need to launch and manage a production-grade design system in hours — not months.**
 
-[![Version](https://img.shields.io/badge/version-0.5.0-6366f1)](.claude-plugin/plugin.json)
+[![Version](https://img.shields.io/badge/version-0.9.0-6366f1)](.claude-plugin/plugin.json)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Built for Claude Code](https://img.shields.io/badge/built%20for-Claude%20Code-d97757)](https://docs.claude.com/en/docs/claude-code)
 [![See it live — Storybook](https://img.shields.io/badge/See%20it%20live-Storybook-FF4785?logo=storybook&logoColor=white)](https://main--6a1ee089ae3a37b70a6e4559.chromatic.com)
@@ -43,6 +43,16 @@ Whether you're starting from scratch or retrofitting an existing design system, 
 
 1. **`/sync-figma-tokens`** — resync changes from Figma to code, landed as a reviewable PR.
 2. **`/new-component`** — ship a new component in Figma, then sync and publish it to code.
+
+## Already have a design system? Retrofit it.
+
+Most teams aren't starting from a blank file — they have a mature codebase with hundreds of hard-coded colors and a Figma file that's drifted from it over the years. ThroughLine treats that as a first-class path, not an afterthought, and it moves *carefully*: it never asserts what's in your files without reading them first, and it never deletes an old token until it's proven nothing still uses it.
+
+1. **Audit before anything changes.** `design-system-audit` sizes both sides of your system — it greps your codebase to measure the real color surface and inventories your Figma file with verified, per-class reads — then tells you how big the migration actually is and how semantic your system already is.
+2. **A crosswalk that guarantees nothing shifts.** `token-crosswalk-builder` maps every new token to its old Figma variable and old code value, then installs a `tokens:validate` gate that fails unless every resolved new value matches the old one (N/N). A zero-reference guard blocks removing an old token while any code still references it.
+3. **A gated, reversible migration.** `retrofit-planner` walks the safe seven-phase sequence — audit → refine variables in place → rebind → sync → capture a visual baseline → retrofit the code → remove the old tokens — pausing for your confirmation between every phase, with an optional decision journal recording each call.
+
+The payoff: your live product looks identical at every step, and you can prove it with a Chromatic baseline captured before the first change.
 
 ## See a real end-to-end system built with it
 
@@ -84,7 +94,7 @@ Then start with:
 
 This is the reliable entry point — it runs environment setup first, ahead of anything else. (You can also just say *"let's set up my design system"*, but if you have other plugins installed that grab "let's build…" style phrases, the slash command guarantees ThroughLine takes the wheel.)
 
-From there, Claude walks you through executing its **9 skills powered by 7 reference documents**, sequenced based on your unique needs and goals. The plugin is built to provide consistent checkpoints for human review and guidance — letting you make the big decisions while it does the dirty work.
+From there, Claude walks you through executing its **12 skills powered by 10 reference documents**, sequenced based on your unique needs and goals. The plugin is built to provide consistent checkpoints for human review and guidance — letting you make the big decisions while it does the dirty work.
 
 Update anytime with:
 
@@ -96,9 +106,9 @@ Update anytime with:
 
 ThroughLine is more than a pile of skills — it's a small system designed to stay consistent across dozens of generation steps. Four layers work together:
 
-**🛠 Nine skills — the steps.** Each owns one stage of the journey, from connecting Figma to standing up CI. They're sequenced, and each knows its prerequisites.
+**🛠 Twelve skills — the steps.** Each owns one stage of the journey, from connecting Figma to retrofitting an existing system to standing up CI. They're sequenced, and each knows its prerequisites.
 
-**📐 Seven reference docs — the constitution.** Shared standards every skill obeys: Figma component rules (auto-layout-on-everything, slot contracts, naming-as-contract, a required post-build audit), the brainstorm-before-build protocol, the sync-adapter specs, the manifest schema, coding-level adaptivity, and the publishing flow. This is *why* two different runs produce the same structure — the rules live in one place, not scattered per skill.
+**📐 Ten reference docs — the constitution.** Shared standards every skill obeys: Figma component rules (auto-layout-on-everything, slot contracts, naming-as-contract, a required post-build audit), the brainstorm-before-build protocol, the sync-adapter specs, the manifest schema, coding-level adaptivity, the publishing flow, and the brownfield-retrofit discipline (read-before-assert, the safe migration sequence, the crosswalk contract). This is *why* two different runs produce the same structure — the rules live in one place, not scattered per skill.
 
 **🧭 An orchestration layer — the memory.** A `design-system.json` manifest in your project records exactly what's set up, with a versioned schema and immutability rules. Every skill reads it, tells you what it's about to do, and offers to run anything missing first. Run **`/design-system-status`** anytime for a plain-language picture of where you stand.
 
@@ -109,14 +119,17 @@ ThroughLine is more than a pile of skills — it's a small system designed to st
 | Skill | What it does |
 |---|---|
 | **figma-environment-setup** | Create your working folder, connect Claude to Figma, scan what already exists. **Start here.** |
+| **design-system-audit** | Measure an existing system *before* retrofitting — size the code-side color surface and inventory the Figma file with verified reads. The brownfield front door. |
 | **token-builder** | A two-tier (primitive + semantic) token system as Figma variables, plus text/effect styles. Generative, descriptive, or import-your-own. |
 | **token-sheet-builder** | A beautiful, on-brand **Foundations** page visualizing every token, live-bound to the variables. |
 | **icon-system-builder** | An **Icons** page with your chosen library (Lucide, Material, or custom) as clean components — the cheap, fast way. |
 | **component-builder** | Your foundational components (button, input, card, modal…) with full variant matrices, slots, and token bindings. |
 | **repository-builder** | Graduate your folder into a pnpm + Turborepo monorepo — folder → local git → GitHub, one gentle step at a time. |
 | **token-sync-layer** | Sync Figma variables to framework-specific code via Style Dictionary, landed as a reviewable PR. Installs `/sync-figma-tokens`. |
+| **token-crosswalk-builder** | Map new tokens to their old Figma variables and old code values, and install the `tokens:validate` gate that proves no value changed during a retrofit. |
 | **storybook-chromatic-builder** | Storybook, component stories, Chromatic visual testing, and Code Connect (where your Figma plan supports it). |
 | **component-pipeline** | Add one new component end to end: Figma → tokens → code + stories. Installs `/new-component`. |
+| **retrofit-planner** | Orchestrate a full retrofit through the safe, gated seven-phase sequence — with a human checkpoint at every phase. |
 
 ## The nitty gritty
 
@@ -170,6 +183,7 @@ ThroughLine is open source and contributions are welcome. Found a bug or have an
 A couple of ground rules:
 - **Figma is the source of truth.** Generated code files are build artifacts — never hand-edited; change things in Figma and re-sync.
 - **Secrets stay yours.** Tokens and keys are never sent through chat or committed to code.
+- **The plugin validates itself.** Every PR runs CI (`.github/workflows/ci.yml`) — the full test suite plus zero-dependency structural validators that check `plugin.json`, the marketplace manifest, and every skill/command's frontmatter. Run them locally with `node --test` and `node ci/validate-plugin.mjs` / `node ci/validate-skills.mjs`.
 
 ## Roadmap
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,26 @@
+# `ci/` — plugin self-validation
+
+Plugin-internal validators run by GitHub Actions (`.github/workflows/ci.yml`).
+**Not** copied into user repos — unlike `scripts/`, these guard *this plugin's*
+own structure. Zero dependencies; stdlib only.
+
+## What runs in CI
+
+1. `node --test` — the full test suite (these validators' logic tests + the
+   `scripts/` suite). Run with **bare `node --test` from the repo root**, never
+   `node --test ci/` (pathed invocation errors on Node ≥21).
+2. `node ci/validate-plugin.mjs` — `.claude-plugin/plugin.json` and
+   `marketplace.json`: valid JSON, required fields, semver version, and that a
+   marketplace entry's `name` matches `plugin.json`.
+3. `node ci/validate-skills.mjs` — every `skills/*/SKILL.md` has `name`
+   (matching its directory) and a `description` (≤ 1024 chars); every
+   `commands/*.md` has a `description`; and the `references/manifest-schema.md`
+   example JSON parses with an integer `schemaVersion`.
+
+## Run locally
+
+```bash
+node --test                  # all tests
+node ci/validate-plugin.mjs  # guard plugin manifests
+node ci/validate-skills.mjs  # guard skill/command/manifest-doc structure
+```

--- a/ci/lib/frontmatter.mjs
+++ b/ci/lib/frontmatter.mjs
@@ -1,0 +1,51 @@
+// Minimal, zero-dependency parser for the simple single-line `key: value`
+// frontmatter used by the plugin's SKILL.md and command files. Values may be
+// wrapped in matching single or double quotes. Splits each line on the FIRST
+// colon, so colons inside a value are preserved.
+//
+// This is intentionally NOT a full YAML parser: no nested maps, lists, or
+// multi-line scalars. The current corpus has none; if a future file needs
+// richer frontmatter, this throws (a missing/malformed fence) rather than
+// silently mis-parsing.
+
+export function parseFrontmatter(text) {
+  const lines = text.split('\n');
+  if (lines[0].trim() !== '---') {
+    throw new Error('missing opening --- frontmatter fence');
+  }
+  let end = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === '---') {
+      end = i;
+      break;
+    }
+  }
+  if (end === -1) {
+    throw new Error('missing closing --- frontmatter fence');
+  }
+  const data = {};
+  for (let i = 1; i < end; i++) {
+    const line = lines[i];
+    if (line.trim() === '') continue;
+    const colon = line.indexOf(':');
+    if (colon === -1) {
+      throw new Error(`malformed frontmatter line (no colon): ${line}`);
+    }
+    const key = line.slice(0, colon).trim();
+    const value = stripQuotes(line.slice(colon + 1).trim());
+    data[key] = value;
+  }
+  const body = lines.slice(end + 1).join('\n');
+  return { data, body };
+}
+
+function stripQuotes(s) {
+  if (
+    s.length >= 2 &&
+    ((s[0] === '"' && s[s.length - 1] === '"') ||
+      (s[0] === "'" && s[s.length - 1] === "'"))
+  ) {
+    return s.slice(1, -1);
+  }
+  return s;
+}

--- a/ci/lib/frontmatter.mjs
+++ b/ci/lib/frontmatter.mjs
@@ -40,11 +40,7 @@ export function parseFrontmatter(text) {
 }
 
 function stripQuotes(s) {
-  if (
-    s.length >= 2 &&
-    ((s[0] === '"' && s[s.length - 1] === '"') ||
-      (s[0] === "'" && s[s.length - 1] === "'"))
-  ) {
+  if (/^"[^"]*"$/.test(s) || /^'[^']*'$/.test(s)) {
     return s.slice(1, -1);
   }
   return s;

--- a/ci/lib/frontmatter.test.mjs
+++ b/ci/lib/frontmatter.test.mjs
@@ -25,6 +25,11 @@ test('preserves colons inside a value (splits on first colon only)', () => {
   assert.equal(data.description, 'IMPORTANT: do the thing');
 });
 
+test('leaves a value with interior quotes untouched (not fully wrapped)', () => {
+  const { data } = parseFrontmatter('---\ndescription: "a" or "b"\n---\n');
+  assert.equal(data.description, '"a" or "b"');
+});
+
 test('throws when the opening fence is missing', () => {
   assert.throws(() => parseFrontmatter('name: foo\n---\n'), /opening/);
 });

--- a/ci/lib/frontmatter.test.mjs
+++ b/ci/lib/frontmatter.test.mjs
@@ -1,0 +1,34 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseFrontmatter } from './frontmatter.mjs';
+
+test('parses name and description into data, returns body', () => {
+  const text = '---\nname: foo\ndescription: a thing\n---\n# Heading\nbody text\n';
+  const { data, body } = parseFrontmatter(text);
+  assert.equal(data.name, 'foo');
+  assert.equal(data.description, 'a thing');
+  assert.equal(body, '# Heading\nbody text\n');
+});
+
+test('strips wrapping double quotes from a value', () => {
+  const { data } = parseFrontmatter('---\ndescription: "quoted value"\n---\n');
+  assert.equal(data.description, 'quoted value');
+});
+
+test('strips wrapping single quotes from a value', () => {
+  const { data } = parseFrontmatter("---\ndescription: 'quoted value'\n---\n");
+  assert.equal(data.description, 'quoted value');
+});
+
+test('preserves colons inside a value (splits on first colon only)', () => {
+  const { data } = parseFrontmatter('---\ndescription: IMPORTANT: do the thing\n---\n');
+  assert.equal(data.description, 'IMPORTANT: do the thing');
+});
+
+test('throws when the opening fence is missing', () => {
+  assert.throws(() => parseFrontmatter('name: foo\n---\n'), /opening/);
+});
+
+test('throws when the closing fence is missing', () => {
+  assert.throws(() => parseFrontmatter('---\nname: foo\n'), /closing/);
+});

--- a/ci/validate-plugin.mjs
+++ b/ci/validate-plugin.mjs
@@ -1,0 +1,90 @@
+// Validates the plugin's two manifest files. Pure function + CLI.
+// Run from anywhere: paths resolve relative to this file (repo root is `..`).
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const SEMVER = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+
+export function validatePlugin({ plugin, marketplace }) {
+  const problems = [];
+
+  // plugin.json
+  if (!isNonEmptyString(plugin.name)) {
+    problems.push('plugin.json: "name" must be a non-empty string');
+  }
+  if (!isNonEmptyString(plugin.description)) {
+    problems.push('plugin.json: "description" must be a non-empty string');
+  }
+  if (!isNonEmptyString(plugin.version)) {
+    problems.push('plugin.json: "version" must be a non-empty string');
+  } else if (!SEMVER.test(plugin.version)) {
+    problems.push(`plugin.json: "version" is not valid semver: ${plugin.version}`);
+  }
+  if (plugin.author === undefined || plugin.author === null) {
+    problems.push('plugin.json: "author" is required');
+  }
+  if (plugin.keywords !== undefined) {
+    if (!Array.isArray(plugin.keywords) || !plugin.keywords.every(isNonEmptyString)) {
+      problems.push('plugin.json: "keywords" must be an array of non-empty strings');
+    }
+  }
+
+  // marketplace.json
+  if (!isNonEmptyString(marketplace.name)) {
+    problems.push('marketplace.json: "name" must be a non-empty string');
+  }
+  if (marketplace.owner === undefined || marketplace.owner === null) {
+    problems.push('marketplace.json: "owner" is required');
+  }
+  if (!Array.isArray(marketplace.plugins) || marketplace.plugins.length === 0) {
+    problems.push('marketplace.json: "plugins" must be a non-empty array');
+  } else {
+    marketplace.plugins.forEach((p, i) => {
+      if (!isNonEmptyString(p.name)) problems.push(`marketplace.json: plugins[${i}].name must be a non-empty string`);
+      if (!isNonEmptyString(p.source)) problems.push(`marketplace.json: plugins[${i}].source must be a non-empty string`);
+      if (!isNonEmptyString(p.description)) problems.push(`marketplace.json: plugins[${i}].description must be a non-empty string`);
+    });
+    if (isNonEmptyString(plugin.name) && !marketplace.plugins.some((p) => p.name === plugin.name)) {
+      problems.push(`marketplace.json: no plugin entry has name "${plugin.name}" (must match plugin.json)`);
+    }
+  }
+
+  return problems;
+}
+
+function isNonEmptyString(v) {
+  return typeof v === 'string' && v.trim().length > 0;
+}
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+function readJson(path) {
+  try {
+    return { value: JSON.parse(readFileSync(path, 'utf8')) };
+  } catch (err) {
+    return { error: `${path}: ${err.message}` };
+  }
+}
+
+function main() {
+  const p = readJson(join(REPO_ROOT, '.claude-plugin', 'plugin.json'));
+  const m = readJson(join(REPO_ROOT, '.claude-plugin', 'marketplace.json'));
+  const problems = [];
+  if (p.error) problems.push(p.error);
+  if (m.error) problems.push(m.error);
+  if (!p.error && !m.error) {
+    problems.push(...validatePlugin({ plugin: p.value, marketplace: m.value }));
+  }
+  if (problems.length === 0) {
+    console.log('✓ plugin.json + marketplace.json OK');
+    return;
+  }
+  console.error(`✗ ${problems.length} problem(s):`);
+  for (const pr of problems) console.error(`  ${pr}`);
+  process.exit(1);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/ci/validate-plugin.mjs
+++ b/ci/validate-plugin.mjs
@@ -41,11 +41,15 @@ export function validatePlugin({ plugin, marketplace }) {
     problems.push('marketplace.json: "plugins" must be a non-empty array');
   } else {
     marketplace.plugins.forEach((p, i) => {
+      if (p === null || typeof p !== 'object') {
+        problems.push(`marketplace.json: plugins[${i}] must be an object`);
+        return;
+      }
       if (!isNonEmptyString(p.name)) problems.push(`marketplace.json: plugins[${i}].name must be a non-empty string`);
       if (!isNonEmptyString(p.source)) problems.push(`marketplace.json: plugins[${i}].source must be a non-empty string`);
       if (!isNonEmptyString(p.description)) problems.push(`marketplace.json: plugins[${i}].description must be a non-empty string`);
     });
-    if (isNonEmptyString(plugin.name) && !marketplace.plugins.some((p) => p.name === plugin.name)) {
+    if (isNonEmptyString(plugin.name) && !marketplace.plugins.some((p) => p !== null && typeof p === 'object' && p.name === plugin.name)) {
       problems.push(`marketplace.json: no plugin entry has name "${plugin.name}" (must match plugin.json)`);
     }
   }

--- a/ci/validate-plugin.test.mjs
+++ b/ci/validate-plugin.test.mjs
@@ -1,0 +1,56 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { validatePlugin } from './validate-plugin.mjs';
+
+const validPlugin = {
+  name: 'throughline',
+  description: 'a design system plugin',
+  version: '0.9.0',
+  author: { name: 'Jordan Pease' },
+  keywords: ['figma', 'tokens'],
+};
+
+const validMarketplace = {
+  name: 'throughline-marketplace',
+  owner: { name: 'Jordan Pease' },
+  plugins: [
+    { name: 'throughline', source: './', description: 'build a design system' },
+  ],
+};
+
+test('valid manifests produce no problems', () => {
+  const problems = validatePlugin({ plugin: validPlugin, marketplace: validMarketplace });
+  assert.deepEqual(problems, []);
+});
+
+test('flags a missing plugin name', () => {
+  const problems = validatePlugin({ plugin: { ...validPlugin, name: '' }, marketplace: validMarketplace });
+  assert.ok(problems.some((p) => /plugin\.json.*name/.test(p)));
+});
+
+test('flags an invalid semver version', () => {
+  const problems = validatePlugin({ plugin: { ...validPlugin, version: 'v1' }, marketplace: validMarketplace });
+  assert.ok(problems.some((p) => /version.*semver/.test(p)));
+});
+
+test('flags keywords that are not an array of strings', () => {
+  const problems = validatePlugin({ plugin: { ...validPlugin, keywords: 'figma' }, marketplace: validMarketplace });
+  assert.ok(problems.some((p) => /keywords/.test(p)));
+});
+
+test('flags an empty plugins array in the marketplace', () => {
+  const problems = validatePlugin({ plugin: validPlugin, marketplace: { ...validMarketplace, plugins: [] } });
+  assert.ok(problems.some((p) => /plugins.*non-empty array/.test(p)));
+});
+
+test('flags a marketplace plugin entry missing a source', () => {
+  const bad = { ...validMarketplace, plugins: [{ name: 'throughline', description: 'x' }] };
+  const problems = validatePlugin({ plugin: validPlugin, marketplace: bad });
+  assert.ok(problems.some((p) => /plugins\[0\]\.source/.test(p)));
+});
+
+test('flags when no marketplace entry name matches plugin.json name', () => {
+  const bad = { ...validMarketplace, plugins: [{ name: 'other', source: './', description: 'x' }] };
+  const problems = validatePlugin({ plugin: validPlugin, marketplace: bad });
+  assert.ok(problems.some((p) => /must match plugin\.json/.test(p)));
+});

--- a/ci/validate-plugin.test.mjs
+++ b/ci/validate-plugin.test.mjs
@@ -54,3 +54,15 @@ test('flags when no marketplace entry name matches plugin.json name', () => {
   const problems = validatePlugin({ plugin: validPlugin, marketplace: bad });
   assert.ok(problems.some((p) => /must match plugin\.json/.test(p)));
 });
+
+test('flags a non-object plugins entry instead of crashing', () => {
+  const bad = { ...validMarketplace, plugins: [null] };
+  const problems = validatePlugin({ plugin: validPlugin, marketplace: bad });
+  assert.ok(problems.some((p) => /plugins\[0\] must be an object/.test(p)));
+});
+
+test('flags a missing author', () => {
+  const { author, ...noAuthor } = validPlugin;
+  const problems = validatePlugin({ plugin: noAuthor, marketplace: validMarketplace });
+  assert.ok(problems.some((p) => /"author" is required/.test(p)));
+});

--- a/ci/validate-skills.mjs
+++ b/ci/validate-skills.mjs
@@ -1,0 +1,101 @@
+// Validates skill frontmatter (skills/*/SKILL.md), command frontmatter
+// (commands/*.md), and the manifest doc's example JSON. Pure functions + CLI.
+import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { parseFrontmatter } from './lib/frontmatter.mjs';
+
+export const MAX_DESCRIPTION = 1024;
+
+export function validateSkill({ dirName, source }) {
+  let data;
+  try {
+    ({ data } = parseFrontmatter(source));
+  } catch (err) {
+    return [`skills/${dirName}/SKILL.md: ${err.message}`];
+  }
+  const problems = [];
+  if (!isNonEmptyString(data.name)) {
+    problems.push(`skills/${dirName}/SKILL.md: "name" is required`);
+  } else if (data.name !== dirName) {
+    problems.push(`skills/${dirName}/SKILL.md: "name" (${data.name}) must equal the directory name (${dirName})`);
+  }
+  if (!isNonEmptyString(data.description)) {
+    problems.push(`skills/${dirName}/SKILL.md: "description" is required`);
+  } else if (data.description.length > MAX_DESCRIPTION) {
+    problems.push(`skills/${dirName}/SKILL.md: "description" is ${data.description.length} chars (max ${MAX_DESCRIPTION})`);
+  }
+  return problems;
+}
+
+export function validateCommand({ fileName, source }) {
+  let data;
+  try {
+    ({ data } = parseFrontmatter(source));
+  } catch (err) {
+    return [`commands/${fileName}: ${err.message}`];
+  }
+  const problems = [];
+  if (!isNonEmptyString(data.description)) {
+    problems.push(`commands/${fileName}: "description" is required`);
+  }
+  return problems;
+}
+
+export function validateManifestDoc(source) {
+  const match = source.match(/```json\n([\s\S]*?)\n```/);
+  if (!match) {
+    return ['references/manifest-schema.md: no ```json example block found'];
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(match[1]);
+  } catch (err) {
+    return [`references/manifest-schema.md: example JSON does not parse: ${err.message}`];
+  }
+  if (!Number.isInteger(parsed.schemaVersion)) {
+    return ['references/manifest-schema.md: example "schemaVersion" must be an integer'];
+  }
+  return [];
+}
+
+function isNonEmptyString(v) {
+  return typeof v === 'string' && v.trim().length > 0;
+}
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+function main() {
+  const problems = [];
+
+  const skillsDir = join(REPO_ROOT, 'skills');
+  const skillDirs = readdirSync(skillsDir).filter((d) => statSync(join(skillsDir, d)).isDirectory());
+  for (const dirName of skillDirs) {
+    const skillPath = join(skillsDir, dirName, 'SKILL.md');
+    if (!existsSync(skillPath)) {
+      problems.push(`skills/${dirName}: missing SKILL.md`);
+      continue;
+    }
+    problems.push(...validateSkill({ dirName, source: readFileSync(skillPath, 'utf8') }));
+  }
+
+  const commandsDir = join(REPO_ROOT, 'commands');
+  const commandFiles = readdirSync(commandsDir).filter((f) => f.endsWith('.md'));
+  for (const fileName of commandFiles) {
+    problems.push(...validateCommand({ fileName, source: readFileSync(join(commandsDir, fileName), 'utf8') }));
+  }
+
+  problems.push(...validateManifestDoc(readFileSync(join(REPO_ROOT, 'references', 'manifest-schema.md'), 'utf8')));
+
+  if (problems.length === 0) {
+    console.log(`✓ ${skillDirs.length} skills, ${commandFiles.length} commands, manifest doc OK`);
+    return;
+  }
+  console.error(`✗ ${problems.length} problem(s):`);
+  for (const pr of problems) console.error(`  ${pr}`);
+  process.exit(1);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/ci/validate-skills.test.mjs
+++ b/ci/validate-skills.test.mjs
@@ -1,0 +1,69 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  validateSkill,
+  validateCommand,
+  validateManifestDoc,
+  MAX_DESCRIPTION,
+} from './validate-skills.mjs';
+
+function skillSource({ name = 'demo', description = 'a demo skill' } = {}) {
+  return `---\nname: ${name}\ndescription: ${description}\n---\n# Demo\n`;
+}
+
+test('a well-formed skill produces no problems', () => {
+  const problems = validateSkill({ dirName: 'demo', source: skillSource() });
+  assert.deepEqual(problems, []);
+});
+
+test('flags a name that does not match the directory', () => {
+  const problems = validateSkill({ dirName: 'demo', source: skillSource({ name: 'other' }) });
+  assert.ok(problems.some((p) => /must equal the directory name/.test(p)));
+});
+
+test('flags a missing description', () => {
+  const src = '---\nname: demo\n---\n# Demo\n';
+  const problems = validateSkill({ dirName: 'demo', source: src });
+  assert.ok(problems.some((p) => /"description" is required/.test(p)));
+});
+
+test('flags an over-length description', () => {
+  const long = 'x'.repeat(MAX_DESCRIPTION + 1);
+  const problems = validateSkill({ dirName: 'demo', source: skillSource({ description: long }) });
+  assert.ok(problems.some((p) => /max/.test(p)));
+});
+
+test('reports a parse error for missing frontmatter', () => {
+  const problems = validateSkill({ dirName: 'demo', source: '# no frontmatter\n' });
+  assert.equal(problems.length, 1);
+  assert.ok(/opening/.test(problems[0]));
+});
+
+test('a well-formed command produces no problems', () => {
+  const src = '---\ndescription: do a thing\n---\nbody\n';
+  const problems = validateCommand({ fileName: 'demo.md', source: src });
+  assert.deepEqual(problems, []);
+});
+
+test('flags a command missing a description', () => {
+  const src = '---\nother: x\n---\nbody\n';
+  const problems = validateCommand({ fileName: 'demo.md', source: src });
+  assert.ok(problems.some((p) => /"description" is required/.test(p)));
+});
+
+test('manifest doc with a valid integer schemaVersion passes', () => {
+  const src = 'text\n```json\n{ "schemaVersion": 4 }\n```\nmore\n';
+  assert.deepEqual(validateManifestDoc(src), []);
+});
+
+test('flags a manifest doc whose example JSON does not parse', () => {
+  const src = '```json\n{ not json }\n```\n';
+  const problems = validateManifestDoc(src);
+  assert.ok(problems.some((p) => /does not parse/.test(p)));
+});
+
+test('flags a manifest doc whose schemaVersion is not an integer', () => {
+  const src = '```json\n{ "schemaVersion": "4" }\n```\n';
+  const problems = validateManifestDoc(src);
+  assert.ok(problems.some((p) => /must be an integer/.test(p)));
+});

--- a/ci/validate-skills.test.mjs
+++ b/ci/validate-skills.test.mjs
@@ -67,3 +67,8 @@ test('flags a manifest doc whose schemaVersion is not an integer', () => {
   const problems = validateManifestDoc(src);
   assert.ok(problems.some((p) => /must be an integer/.test(p)));
 });
+
+test('flags a manifest doc with no json block', () => {
+  const problems = validateManifestDoc('no code block here');
+  assert.ok(problems.some((p) => /no.*json.*block/i.test(p)));
+});

--- a/commands/design-system-status.md
+++ b/commands/design-system-status.md
@@ -18,10 +18,27 @@ Report, in friendly prose (not a JSON dump), scaled to `user.codingLevel`:
 - **Sync:** which platforms/adapters? any custom adapters? when last run?
 - **Storybook:** initialized? Chromatic? Code Connect?
 - **Coding level + UI framework** on record.
+- **Retrofit** (brownfield only — skip the whole block if `tokens.intakeMode` isn't
+  `"retrofit"` and `audit.ranAt` is null):
+  - Audit: has it run (`audit.ranAt`)? If so, the code-surface counts
+    (`audit.codeSurface`), the Figma inventory (`audit.figmaInventory` — variables,
+    bindings, text/effect styles, modes), and how semantic the system is
+    (`audit.percentSemantic`).
+  - Crosswalk: is it built (`tokenCrosswalk.path`)? The status counts
+    (`tokenCrosswalk.statusCounts`) and whether the validator is passing
+    (`tokenCrosswalk.validatorPassing`).
+  - Retrofit progress: which phase (`retrofit.phase`), and whether the decision journal
+    was scaffolded (`retrofit.journalScaffolded`).
 
 Then suggest **sensible next steps** based on what's missing — e.g. "You've got
 tokens and a repo but haven't synced yet — want to run `/sync-figma-tokens`?" or
 "No components yet — want to build your foundational set?" Offer, don't force.
+
+For a brownfield system, suggest the next retrofit step from the state: no audit yet
+→ "want to run `design-system-audit` to size the retrofit?"; audited but no crosswalk
+→ "want to build the crosswalk with `token-crosswalk-builder`?"; mid-retrofit
+(`retrofit.phase` set, not `"done"`) → "want to resume the retrofit at the `<phase>`
+phase with `retrofit-planner`?".
 
 If `design-system.json` doesn't exist, explain that no design system has been
 set up in this folder yet and offer to run `figma-environment-setup` to start.

--- a/commands/start.md
+++ b/commands/start.md
@@ -16,7 +16,10 @@ Invoke the `figma-environment-setup` skill now and follow it exactly. It will:
 
 If `design-system.json` already exists in this folder, the setup skill will
 detect it and route the user to the right next step rather than starting over —
-let it make that call.
+let it make that call. That routing now covers brownfield systems too: an
+existing/mature repo or populated Figma file is sent to `design-system-audit`
+first, and an in-progress retrofit (`retrofit.phase` set) resumes at its phase
+via `retrofit-planner` — the setup skill makes that call.
 
 Scale all explanation to the user's coding level. Assume they may be
 design-fluent but new to developer tooling, terminals, and API tokens.

--- a/docs/superpowers/plans/2026-06-25-brownfield-crosswalk.md
+++ b/docs/superpowers/plans/2026-06-25-brownfield-crosswalk.md
@@ -1,0 +1,1438 @@
+# Brownfield Retrofit — Plan 2: Crosswalk Scripts + Builder Skill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the crosswalk backbone — a finalized `crosswalk.json` schema, three canonical vetted Node scripts (validator, reverse-index generator, repo-wide token-removal guard), and the `token-crosswalk-builder` skill that builds the crosswalk, installs the scripts into the user's monorepo, and wires the `tokens:validate` CI gate.
+
+**Architecture:** The plugin gains its first executable code in a new `scripts/` directory — the executable analog of `references/`. Scripts are plain ESM Node modules (`.mjs`), **zero runtime dependencies**, tested with Node's built-in test runner (`node --test`). Each script exports pure functions (testable in isolation) and guards its CLI behind a `main()` entrypoint check. A tiny shared loader (`scripts/lib/crosswalk.mjs`) reads and structurally validates `crosswalk.json` for all three. The crosswalk schema is finalized **first** (per spec §11) as both a canonical reference doc and a JSON Schema file. The `token-crosswalk-builder` skill (a `retrofit-planner` sub-skill, no slash command) copies the vetted scripts into the user's `packages/tokens/` and wires `tokens:validate` into their `package.json`, then writes the `tokenCrosswalk` manifest section it owns. Greenfield paths are untouched; the color-usage grep scaffold and binding-survival audit are deliberately deferred to Plan 3 alongside their consumer (`design-system-audit`).
+
+**Tech Stack:** Node.js (≥18; dev machine has v24) ESM, `node:test` + `node:assert`, `node:util` `parseArgs`, `node:fs`/`node:path`/`node:os`/`node:url`. No `package.json`, no npm install, no third-party deps in the plugin. The crosswalk validator resolves against the DTCG token JSON that `token-sync-layer` emits at `packages/tokens/dtcg/tokens.json`. Markdown for the skill and reference docs, matching the house style in `skills/` and `references/`.
+
+---
+
+## Scope & boundaries
+
+**In scope (this plan):**
+- `references/crosswalk-schema.md` — the finalized, canonical crosswalk contract.
+- `scripts/crosswalk.schema.json` — machine-readable JSON Schema (documentation + editor support).
+- `scripts/lib/crosswalk.mjs` — shared loader + structural validation + status-count rollup.
+- `scripts/validate-crosswalk.mjs` — the N/N `tokens:validate` gate (resolved value == new value).
+- `scripts/build-reverse-index.mjs` — code symbol → new token map generator.
+- `scripts/guard-token-removal.mjs` — repo-wide zero-reference grep guard.
+- `scripts/*.test.mjs` — tests for each of the above.
+- `scripts/README.md` — what the scripts are, how the skill installs them, how to run tests.
+- `skills/token-crosswalk-builder/SKILL.md` — the builder skill.
+- `CHANGELOG.md` — `[Unreleased]` entry.
+
+**Deliberately out of scope (deferred to Plan 3, by design):**
+- **Color-usage grep scaffold** — §6 classes it as the *skill-adapted* (not vetted-as-is) script; §4.1 binds it to `design-system-audit`, its only consumer, which lands in Plan 3. Building it now would orphan it.
+- **Binding-survival audit** — stays in `references/` (runs in Figma via `figma_execute`, not the repo); belongs with `token-builder`'s brownfield branch in Plan 3 (§6).
+- The `design-system-audit` and `retrofit-planner` skills, and the brownfield branches of existing skills.
+
+---
+
+## File Map
+
+| Action | File | What changes |
+|---|---|---|
+| Create | `references/crosswalk-schema.md` | Canonical crosswalk.json contract: columns, `status` enum, kebab↔camel status-count mapping, top-level shape, worked example, where the file lives, relationship to the `tokenCrosswalk` manifest section |
+| Create | `scripts/crosswalk.schema.json` | JSON Schema (draft 2020-12) for `crosswalk.json` — the finalized machine contract |
+| Create | `scripts/lib/crosswalk.mjs` | `loadCrosswalk(path)` (read + structural validate), `statusCounts(crosswalk)`, `STATUS_VALUES`, `STATUS_COUNT_KEY` |
+| Create | `scripts/lib/crosswalk.test.mjs` | Tests for the loader: valid file, each rejection path, status-count rollup |
+| Create | `scripts/validate-crosswalk.mjs` | `flattenDtcg`, `resolveValue`, `validate`, CLI `main()` — the N/N gate |
+| Create | `scripts/validate-crosswalk.test.mjs` | Tests: flatten, alias resolution, pass/mismatch/missing, value normalization |
+| Create | `scripts/build-reverse-index.mjs` | `buildReverseIndex`, CLI `main()` — code symbol → new token |
+| Create | `scripts/build-reverse-index.test.mjs` | Tests: mapping, multi-code rows, conflict detection, stable ordering |
+| Create | `scripts/guard-token-removal.mjs` | `walk`, `scanFile`, `guard`, CLI `main()` — repo-wide zero-reference grep |
+| Create | `scripts/guard-token-removal.test.mjs` | Tests: finds references, honors excludes, clean tree returns empty |
+| Create | `scripts/README.md` | Scripts overview, install-into-user-repo contract, `node --test` instructions |
+| Create | `skills/token-crosswalk-builder/SKILL.md` | The builder skill (frontmatter + steps), owns `tokenCrosswalk` manifest section |
+| Modify | `CHANGELOG.md` | `[Unreleased]` entry for the scripts + skill |
+
+---
+
+## The crosswalk.json contract (reference for every task below)
+
+This is the finalized shape. All tasks must agree with it; it is reproduced in
+`references/crosswalk-schema.md` (Task 1) and enforced by `scripts/lib/crosswalk.mjs` (Task 2).
+
+```jsonc
+{
+  "$schema": "./crosswalk.schema.json",
+  "version": 1,
+  "tokens": [
+    {
+      "newToken": "color.text.primary",      // DTCG dot-path; matches the emitted token name
+      "newValue": "#111827",                  // the RESOLVED literal value (aliases followed to a leaf)
+      "tier": "semantic",                     // "primitive" | "semantic"
+      "figmaOld": "Text/Default",             // old Figma variable name/path, or null if newly added
+      "codeTokens": ["$text-default", "text-grey-900"], // old code identifiers this token replaces (may be [])
+      "status": "renamed",                    // aligned | renamed | drift-fix | added | mapped-nearest
+      "recommendedSemantic": null             // optional suggested semantic target, or null
+    }
+  ]
+}
+```
+
+- **`newToken`** is the DTCG dot-path exactly as `token-sync-layer` emits it (e.g. `color.gray.500`, `color.text.primary`) — that is what the validator resolves against `packages/tokens/dtcg/tokens.json`.
+- **`newValue`** is the **resolved leaf value** (aliases followed). For a semantic token whose `$value` is `{color.gray.900}`, `newValue` is the primitive's literal (`#111827`), not the `{…}` reference.
+- **`status` enum** (kebab-case, from the case study): `aligned | renamed | drift-fix | added | mapped-nearest`.
+- **Manifest `tokenCrosswalk.statusCounts` uses camelCase keys**: `aligned, renamed, driftFix, added, mappedNearest`. The kebab→camel mapping lives in `STATUS_COUNT_KEY` (Task 2) and is documented in Task 1.
+- **`figmaOld`** is `null` for `added` rows (no prior Figma variable).
+- **`codeTokens`** may be `[]` (e.g. an `added` token with no legacy code symbol).
+- **File location:** `packages/tokens/crosswalk.json`, beside `packages/tokens/dtcg/tokens.json`. (Spec §8 shows `"tokens/crosswalk.json"` illustratively; the manifest `tokenCrosswalk.path` records the **actual** path the skill wrote, which in the standard monorepo is `packages/tokens/crosswalk.json`.)
+
+---
+
+## Task 1: Finalize the crosswalk schema (the contract — first, per §11)
+
+Spec §11 is explicit: *"Finalize the `crosswalk.json` schema first. The validator and reverse-index generator depend on it; ship the schema before the scripts that consume it."* This task ships no executable code — it locks the contract every later task builds on.
+
+**Files:**
+- Create: `references/crosswalk-schema.md`
+- Create: `scripts/crosswalk.schema.json`
+
+- [ ] **Step 1.1: Create the `scripts/` directory and the JSON Schema file**
+
+  Create `scripts/crosswalk.schema.json` with exactly this content:
+
+  ```json
+  {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://throughline.dev/schemas/crosswalk.schema.json",
+    "title": "ThroughLine token crosswalk",
+    "description": "Three-way map: new token <-> old Figma token <-> code identifier. Drives the brownfield code retrofit and the tokens:validate CI gate.",
+    "type": "object",
+    "required": ["version", "tokens"],
+    "additionalProperties": false,
+    "properties": {
+      "$schema": { "type": "string" },
+      "version": { "const": 1 },
+      "tokens": {
+        "type": "array",
+        "items": { "$ref": "#/$defs/row" }
+      }
+    },
+    "$defs": {
+      "row": {
+        "type": "object",
+        "required": ["newToken", "newValue", "tier", "figmaOld", "codeTokens", "status"],
+        "additionalProperties": false,
+        "properties": {
+          "newToken": { "type": "string", "minLength": 1, "description": "DTCG dot-path, e.g. color.text.primary" },
+          "newValue": { "type": "string", "minLength": 1, "description": "Resolved leaf value (aliases followed)" },
+          "tier": { "type": "string", "enum": ["primitive", "semantic"] },
+          "figmaOld": { "type": ["string", "null"], "description": "Old Figma variable name/path, or null if newly added" },
+          "codeTokens": { "type": "array", "items": { "type": "string" }, "description": "Old code identifiers this token replaces" },
+          "status": { "type": "string", "enum": ["aligned", "renamed", "drift-fix", "added", "mapped-nearest"] },
+          "recommendedSemantic": { "type": ["string", "null"] }
+        }
+      }
+    }
+  }
+  ```
+
+- [ ] **Step 1.2: Verify the schema file is valid JSON**
+
+  Run (from the repo root):
+
+  ```bash
+  node -e "JSON.parse(require('fs').readFileSync('scripts/crosswalk.schema.json','utf8')); console.log('valid JSON')"
+  ```
+
+  Expected output:
+
+  ```
+  valid JSON
+  ```
+
+- [ ] **Step 1.3: Create the canonical reference doc**
+
+  Create `references/crosswalk-schema.md` with exactly this content:
+
+  ````markdown
+  # Crosswalk schema — `crosswalk.json`
+
+  The crosswalk is the backbone artifact of a brownfield retrofit: a persistent,
+  machine-readable **three-way map** between the new token, the old Figma variable,
+  and the old code identifier(s). It drives the code retrofit and the
+  `tokens:validate` CI gate. Built by the `token-crosswalk-builder` skill; consumed
+  by the validator and reverse-index scripts (`scripts/`). The machine contract is
+  `${CLAUDE_PLUGIN_ROOT}/scripts/crosswalk.schema.json`; this doc is its prose home.
+
+  ## Where it lives
+
+  `packages/tokens/crosswalk.json`, beside the DTCG intermediate
+  `packages/tokens/dtcg/tokens.json` that `token-sync-layer` emits. The manifest's
+  `tokenCrosswalk.path` records the actual path. (Spec §8 shows `tokens/crosswalk.json`
+  illustratively; the standard monorepo path is `packages/tokens/crosswalk.json`.)
+
+  ## Top-level shape
+
+  ```jsonc
+  {
+    "$schema": "./crosswalk.schema.json",
+    "version": 1,
+    "tokens": [ /* rows */ ]
+  }
+  ```
+
+  ## Row columns
+
+  | Field | Type | Meaning |
+  | --- | --- | --- |
+  | `newToken` | string | DTCG dot-path, exactly as `token-sync-layer` emits it (`color.text.primary`). This is the key the validator resolves against the DTCG tokens. |
+  | `newValue` | string | The **resolved leaf value** — aliases followed to a literal. For a semantic token whose `$value` is `{color.gray.900}`, this is the primitive literal (`#111827`), never the `{…}` reference. |
+  | `tier` | `"primitive"` \| `"semantic"` | Which tier the new token belongs to. |
+  | `figmaOld` | string \| null | The old Figma variable name/path being reconciled, or `null` for an `added` token with no prior Figma variable. |
+  | `codeTokens` | string[] | Old code identifiers this token replaces (`$primary-red`, `bg-primary-red`, `Colors.primaryRed`, `--primary-red`). May be `[]`. Drives the reverse index. |
+  | `status` | enum | The reconciliation status — see below. |
+  | `recommendedSemantic` | string \| null | An optional suggested semantic token to migrate a raw/primitive usage toward. |
+
+  ## `status` enum
+
+  Kebab-case, from the Sweet case study (151 renamed, 42 added, 12 aligned,
+  3 mapped-nearest, 2 drift-fix):
+
+  | `status` | Meaning |
+  | --- | --- |
+  | `aligned` | New token already matches the old one in name and value — no change needed. |
+  | `renamed` | Same value, new name. The bulk of a ~90%-semantic retrofit. |
+  | `drift-fix` | The old value was wrong/inconsistent; the new value intentionally differs (a deliberate fix, distinguishable from a regression via the Chromatic baseline). |
+  | `added` | A new token with no prior Figma variable (`figmaOld: null`). |
+  | `mapped-nearest` | No exact old equivalent; mapped to the nearest new token (a judgment call worth review). |
+
+  ## Status-count rollup (kebab → camelCase)
+
+  The manifest's `tokenCrosswalk.statusCounts` uses camelCase keys. The validator
+  emits the rollup in this shape so the skill can copy it straight into the manifest:
+
+  | Row `status` | `statusCounts` key |
+  | --- | --- |
+  | `aligned` | `aligned` |
+  | `renamed` | `renamed` |
+  | `drift-fix` | `driftFix` |
+  | `added` | `added` |
+  | `mapped-nearest` | `mappedNearest` |
+
+  ## The validation gate
+
+  `tokens:validate` resolves every `newToken` against `packages/tokens/dtcg/tokens.json`
+  (following `{…}` alias chains to a leaf) and asserts the resolved value equals the
+  row's `newValue`, for **every** row (the N/N gate — Sweet passed 210/210). Value
+  comparison is case-insensitive and trimmed, so `#EF4444` and `#ef4444` are equal. A
+  token present in the crosswalk but absent from the DTCG source is a failure
+  (reported as *missing*), never silently skipped — this honors the read-discipline
+  principle in `${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md`.
+
+  ## Worked example
+
+  ```jsonc
+  {
+    "$schema": "./crosswalk.schema.json",
+    "version": 1,
+    "tokens": [
+      {
+        "newToken": "color.gray.900",
+        "newValue": "#111827",
+        "tier": "primitive",
+        "figmaOld": "grey/900",
+        "codeTokens": ["$grey-900"],
+        "status": "renamed",
+        "recommendedSemantic": "color.text.primary"
+      },
+      {
+        "newToken": "color.text.primary",
+        "newValue": "#111827",
+        "tier": "semantic",
+        "figmaOld": "Text/Default",
+        "codeTokens": ["$text-default", "text-grey-900"],
+        "status": "renamed",
+        "recommendedSemantic": null
+      },
+      {
+        "newToken": "color.surface.raised",
+        "newValue": "#ffffff",
+        "tier": "semantic",
+        "figmaOld": null,
+        "codeTokens": [],
+        "status": "added",
+        "recommendedSemantic": null
+      }
+    ]
+  }
+  ```
+  ````
+
+- [ ] **Step 1.4: Self-review against the spec**
+
+  Open `docs/superpowers/specs/2026-06-25-brownfield-retrofit-design.md` §4.2 and §8,
+  and `docs/brownfield-retrofit-learnings.md` §2. Confirm:
+  - The columns match §4.2 exactly: `newToken`, `newValue`, `tier`, `figmaOld`,
+    `codeTokens[]`, `status`, `recommendedSemantic`.
+  - The `status` enum matches: `aligned | renamed | drift-fix | added | mapped-nearest`.
+  - The camelCase rollup keys match the manifest `tokenCrosswalk.statusCounts` in
+    `references/manifest-schema.md` (`aligned, renamed, driftFix, added, mappedNearest`).
+    Open that file and confirm the five keys are identical.
+  Fix any drift inline.
+
+- [ ] **Step 1.5: Commit**
+
+  ```bash
+  git add references/crosswalk-schema.md scripts/crosswalk.schema.json
+  git commit -m "feat: finalize crosswalk.json schema (reference doc + JSON Schema)"
+  ```
+
+---
+
+## Task 2: Shared crosswalk loader (`scripts/lib/crosswalk.mjs`)
+
+The loader is the single place that reads and structurally validates `crosswalk.json`.
+The validator and reverse-index both depend on it (DRY). It performs **zero-dependency**
+structural validation mirroring the JSON Schema's `required`/`enum` rules — we do not
+pull in a JSON Schema validator library; the `.schema.json` is the contract/doc, this
+loader is the runtime enforcer.
+
+**Files:**
+- Create: `scripts/lib/crosswalk.mjs`
+- Test: `scripts/lib/crosswalk.test.mjs`
+
+- [ ] **Step 2.1: Write the failing test**
+
+  Create `scripts/lib/crosswalk.test.mjs`:
+
+  ```javascript
+  import { test } from 'node:test';
+  import assert from 'node:assert/strict';
+  import { mkdtempSync, writeFileSync } from 'node:fs';
+  import { tmpdir } from 'node:os';
+  import { join } from 'node:path';
+  import { loadCrosswalk, statusCounts, STATUS_VALUES, STATUS_COUNT_KEY } from './crosswalk.mjs';
+
+  function writeTemp(obj) {
+    const dir = mkdtempSync(join(tmpdir(), 'crosswalk-'));
+    const path = join(dir, 'crosswalk.json');
+    writeFileSync(path, typeof obj === 'string' ? obj : JSON.stringify(obj));
+    return path;
+  }
+
+  const validRow = {
+    newToken: 'color.gray.900',
+    newValue: '#111827',
+    tier: 'primitive',
+    figmaOld: 'grey/900',
+    codeTokens: ['$grey-900'],
+    status: 'renamed',
+    recommendedSemantic: null,
+  };
+  const validDoc = { version: 1, tokens: [validRow] };
+
+  test('loads a valid crosswalk', () => {
+    const cw = loadCrosswalk(writeTemp(validDoc));
+    assert.equal(cw.tokens.length, 1);
+    assert.equal(cw.tokens[0].newToken, 'color.gray.900');
+  });
+
+  test('rejects a missing file', () => {
+    assert.throws(() => loadCrosswalk('/no/such/file.json'), /cannot read file/);
+  });
+
+  test('rejects invalid JSON', () => {
+    assert.throws(() => loadCrosswalk(writeTemp('{ not json')), /invalid JSON/);
+  });
+
+  test('rejects a doc without a tokens array', () => {
+    assert.throws(() => loadCrosswalk(writeTemp({ version: 1 })), /"tokens" array/);
+  });
+
+  test('rejects a bad status', () => {
+    const bad = { version: 1, tokens: [{ ...validRow, status: 'frobnicated' }] };
+    assert.throws(() => loadCrosswalk(writeTemp(bad)), /status must be one of/);
+  });
+
+  test('rejects a bad tier', () => {
+    const bad = { version: 1, tokens: [{ ...validRow, tier: 'tertiary' }] };
+    assert.throws(() => loadCrosswalk(writeTemp(bad)), /tier must be/);
+  });
+
+  test('rejects a missing required string field', () => {
+    const bad = { version: 1, tokens: [{ ...validRow, newValue: '' }] };
+    assert.throws(() => loadCrosswalk(writeTemp(bad)), /newValue must be a non-empty string/);
+  });
+
+  test('rejects codeTokens that is not a string array', () => {
+    const bad = { version: 1, tokens: [{ ...validRow, codeTokens: [1, 2] }] };
+    assert.throws(() => loadCrosswalk(writeTemp(bad)), /codeTokens must be an array of strings/);
+  });
+
+  test('allows figmaOld null for added tokens', () => {
+    const added = { version: 1, tokens: [{ ...validRow, status: 'added', figmaOld: null, codeTokens: [] }] };
+    assert.doesNotThrow(() => loadCrosswalk(writeTemp(added)));
+  });
+
+  test('rejects duplicate newToken', () => {
+    const dup = { version: 1, tokens: [validRow, { ...validRow }] };
+    assert.throws(() => loadCrosswalk(writeTemp(dup)), /duplicate newToken/);
+  });
+
+  test('rolls up status counts in camelCase', () => {
+    const doc = {
+      version: 1,
+      tokens: [
+        { ...validRow, newToken: 'a', status: 'aligned' },
+        { ...validRow, newToken: 'b', status: 'renamed' },
+        { ...validRow, newToken: 'c', status: 'drift-fix' },
+        { ...validRow, newToken: 'd', status: 'added', figmaOld: null },
+        { ...validRow, newToken: 'e', status: 'mapped-nearest' },
+        { ...validRow, newToken: 'f', status: 'renamed' },
+      ],
+    };
+    const counts = statusCounts(loadCrosswalk(writeTemp(doc)));
+    assert.deepEqual(counts, { aligned: 1, renamed: 2, driftFix: 1, added: 1, mappedNearest: 1 });
+  });
+
+  test('exposes the enum and the kebab->camel map', () => {
+    assert.deepEqual(STATUS_VALUES, ['aligned', 'renamed', 'drift-fix', 'added', 'mapped-nearest']);
+    assert.equal(STATUS_COUNT_KEY['drift-fix'], 'driftFix');
+    assert.equal(STATUS_COUNT_KEY['mapped-nearest'], 'mappedNearest');
+  });
+  ```
+
+- [ ] **Step 2.2: Run the test to verify it fails**
+
+  Run: `node --test scripts/lib/crosswalk.test.mjs`
+  Expected: FAIL — `Cannot find module '.../scripts/lib/crosswalk.mjs'` (the module does not exist yet).
+
+- [ ] **Step 2.3: Write the implementation**
+
+  Create `scripts/lib/crosswalk.mjs`:
+
+  ```javascript
+  // Shared loader + structural validation for crosswalk.json.
+  // Zero dependencies. Mirrors scripts/crosswalk.schema.json's required/enum rules.
+  import { readFileSync } from 'node:fs';
+
+  export const STATUS_VALUES = ['aligned', 'renamed', 'drift-fix', 'added', 'mapped-nearest'];
+
+  // Row status (kebab) -> manifest tokenCrosswalk.statusCounts key (camelCase).
+  export const STATUS_COUNT_KEY = {
+    'aligned': 'aligned',
+    'renamed': 'renamed',
+    'drift-fix': 'driftFix',
+    'added': 'added',
+    'mapped-nearest': 'mappedNearest',
+  };
+
+  const TIERS = ['primitive', 'semantic'];
+
+  export function loadCrosswalk(path) {
+    let raw;
+    try {
+      raw = readFileSync(path, 'utf8');
+    } catch (e) {
+      throw new Error(`crosswalk: cannot read file at ${path}: ${e.message}`);
+    }
+    let data;
+    try {
+      data = JSON.parse(raw);
+    } catch (e) {
+      throw new Error(`crosswalk: invalid JSON in ${path}: ${e.message}`);
+    }
+    if (!data || typeof data !== 'object' || !Array.isArray(data.tokens)) {
+      throw new Error('crosswalk: expected an object with a "tokens" array');
+    }
+    const seen = new Set();
+    data.tokens.forEach((row, i) => validateRow(row, i, seen));
+    return data;
+  }
+
+  function validateRow(row, i, seen) {
+    const where = `tokens[${i}]`;
+    if (!row || typeof row !== 'object') {
+      throw new Error(`crosswalk: ${where} is not an object`);
+    }
+    for (const field of ['newToken', 'newValue', 'tier', 'status']) {
+      if (typeof row[field] !== 'string' || row[field] === '') {
+        throw new Error(`crosswalk: ${where}.${field} must be a non-empty string`);
+      }
+    }
+    if (!TIERS.includes(row.tier)) {
+      throw new Error(`crosswalk: ${where}.tier must be one of ${TIERS.join(', ')}, got "${row.tier}"`);
+    }
+    if (!STATUS_VALUES.includes(row.status)) {
+      throw new Error(`crosswalk: ${where}.status must be one of ${STATUS_VALUES.join(', ')}, got "${row.status}"`);
+    }
+    if (!Array.isArray(row.codeTokens) || row.codeTokens.some((t) => typeof t !== 'string')) {
+      throw new Error(`crosswalk: ${where}.codeTokens must be an array of strings`);
+    }
+    if (row.figmaOld !== null && typeof row.figmaOld !== 'string') {
+      throw new Error(`crosswalk: ${where}.figmaOld must be a string or null`);
+    }
+    if (row.recommendedSemantic != null && typeof row.recommendedSemantic !== 'string') {
+      throw new Error(`crosswalk: ${where}.recommendedSemantic must be a string or null`);
+    }
+    if (seen.has(row.newToken)) {
+      throw new Error(`crosswalk: duplicate newToken "${row.newToken}"`);
+    }
+    seen.add(row.newToken);
+  }
+
+  export function statusCounts(crosswalk) {
+    const counts = { aligned: 0, renamed: 0, driftFix: 0, added: 0, mappedNearest: 0 };
+    for (const row of crosswalk.tokens) {
+      counts[STATUS_COUNT_KEY[row.status]] += 1;
+    }
+    return counts;
+  }
+  ```
+
+- [ ] **Step 2.4: Run the test to verify it passes**
+
+  Run: `node --test scripts/lib/crosswalk.test.mjs`
+  Expected: PASS — all assertions green (`# pass 12`, `# fail 0`).
+
+- [ ] **Step 2.5: Commit**
+
+  ```bash
+  git add scripts/lib/crosswalk.mjs scripts/lib/crosswalk.test.mjs
+  git commit -m "feat: shared crosswalk loader with structural validation + status rollup"
+  ```
+
+---
+
+## Task 3: Crosswalk validator (`scripts/validate-crosswalk.mjs`) — the `tokens:validate` gate
+
+Resolves every `newToken` against the DTCG token source and asserts the resolved value
+equals the row's `newValue`. This is the N/N CI gate (Sweet: 210/210).
+
+**Files:**
+- Create: `scripts/validate-crosswalk.mjs`
+- Test: `scripts/validate-crosswalk.test.mjs`
+
+- [ ] **Step 3.1: Write the failing test**
+
+  Create `scripts/validate-crosswalk.test.mjs`:
+
+  ```javascript
+  import { test } from 'node:test';
+  import assert from 'node:assert/strict';
+  import { flattenDtcg, resolveValue, validate } from './validate-crosswalk.mjs';
+
+  const dtcg = {
+    color: {
+      gray: {
+        900: { $value: '#111827', $type: 'color' },
+      },
+      text: {
+        primary: { $value: '{color.gray.900}', $type: 'color' },
+      },
+    },
+  };
+
+  test('flattenDtcg produces dot-path keys with raw $value', () => {
+    const flat = flattenDtcg(dtcg);
+    assert.equal(flat['color.gray.900'], '#111827');
+    assert.equal(flat['color.text.primary'], '{color.gray.900}');
+  });
+
+  test('resolveValue follows alias chains to a leaf', () => {
+    const flat = flattenDtcg(dtcg);
+    assert.equal(resolveValue('color.text.primary', flat), '#111827');
+    assert.equal(resolveValue('color.gray.900', flat), '#111827');
+  });
+
+  test('resolveValue throws on a missing token', () => {
+    assert.throws(() => resolveValue('color.nope', {}), /not found/);
+  });
+
+  test('resolveValue throws on a circular reference', () => {
+    const flat = { 'a': '{b}', 'b': '{a}' };
+    assert.throws(() => resolveValue('a', flat), /circular/);
+  });
+
+  test('validate passes N/N when every resolved value matches', () => {
+    const crosswalk = {
+      version: 1,
+      tokens: [
+        { newToken: 'color.gray.900', newValue: '#111827', tier: 'primitive', figmaOld: 'grey/900', codeTokens: [], status: 'renamed', recommendedSemantic: null },
+        { newToken: 'color.text.primary', newValue: '#111827', tier: 'semantic', figmaOld: 'Text/Default', codeTokens: [], status: 'renamed', recommendedSemantic: null },
+      ],
+    };
+    const r = validate(crosswalk, dtcg);
+    assert.equal(r.total, 2);
+    assert.equal(r.passed, 2);
+    assert.equal(r.mismatches.length, 0);
+    assert.equal(r.missing.length, 0);
+  });
+
+  test('validate compares case-insensitively and trims', () => {
+    const crosswalk = { version: 1, tokens: [
+      { newToken: 'color.gray.900', newValue: '  #111827  ', tier: 'primitive', figmaOld: null, codeTokens: [], status: 'aligned', recommendedSemantic: null },
+    ]};
+    // newValue with surrounding whitespace must still match the trimmed source value
+    const r = validate(crosswalk, { color: { gray: { 900: { $value: '#111827' } } } });
+    assert.equal(r.passed, 1);
+    const rUpper = validate({ version: 1, tokens: [
+      { newToken: 'color.gray.900', newValue: '#EF4444', tier: 'primitive', figmaOld: null, codeTokens: [], status: 'aligned', recommendedSemantic: null },
+    ]}, { color: { gray: { 900: { $value: '#ef4444' } } } });
+    assert.equal(rUpper.passed, 1);
+  });
+
+  test('validate reports a mismatch', () => {
+    const crosswalk = { version: 1, tokens: [
+      { newToken: 'color.gray.900', newValue: '#000000', tier: 'primitive', figmaOld: null, codeTokens: [], status: 'drift-fix', recommendedSemantic: null },
+    ]};
+    const r = validate(crosswalk, dtcg);
+    assert.equal(r.passed, 0);
+    assert.equal(r.mismatches.length, 1);
+    assert.equal(r.mismatches[0].token, 'color.gray.900');
+    assert.equal(r.mismatches[0].expected, '#000000');
+    assert.equal(r.mismatches[0].actual, '#111827');
+  });
+
+  test('validate reports a token missing from the DTCG source', () => {
+    const crosswalk = { version: 1, tokens: [
+      { newToken: 'color.ghost', newValue: '#fff', tier: 'primitive', figmaOld: null, codeTokens: [], status: 'added', recommendedSemantic: null },
+    ]};
+    const r = validate(crosswalk, dtcg);
+    assert.deepEqual(r.missing, ['color.ghost']);
+    assert.equal(r.passed, 0);
+  });
+  ```
+
+- [ ] **Step 3.2: Run the test to verify it fails**
+
+  Run: `node --test scripts/validate-crosswalk.test.mjs`
+  Expected: FAIL — `Cannot find module '.../scripts/validate-crosswalk.mjs'`.
+
+- [ ] **Step 3.3: Write the implementation**
+
+  Create `scripts/validate-crosswalk.mjs`:
+
+  ```javascript
+  // Crosswalk validator: resolved DTCG value == crosswalk newValue, for every row.
+  // The tokens:validate CI gate. Zero dependencies.
+  //
+  // Usage:
+  //   node validate-crosswalk.mjs --crosswalk crosswalk.json --tokens dtcg/tokens.json
+  import { readFileSync } from 'node:fs';
+  import { parseArgs } from 'node:util';
+  import { pathToFileURL } from 'node:url';
+  import { loadCrosswalk, statusCounts } from './lib/crosswalk.mjs';
+
+  const REF = /^\{([^}]+)\}$/;
+
+  // Flatten nested DTCG groups into { "dot.path": rawValue }. Skips $-prefixed meta keys.
+  export function flattenDtcg(obj, prefix = [], out = {}) {
+    for (const [key, val] of Object.entries(obj)) {
+      if (key.startsWith('$')) continue;
+      if (val && typeof val === 'object' && '$value' in val) {
+        out[[...prefix, key].join('.')] = val.$value;
+      } else if (val && typeof val === 'object') {
+        flattenDtcg(val, [...prefix, key], out);
+      }
+    }
+    return out;
+  }
+
+  // Follow {alias} chains to a leaf literal. Throws on missing or circular refs.
+  export function resolveValue(name, flat, seen = new Set()) {
+    if (!(name in flat)) throw new Error(`token "${name}" not found in DTCG source`);
+    const val = flat[name];
+    if (typeof val === 'string') {
+      const m = val.match(REF);
+      if (m) {
+        if (seen.has(name)) throw new Error(`circular reference at "${name}"`);
+        seen.add(name);
+        return resolveValue(m[1], flat, seen);
+      }
+    }
+    return val;
+  }
+
+  function norm(v) {
+    return String(v).trim().toLowerCase();
+  }
+
+  export function validate(crosswalk, dtcg) {
+    const flat = flattenDtcg(dtcg);
+    const results = { total: crosswalk.tokens.length, passed: 0, mismatches: [], missing: [] };
+    for (const row of crosswalk.tokens) {
+      let resolved;
+      try {
+        resolved = resolveValue(row.newToken, flat);
+      } catch {
+        results.missing.push(row.newToken);
+        continue;
+      }
+      if (norm(resolved) === norm(row.newValue)) {
+        results.passed += 1;
+      } else {
+        results.mismatches.push({ token: row.newToken, expected: row.newValue, actual: resolved });
+      }
+    }
+    return results;
+  }
+
+  function main() {
+    const { values } = parseArgs({
+      options: {
+        crosswalk: { type: 'string' },
+        tokens: { type: 'string' },
+      },
+    });
+    if (!values.crosswalk || !values.tokens) {
+      console.error('usage: validate-crosswalk.mjs --crosswalk <crosswalk.json> --tokens <dtcg/tokens.json>');
+      process.exit(2);
+    }
+    const crosswalk = loadCrosswalk(values.crosswalk);
+    const dtcg = JSON.parse(readFileSync(values.tokens, 'utf8'));
+    const r = validate(crosswalk, dtcg);
+
+    console.log(`tokens:validate — ${r.passed}/${r.total} resolved values match`);
+    console.log('status counts:', JSON.stringify(statusCounts(crosswalk)));
+    if (r.missing.length) {
+      console.error(`\n${r.missing.length} token(s) missing from the DTCG source:`);
+      for (const t of r.missing) console.error(`  - ${t}`);
+    }
+    if (r.mismatches.length) {
+      console.error(`\n${r.mismatches.length} mismatch(es):`);
+      for (const m of r.mismatches) console.error(`  - ${m.token}: crosswalk says ${m.expected}, source resolves to ${m.actual}`);
+    }
+    const ok = r.passed === r.total;
+    if (!ok) process.exit(1);
+  }
+
+  if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    main();
+  }
+  ```
+
+- [ ] **Step 3.4: Run the test to verify it passes**
+
+  Run: `node --test scripts/validate-crosswalk.test.mjs`
+  Expected: PASS (`# pass 8`, `# fail 0`).
+
+- [ ] **Step 3.5: Smoke-test the CLI with the doc's worked example**
+
+  Create a scratch DTCG file and a scratch crosswalk, then run the CLI to confirm
+  it prints the N/N line and the camelCase counts, and exits 0:
+
+  ```bash
+  cat > /tmp/dtcg.json <<'JSON'
+  { "color": { "gray": { "900": { "$value": "#111827" } }, "text": { "primary": { "$value": "{color.gray.900}" } } } }
+  JSON
+  cat > /tmp/crosswalk.json <<'JSON'
+  { "version": 1, "tokens": [
+    { "newToken": "color.gray.900", "newValue": "#111827", "tier": "primitive", "figmaOld": "grey/900", "codeTokens": ["$grey-900"], "status": "renamed", "recommendedSemantic": null },
+    { "newToken": "color.text.primary", "newValue": "#111827", "tier": "semantic", "figmaOld": "Text/Default", "codeTokens": ["$text-default"], "status": "renamed", "recommendedSemantic": null }
+  ] }
+  JSON
+  node scripts/validate-crosswalk.mjs --crosswalk /tmp/crosswalk.json --tokens /tmp/dtcg.json; echo "exit=$?"
+  ```
+
+  Expected output (last lines):
+
+  ```
+  tokens:validate — 2/2 resolved values match
+  status counts: {"aligned":0,"renamed":2,"driftFix":0,"added":0,"mappedNearest":0}
+  exit=0
+  ```
+
+- [ ] **Step 3.6: Commit**
+
+  ```bash
+  git add scripts/validate-crosswalk.mjs scripts/validate-crosswalk.test.mjs
+  git commit -m "feat: crosswalk validator — N/N resolved-value gate (tokens:validate)"
+  ```
+
+---
+
+## Task 4: Reverse-index generator (`scripts/build-reverse-index.mjs`)
+
+Emits a `codeToken → newToken` map from the crosswalk to semi-automate the SCSS/Tailwind
+swaps. Detects conflicts (one old symbol mapping to two different new tokens).
+
+**Files:**
+- Create: `scripts/build-reverse-index.mjs`
+- Test: `scripts/build-reverse-index.test.mjs`
+
+- [ ] **Step 4.1: Write the failing test**
+
+  Create `scripts/build-reverse-index.test.mjs`:
+
+  ```javascript
+  import { test } from 'node:test';
+  import assert from 'node:assert/strict';
+  import { buildReverseIndex } from './build-reverse-index.mjs';
+
+  test('maps each codeToken to its newToken', () => {
+    const cw = { version: 1, tokens: [
+      { newToken: 'color.text.primary', codeTokens: ['$text-default', 'text-grey-900'], newValue: '#111827', tier: 'semantic', figmaOld: null, status: 'renamed', recommendedSemantic: null },
+    ]};
+    const { index, conflicts } = buildReverseIndex(cw);
+    assert.equal(index['$text-default'], 'color.text.primary');
+    assert.equal(index['text-grey-900'], 'color.text.primary');
+    assert.equal(conflicts.length, 0);
+  });
+
+  test('two code symbols can map to the same new token without conflict', () => {
+    const cw = { version: 1, tokens: [
+      { newToken: 'color.gray.900', codeTokens: ['$grey-900', '$gray-900'], newValue: '#111827', tier: 'primitive', figmaOld: null, status: 'renamed', recommendedSemantic: null },
+    ]};
+    const { conflicts } = buildReverseIndex(cw);
+    assert.equal(conflicts.length, 0);
+  });
+
+  test('flags a code symbol mapping to two different new tokens', () => {
+    const cw = { version: 1, tokens: [
+      { newToken: 'color.gray.900', codeTokens: ['$x'], newValue: '#111827', tier: 'primitive', figmaOld: null, status: 'renamed', recommendedSemantic: null },
+      { newToken: 'color.gray.800', codeTokens: ['$x'], newValue: '#1f2937', tier: 'primitive', figmaOld: null, status: 'renamed', recommendedSemantic: null },
+    ]};
+    const { conflicts } = buildReverseIndex(cw);
+    assert.equal(conflicts.length, 1);
+    assert.equal(conflicts[0].codeToken, '$x');
+    assert.deepEqual(conflicts[0].tokens, ['color.gray.900', 'color.gray.800']);
+  });
+
+  test('emits keys sorted longest-first (safe find-and-replace ordering)', () => {
+    const cw = { version: 1, tokens: [
+      { newToken: 'color.a', codeTokens: ['$blue'], newValue: '#1', tier: 'primitive', figmaOld: null, status: 'renamed', recommendedSemantic: null },
+      { newToken: 'color.b', codeTokens: ['$blue-100'], newValue: '#2', tier: 'primitive', figmaOld: null, status: 'renamed', recommendedSemantic: null },
+    ]};
+    const { index } = buildReverseIndex(cw);
+    assert.deepEqual(Object.keys(index), ['$blue-100', '$blue']);
+  });
+
+  test('skips rows with no codeTokens', () => {
+    const cw = { version: 1, tokens: [
+      { newToken: 'color.surface.raised', codeTokens: [], newValue: '#fff', tier: 'semantic', figmaOld: null, status: 'added', recommendedSemantic: null },
+    ]};
+    const { index } = buildReverseIndex(cw);
+    assert.deepEqual(index, {});
+  });
+  ```
+
+- [ ] **Step 4.2: Run the test to verify it fails**
+
+  Run: `node --test scripts/build-reverse-index.test.mjs`
+  Expected: FAIL — `Cannot find module '.../scripts/build-reverse-index.mjs'`.
+
+- [ ] **Step 4.3: Write the implementation**
+
+  Create `scripts/build-reverse-index.mjs`:
+
+  ```javascript
+  // Reverse-index generator: codeToken -> newToken, from crosswalk.json.
+  // Semi-automates the SCSS/Tailwind swaps. Zero dependencies.
+  //
+  // Usage:
+  //   node build-reverse-index.mjs --crosswalk crosswalk.json --out crosswalk.reverse.json
+  import { writeFileSync } from 'node:fs';
+  import { parseArgs } from 'node:util';
+  import { pathToFileURL } from 'node:url';
+  import { loadCrosswalk } from './lib/crosswalk.mjs';
+
+  export function buildReverseIndex(crosswalk) {
+    const raw = {};
+    const conflicts = [];
+    for (const row of crosswalk.tokens) {
+      for (const code of row.codeTokens) {
+        if (code in raw && raw[code] !== row.newToken) {
+          conflicts.push({ codeToken: code, tokens: [raw[code], row.newToken] });
+        } else {
+          raw[code] = row.newToken;
+        }
+      }
+    }
+    // Sort keys longest-first so a literal find-and-replace can't clobber a longer
+    // symbol via a shorter substring (e.g. replace "$blue-100" before "$blue").
+    const index = {};
+    for (const key of Object.keys(raw).sort((a, b) => b.length - a.length || a.localeCompare(b))) {
+      index[key] = raw[key];
+    }
+    return { index, conflicts };
+  }
+
+  function main() {
+    const { values } = parseArgs({
+      options: {
+        crosswalk: { type: 'string' },
+        out: { type: 'string' },
+      },
+    });
+    if (!values.crosswalk || !values.out) {
+      console.error('usage: build-reverse-index.mjs --crosswalk <crosswalk.json> --out <reverse.json>');
+      process.exit(2);
+    }
+    const crosswalk = loadCrosswalk(values.crosswalk);
+    const { index, conflicts } = buildReverseIndex(crosswalk);
+    writeFileSync(values.out, JSON.stringify(index, null, 2) + '\n');
+    console.log(`reverse index: ${Object.keys(index).length} code symbol(s) -> ${values.out}`);
+    if (conflicts.length) {
+      console.error(`\n${conflicts.length} conflict(s) — one code symbol maps to multiple new tokens:`);
+      for (const c of conflicts) console.error(`  - ${c.codeToken}: ${c.tokens.join(' vs ')}`);
+      process.exit(1);
+    }
+  }
+
+  if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    main();
+  }
+  ```
+
+- [ ] **Step 4.4: Run the test to verify it passes**
+
+  Run: `node --test scripts/build-reverse-index.test.mjs`
+  Expected: PASS (`# pass 5`, `# fail 0`).
+
+- [ ] **Step 4.5: Commit**
+
+  ```bash
+  git add scripts/build-reverse-index.mjs scripts/build-reverse-index.test.mjs
+  git commit -m "feat: reverse-index generator — code symbol to new token map"
+  ```
+
+---
+
+## Task 5: Repo-wide token-removal guard (`scripts/guard-token-removal.mjs`)
+
+Greps all `.ts/.tsx` (minus generated + tests) for references to about-to-be-deleted
+symbols. Deleted Tailwind utilities become silent no-ops that `tsc`/build won't catch
+(guardrail 4), so cleanup must not proceed until this returns zero references.
+
+**Files:**
+- Create: `scripts/guard-token-removal.mjs`
+- Test: `scripts/guard-token-removal.test.mjs`
+
+- [ ] **Step 5.1: Write the failing test**
+
+  Create `scripts/guard-token-removal.test.mjs`:
+
+  ```javascript
+  import { test } from 'node:test';
+  import assert from 'node:assert/strict';
+  import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+  import { tmpdir } from 'node:os';
+  import { join } from 'node:path';
+  import { guard, scanFile } from './guard-token-removal.mjs';
+
+  function fixtureTree() {
+    const root = mkdtempSync(join(tmpdir(), 'guard-'));
+    writeFileSync(join(root, 'app.tsx'), 'const x = "bg-primary-red";\nconst y = 1;\n');
+    writeFileSync(join(root, 'clean.ts'), 'const z = "bg-surface";\n');
+    mkdirSync(join(root, 'generated'), { recursive: true });
+    writeFileSync(join(root, 'generated', 'tokens.ts'), 'export const c = "bg-primary-red";\n');
+    writeFileSync(join(root, 'app.test.tsx'), 'expect("bg-primary-red").toBe(x);\n');
+    mkdirSync(join(root, 'node_modules', 'pkg'), { recursive: true });
+    writeFileSync(join(root, 'node_modules', 'pkg', 'index.ts'), 'const m = "bg-primary-red";\n');
+    return root;
+  }
+
+  test('scanFile reports each line containing a symbol', () => {
+    const root = fixtureTree();
+    const hits = scanFile(join(root, 'app.tsx'), ['bg-primary-red']);
+    assert.equal(hits.length, 1);
+    assert.equal(hits[0].line, 1);
+    assert.equal(hits[0].symbol, 'bg-primary-red');
+  });
+
+  test('guard finds references in source, ignoring generated/tests/node_modules', () => {
+    const root = fixtureTree();
+    const findings = guard(root, ['bg-primary-red']);
+    assert.equal(findings.length, 1);
+    assert.equal(findings[0].file, 'app.tsx');
+    assert.equal(findings[0].symbol, 'bg-primary-red');
+  });
+
+  test('guard returns empty when no source references remain', () => {
+    const root = fixtureTree();
+    const findings = guard(root, ['bg-does-not-exist']);
+    assert.deepEqual(findings, []);
+  });
+
+  test('guard scans multiple symbols at once', () => {
+    const root = fixtureTree();
+    const findings = guard(root, ['bg-primary-red', 'bg-surface']);
+    const files = findings.map((f) => f.file).sort();
+    assert.deepEqual(files, ['app.tsx', 'clean.ts']);
+  });
+  ```
+
+- [ ] **Step 5.2: Run the test to verify it fails**
+
+  Run: `node --test scripts/guard-token-removal.test.mjs`
+  Expected: FAIL — `Cannot find module '.../scripts/guard-token-removal.mjs'`.
+
+- [ ] **Step 5.3: Write the implementation**
+
+  Create `scripts/guard-token-removal.mjs`:
+
+  ```javascript
+  // Repo-wide token-removal guard: grep .ts/.tsx (minus generated + tests) for
+  // references to about-to-be-deleted symbols. Zero dependencies.
+  //
+  // Cleanup must not proceed until this returns zero references — deleted Tailwind
+  // utilities become silent no-ops that tsc/build will not catch (guardrail 4).
+  //
+  // Usage:
+  //   node guard-token-removal.mjs --root <dir> --symbols <symbols.txt>
+  //     symbols file: one symbol per line (blank lines and # comments ignored)
+  import { readFileSync, readdirSync, statSync } from 'node:fs';
+  import { join, relative } from 'node:path';
+  import { parseArgs } from 'node:util';
+  import { pathToFileURL } from 'node:url';
+
+  export const DEFAULT_EXCLUDES = [
+    /(^|\/)node_modules(\/|$)/,
+    /(^|\/)generated(\/|$)/,
+    /\.generated\./,
+    /\.test\./,
+    /\.spec\./,
+    /(^|\/)__tests__(\/|$)/,
+    /(^|\/)dist(\/|$)/,
+    /(^|\/)\.next(\/|$)/,
+  ];
+
+  export function* walk(root, excludes = DEFAULT_EXCLUDES) {
+    for (const entry of readdirSync(root)) {
+      const full = join(root, entry);
+      if (excludes.some((re) => re.test(full))) continue;
+      const st = statSync(full);
+      if (st.isDirectory()) {
+        yield* walk(full, excludes);
+      } else if (/\.tsx?$/.test(full)) {
+        yield full;
+      }
+    }
+  }
+
+  export function scanFile(path, symbols) {
+    const lines = readFileSync(path, 'utf8').split('\n');
+    const hits = [];
+    lines.forEach((line, i) => {
+      for (const sym of symbols) {
+        if (line.includes(sym)) {
+          hits.push({ line: i + 1, symbol: sym, text: line.trim() });
+        }
+      }
+    });
+    return hits;
+  }
+
+  export function guard(root, symbols, excludes = DEFAULT_EXCLUDES) {
+    const findings = [];
+    for (const file of walk(root, excludes)) {
+      for (const hit of scanFile(file, symbols)) {
+        findings.push({ file: relative(root, file), ...hit });
+      }
+    }
+    return findings;
+  }
+
+  function readSymbols(path) {
+    return readFileSync(path, 'utf8')
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l && !l.startsWith('#'));
+  }
+
+  function main() {
+    const { values } = parseArgs({
+      options: {
+        root: { type: 'string' },
+        symbols: { type: 'string' },
+      },
+    });
+    if (!values.root || !values.symbols) {
+      console.error('usage: guard-token-removal.mjs --root <dir> --symbols <symbols.txt>');
+      process.exit(2);
+    }
+    const symbols = readSymbols(values.symbols);
+    const findings = guard(values.root, symbols);
+    if (findings.length === 0) {
+      console.log(`token-removal guard: 0 references to ${symbols.length} symbol(s) — safe to remove.`);
+      return;
+    }
+    console.error(`token-removal guard: ${findings.length} remaining reference(s) — do NOT remove yet:`);
+    for (const f of findings) {
+      console.error(`  ${f.file}:${f.line}  ${f.symbol}  | ${f.text}`);
+    }
+    process.exit(1);
+  }
+
+  if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    main();
+  }
+  ```
+
+- [ ] **Step 5.4: Run the test to verify it passes**
+
+  Run: `node --test scripts/guard-token-removal.test.mjs`
+  Expected: PASS (`# pass 4`, `# fail 0`).
+
+- [ ] **Step 5.5: Run the full script test suite**
+
+  Run (from the repo root): `node --test`
+  Expected: all test files discovered recursively and green — `# tests 31`,
+  `# pass 31`, `# fail 0` (14 loader + 8 validator + 5 reverse-index + 4 guard).
+  Note: use bare `node --test` (auto-discovers `**/*.test.mjs`); `node --test scripts/`
+  errors on Node ≥21 because a directory positional is treated as a test name, and a
+  `scripts/*.test.mjs` glob misses the `scripts/lib/` subdirectory. This is the command
+  the README documents and the plugin should run before shipping script edits.
+
+- [ ] **Step 5.6: Commit**
+
+  ```bash
+  git add scripts/guard-token-removal.mjs scripts/guard-token-removal.test.mjs
+  git commit -m "feat: repo-wide token-removal guard — zero-reference grep before cleanup"
+  ```
+
+---
+
+## Task 6: Scripts README
+
+Document what the scripts are, the install-into-user-repo contract the skill follows,
+and how to run the tests.
+
+**Files:**
+- Create: `scripts/README.md`
+
+- [ ] **Step 6.1: Create the README**
+
+  Create `scripts/README.md` with exactly this content:
+
+  ````markdown
+  # ThroughLine scripts
+
+  The executable analog of `references/`: canonical, vetted, **zero-dependency** Node
+  (ESM) scripts that the brownfield skills install into a user's monorepo. Authored and
+  tested here; copied verbatim by `token-crosswalk-builder` into the user's
+  `packages/tokens/scripts/`.
+
+  | Script | Purpose | Installed as |
+  | --- | --- | --- |
+  | `validate-crosswalk.mjs` | Resolve every `newToken` against the DTCG token source; assert resolved value == `newValue`, N/N. The CI gate. | `tokens:validate` |
+  | `build-reverse-index.mjs` | Emit a `codeToken -> newToken` map from the crosswalk to semi-automate SCSS/Tailwind swaps. | `tokens:reverse-index` |
+  | `guard-token-removal.mjs` | Grep `.ts/.tsx` (minus generated + tests) for about-to-be-deleted symbols; blocks cleanup until zero references remain. | run during the cleanup phase |
+  | `lib/crosswalk.mjs` | Shared loader + structural validation for `crosswalk.json` (used by the validator and reverse-index). | copied alongside |
+  | `crosswalk.schema.json` | The finalized JSON Schema for `crosswalk.json` (contract + editor support). | copied beside `crosswalk.json` |
+
+  The crosswalk contract is documented in
+  `${CLAUDE_PLUGIN_ROOT}/references/crosswalk-schema.md`.
+
+  ## Usage
+
+  ```bash
+  node validate-crosswalk.mjs --crosswalk crosswalk.json --tokens dtcg/tokens.json
+  node build-reverse-index.mjs --crosswalk crosswalk.json --out crosswalk.reverse.json
+  node guard-token-removal.mjs --root . --symbols symbols-to-remove.txt
+  ```
+
+  Exit codes: `0` success, `1` validation/guard failure (mismatch, missing token,
+  conflict, or remaining reference), `2` bad CLI arguments.
+
+  ## How the skill installs these
+
+  `token-crosswalk-builder` copies `lib/crosswalk.mjs`, `validate-crosswalk.mjs`,
+  `build-reverse-index.mjs`, `guard-token-removal.mjs`, and `crosswalk.schema.json`
+  into the user's `packages/tokens/scripts/` (schema beside `crosswalk.json`), then
+  wires `packages/tokens/package.json`:
+
+  ```jsonc
+  "scripts": {
+    "tokens:validate": "node scripts/validate-crosswalk.mjs --crosswalk crosswalk.json --tokens dtcg/tokens.json",
+    "tokens:reverse-index": "node scripts/build-reverse-index.mjs --crosswalk crosswalk.json --out crosswalk.reverse.json"
+  }
+  ```
+
+  The scripts version with the user's repo so their CI runs them locally — a path
+  inside the plugin install would not be reachable from the user's CI.
+
+  ## Tests
+
+  Run the suite from the repo root (no install step — uses only Node built-ins):
+
+  ```bash
+  node --test
+  ```
+
+  This auto-discovers every `**/*.test.mjs` recursively (31 tests). Don't use
+  `node --test scripts/` — a directory positional is treated as a test name on
+  Node ≥21 and errors; a `scripts/*.test.mjs` glob silently skips `scripts/lib/`.
+  ````
+
+- [ ] **Step 6.2: Commit**
+
+  ```bash
+  git add scripts/README.md
+  git commit -m "docs: scripts README — purpose, install contract, test command"
+  ```
+
+---
+
+## Task 7: The `token-crosswalk-builder` skill
+
+The backbone skill. Builds `crosswalk.json`, installs the vetted scripts into the user's
+monorepo, wires `tokens:validate`, runs it green, and writes the `tokenCrosswalk`
+manifest section it owns. A `retrofit-planner` sub-skill — no slash command (mirrors
+`component-builder`).
+
+**Files:**
+- Create: `skills/token-crosswalk-builder/SKILL.md`
+
+- [ ] **Step 7.1: Create the skill**
+
+  Create `skills/token-crosswalk-builder/SKILL.md` with exactly this content:
+
+  ````markdown
+  ---
+  name: token-crosswalk-builder
+  description: Build the brownfield token crosswalk — a persistent three-way map between each new token, the old Figma variable, and the old code identifier(s) — as crosswalk.json, then install the vetted validator/reverse-index scripts into the monorepo and wire the tokens:validate CI gate. Use this when retrofitting a design system onto a mature codebase, when the user wants to map old tokens to new ones, build a crosswalk, set up tokens:validate, or generate a reverse index for SCSS/Tailwind swaps. Also trigger when retrofit-planner reaches the crosswalk stage, or after design-system-audit has sized the retrofit. Make sure to use this whenever someone needs the machine-readable backbone that drives a brownfield code retrofit and its validation gate.
+  ---
+
+  # Token crosswalk builder
+
+  Builds the **backbone artifact** of a brownfield retrofit: `crosswalk.json`, a
+  persistent three-way map of **new token ↔ old Figma variable ↔ old code identifier**.
+  It drives the code retrofit and the `tokens:validate` CI gate. This skill also
+  installs the canonical scripts into the user's repo and wires the gate.
+
+  This is a brownfield skill. **Before doing anything, read**
+  `${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md` (read discipline, the 7
+  guardrails, the safe sequence) and
+  `${CLAUDE_PLUGIN_ROOT}/references/crosswalk-schema.md` (the exact contract). Greenfield
+  builds don't need this skill.
+
+  ## Calibrate
+
+  Read `user.codingLevel` (`${CLAUDE_PLUGIN_ROOT}/references/coding-level.md`) and scale
+  explanation accordingly. The crosswalk involves JSON, npm scripts, and a CI gate — for
+  `new` users explain each plainly the first time; for `comfortable` users be terse.
+  Actions are identical across levels.
+
+  ## Prerequisites (offer to run them, don't bail)
+
+  Read the manifest. This skill needs:
+
+  1. **A DTCG token source** at `packages/tokens/dtcg/tokens.json` — the validator
+     resolves against it. If it doesn't exist, offer to run `token-sync-layer` first
+     (it emits this file). Apply the read discipline: confirm the file exists by
+     reading it, never assume it's absent without looking.
+  2. **The audit inputs** — ideally the `audit` manifest section (code surface,
+     Figma inventory, `percentSemantic`) populated by `design-system-audit`. If
+     `audit` is present, use it to seed the rows. If it is `null` (audit hasn't run —
+     it lands in Plan 3), don't block: ask the user for the old→new mapping inputs
+     directly (which old Figma variables and code symbols map to which new tokens),
+     and proceed. Note plainly that running `design-system-audit` first would
+     pre-fill this.
+  3. **A repo at `local-git` or `github`** (`workspace.stage`) so the installed
+     scripts and `package.json` changes land as a reviewable diff/PR. If still
+     `folder`, offer `repository-builder`.
+
+  ## Step 1 — Build `crosswalk.json`
+
+  Write `packages/tokens/crosswalk.json` per the contract in
+  `${CLAUDE_PLUGIN_ROOT}/references/crosswalk-schema.md`. One row per new token:
+
+  - `newToken` — the DTCG dot-path exactly as it appears in
+    `packages/tokens/dtcg/tokens.json` (e.g. `color.text.primary`).
+  - `newValue` — the **resolved** leaf value (follow `{…}` aliases to the literal).
+  - `tier` — `primitive` or `semantic`.
+  - `figmaOld` — the old Figma variable name/path, or `null` if newly added.
+  - `codeTokens[]` — the old code identifiers this token replaces (`$primary-red`,
+    `bg-primary-red`, `Colors.primaryRed`, `--primary-red`). May be `[]`.
+  - `status` — `aligned | renamed | drift-fix | added | mapped-nearest`. Assign by:
+    same name & value → `aligned`; same value, new name → `renamed`; value
+    intentionally changed → `drift-fix`; brand-new token → `added`; no exact old
+    equivalent, mapped to nearest → `mapped-nearest`.
+  - `recommendedSemantic` — optional semantic target for a raw/primitive usage, else
+    `null`.
+
+  Do not guess values. Every `newValue` comes from a read of the DTCG source, not an
+  assumption (read discipline).
+
+  ## Step 2 — Install the vetted scripts + wire `tokens:validate`
+
+  Copy these from `${CLAUDE_PLUGIN_ROOT}/scripts/` into the user's repo **verbatim**
+  (they are zero-dependency and version with the user's repo so their CI can run them):
+
+  - `lib/crosswalk.mjs` → `packages/tokens/scripts/lib/crosswalk.mjs`
+  - `validate-crosswalk.mjs` → `packages/tokens/scripts/validate-crosswalk.mjs`
+  - `build-reverse-index.mjs` → `packages/tokens/scripts/build-reverse-index.mjs`
+  - `guard-token-removal.mjs` → `packages/tokens/scripts/guard-token-removal.mjs`
+  - `crosswalk.schema.json` → `packages/tokens/crosswalk.schema.json` (beside
+    `crosswalk.json`, so the `$schema` pointer resolves)
+
+  Then add to `packages/tokens/package.json` `scripts` (don't clobber existing keys):
+
+  ```jsonc
+  "tokens:validate": "node scripts/validate-crosswalk.mjs --crosswalk crosswalk.json --tokens dtcg/tokens.json",
+  "tokens:reverse-index": "node scripts/build-reverse-index.mjs --crosswalk crosswalk.json --out crosswalk.reverse.json"
+  ```
+
+  See `${CLAUDE_PLUGIN_ROOT}/scripts/README.md` for the full install contract.
+
+  ## Step 3 — Run the gate (must pass N/N)
+
+  Run `npm run tokens:validate` (from `packages/tokens/`). It must report **N/N** —
+  every row's resolved value matches its `newValue`. If it reports mismatches or
+  missing tokens, fix the crosswalk (or the token source) and re-run. **Never proceed
+  on a red validator and never edit a generated token file to make it pass** — change
+  the source in Figma and re-sync (guardrail 7). The validator is the source of truth
+  that the crosswalk and the real tokens agree.
+
+  ## Step 4 — Generate the reverse index
+
+  Run `npm run tokens:reverse-index`. This writes `crosswalk.reverse.json`
+  (`codeToken → newToken`), which the code-retrofit phase uses to semi-automate the
+  SCSS/Tailwind swaps. If it reports conflicts (one old symbol mapping to two new
+  tokens), resolve them in the crosswalk before relying on the index.
+
+  ## Step 5 — Update the manifest
+
+  Write the `tokenCrosswalk` section **only** (this skill owns it; never write another
+  skill's fields):
+
+  - `path` — the actual path written (`"packages/tokens/crosswalk.json"`).
+  - `statusCounts` — copy the camelCase object the validator printed
+    (`{ aligned, renamed, driftFix, added, mappedNearest }`).
+  - `validatorPassing` — `true` once `tokens:validate` passes N/N.
+
+  Append `token-crosswalk-builder` to `completedSkills`.
+
+  ## What this skill must NOT do
+
+  - Never delete old tokens or outputs here — that's the cleanup phase, gated by the
+    token-removal guard returning zero references (safe sequence, guardrail 4).
+  - Never edit generated token files to make the validator pass — fix the source.
+  - Never write another skill's manifest fields (e.g. `tokens.intakeMode` is owned by
+    `design-system-audit`).
+  - Never proceed past a red `tokens:validate`.
+  - Never assert a prerequisite is absent without a verified read (read discipline).
+  ````
+
+- [ ] **Step 7.2: Self-review the skill against the spec**
+
+  Open spec §4.2 and confirm the skill delivers: the three-way map with the exact
+  columns; the `status` enum; the reverse index; the `tokens:validate` N/N gate. Open
+  §8 and confirm the skill writes only `tokenCrosswalk.{path, statusCounts,
+  validatorPassing}` and appends to `completedSkills` (ownership honored — it does NOT
+  set `tokens.intakeMode`). Confirm the frontmatter `name` matches the directory name
+  (`token-crosswalk-builder`) and the description trigger-phrasing matches house style
+  (compare to `skills/token-sync-layer/SKILL.md`). Fix any drift inline.
+
+- [ ] **Step 7.3: Commit**
+
+  ```bash
+  git add skills/token-crosswalk-builder/SKILL.md
+  git commit -m "feat: token-crosswalk-builder skill — build crosswalk, install scripts, wire tokens:validate"
+  ```
+
+---
+
+## Task 8: CHANGELOG + plugin-level self-review
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 8.1: Add the `[Unreleased]` entry**
+
+  Open `CHANGELOG.md` and read the existing `[Unreleased]` section (it carries the
+  Plan 1 brownfield entries). Add, under the appropriate `### Added` heading in
+  `[Unreleased]` (create the heading only if absent — match the existing structure),
+  these bullets:
+
+  ```markdown
+  - **`scripts/` directory** — the plugin's first executable code: canonical,
+    zero-dependency Node (ESM) scripts for brownfield retrofits, tested with
+    `node --test`.
+    - `validate-crosswalk.mjs` — the `tokens:validate` CI gate (resolved value ==
+      new value, N/N).
+    - `build-reverse-index.mjs` — code symbol → new token map for semi-automated
+      SCSS/Tailwind swaps.
+    - `guard-token-removal.mjs` — repo-wide zero-reference grep that blocks cleanup
+      while any reference to an about-to-be-deleted symbol remains.
+    - `lib/crosswalk.mjs` — shared loader + structural validation.
+  - **`crosswalk.json` schema** — finalized contract: `references/crosswalk-schema.md`
+    (prose) + `scripts/crosswalk.schema.json` (JSON Schema).
+  - **`token-crosswalk-builder` skill** — builds the new-token ↔ old-Figma ↔ old-code
+    crosswalk, installs the vetted scripts into `packages/tokens/`, wires
+    `tokens:validate`, and owns the `tokenCrosswalk` manifest section.
+  ```
+
+- [ ] **Step 8.2: Verify the full script test suite passes**
+
+  Run (from the repo root): `node --test`
+  Expected: all files green — `# tests 31`, `# pass 31`, `# fail 0`.
+
+- [ ] **Step 8.3: Verify the JSON Schema and the doc example are valid JSON**
+
+  ```bash
+  node -e "JSON.parse(require('fs').readFileSync('scripts/crosswalk.schema.json','utf8')); console.log('schema OK')"
+  ```
+
+  Expected: `schema OK`.
+
+- [ ] **Step 8.4: Commit**
+
+  ```bash
+  git add CHANGELOG.md
+  git commit -m "docs: CHANGELOG [Unreleased] — scripts dir, crosswalk schema, token-crosswalk-builder"
+  ```
+
+---
+
+## Self-Review (run after all tasks)
+
+**1. Spec coverage** (against `docs/superpowers/specs/2026-06-25-brownfield-retrofit-design.md`):
+- §4.2 `token-crosswalk-builder` — three-way map, exact columns, `status` enum, reverse
+  index, `tokens:validate` N/N gate, owns `tokenCrosswalk` → Tasks 1, 4, 7. ✓
+- §6 canonical scripts — crosswalk validator, reverse-index generator, token-removal
+  guard, shipped vetted → Tasks 3, 4, 5. ✓
+- §6 color-usage grep scaffold + binding-survival audit → **deferred to Plan 3** (see
+  Scope & boundaries; tied to `design-system-audit` / `token-builder` brownfield
+  branch). Confirm none of Plan 2's deliverables silently depend on them — they do not.
+- §8 manifest `tokenCrosswalk.{path, statusCounts, validatorPassing}` — written by the
+  skill (Task 7), camelCase counts produced by the validator (Task 3) and rolled up by
+  the loader (Task 2). The five `statusCounts` keys match `references/manifest-schema.md`. ✓
+- §11 Plan-2 risks: "finalize the crosswalk schema first" → Task 1 precedes every
+  consuming script. ✓ "ship vetted scripts is only partly achievable / log what's
+  assumed vs detected" → applies to the color-usage grep, which is deferred to Plan 3;
+  the three canonical scripts shipped here are genuinely generalizable (schema/arg-driven). ✓
+
+**2. Placeholder scan:** No "TBD"/"TODO"/"implement later". Every code step shows
+complete, runnable code; every run step shows the exact command and expected output.
+
+**3. Type/name consistency:**
+- `status` enum is identical across the schema JSON (Task 1), `STATUS_VALUES` (Task 2),
+  the reference doc (Task 1), and the skill (Task 7): `aligned, renamed, drift-fix,
+  added, mapped-nearest`.
+- `STATUS_COUNT_KEY` / `statusCounts` camelCase keys (`aligned, renamed, driftFix,
+  added, mappedNearest`) are identical in Task 2, the validator output (Task 3), the
+  reference doc (Task 1), and the skill's manifest write (Task 7).
+- Exported function names referenced in tests match their modules: `loadCrosswalk`,
+  `statusCounts`, `STATUS_VALUES`, `STATUS_COUNT_KEY` (Task 2); `flattenDtcg`,
+  `resolveValue`, `validate` (Task 3); `buildReverseIndex` (Task 4); `walk`, `scanFile`,
+  `guard`, `DEFAULT_EXCLUDES` (Task 5).
+- Field names (`newToken`, `newValue`, `tier`, `figmaOld`, `codeTokens`, `status`,
+  `recommendedSemantic`) are identical across the schema, loader validation, every test
+  fixture, and the skill.
+- Installed paths agree: `packages/tokens/scripts/...`, `packages/tokens/crosswalk.json`,
+  `packages/tokens/dtcg/tokens.json` in Task 6 (README), Task 7 (skill), and the
+  `tokens:validate` wiring.
+
+---
+
+## Execution Handoff
+
+Plan 2 of 3. After this ships, Plan 3 (the `design-system-audit` and `retrofit-planner`
+skills, the color-usage grep scaffold + binding-survival audit, brownfield branches in
+`token-builder`/`token-sync-layer`/`storybook-chromatic-builder`, env-setup
+routing+baseline, the decision journal, and the B3 behavioral fix) gets written and
+executed in turn.
+
+**Critical dependency note:** Plan 2 builds on Plan 1 (manifest v4 `tokenCrosswalk`
+section + `references/brownfield-retrofit.md`), which currently lives on the PR #12
+branch. This worktree already has those artifacts present, so execution can proceed
+here; if executing elsewhere, branch off the Plan 1 branch, not a stale `main`.

--- a/docs/superpowers/plans/2026-06-25-brownfield-foundation.md
+++ b/docs/superpowers/plans/2026-06-25-brownfield-foundation.md
@@ -1,0 +1,517 @@
+# Brownfield Retrofit — Plan 1: Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Lay the cross-cutting groundwork for brownfield retrofits — manifest v4 sections, a canonical brownfield reference with the 7 guardrails + verification triad, and the B1–B4 "never assert state without a verified read" hardening in the Figma scripting and environment-setup skills.
+
+**Architecture:** Four markdown-only file changes. (1) Extend `references/manifest-schema.md` to schemaVersion 4 with `audit` / `tokenCrosswalk` / `retrofit` sections, a `"retrofit"` intake mode, and clarified publish-state field docs (B3). (2) Create `references/brownfield-retrofit.md` as the canonical home for the unified read-discipline principle, the 7 DON'T guardrails, the safe sequence, and the verification triad. (3) Harden `references/figma-scripting.md`: live-vs-stale bridge-port discipline (B4) and a new read-discipline section (B1/B2). (4) Fix the `figma-environment-setup` Step 6 liveness check so it never reports counts from a cheap/early read (B1/B2). No executable code, no new skills, no routing changes (those land in Plan 3). Greenfield paths are untouched.
+
+**Tech Stack:** Markdown instruction files. No build, no automated tests (the plugin ships no test harness). Verification is a structured self-review checklist plus a JSON-validity check on the manifest schema block, matching the house style of prior plans in `docs/superpowers/plans/`.
+
+---
+
+## File Map
+
+| Action | File | What changes |
+|---|---|---|
+| Modify | `references/manifest-schema.md` | Bump schemaVersion 3→4; add `audit`, `tokenCrosswalk`, `retrofit` to JSON block + field docs; add `"retrofit"` to `tokens.intakeMode`; clarify `figma.canPublish`/`libraryPublished` docs for B3 |
+| Create | `references/brownfield-retrofit.md` | Unified read-discipline principle (B1–B4); the 7 DON'T guardrails; the safe retrofit sequence; the verification triad |
+| Modify | `references/figma-scripting.md` | Rewrite the bridge-instance preflight for live-vs-stale (B4); add a "Read discipline" section (B1/B2) |
+| Modify | `skills/figma-environment-setup/SKILL.md` | Step 6: apply read discipline — prove connection cheaply, never report inventory counts from that probe; point at the new reference |
+
+---
+
+## Task 1: Manifest schema → v4
+
+**Files:**
+- Modify: `references/manifest-schema.md`
+
+- [ ] **Step 1.1: Bump the schemaVersion in the heading and JSON block**
+
+  In `references/manifest-schema.md`, change the section heading on line 14 from:
+
+  ```markdown
+  ## Schema (schemaVersion 3)
+  ```
+
+  to:
+
+  ```markdown
+  ## Schema (schemaVersion 4)
+  ```
+
+  And in the JSON block, change line 18 from:
+
+  ```json
+    "schemaVersion": 3,
+  ```
+
+  to:
+
+  ```json
+    "schemaVersion": 4,
+  ```
+
+- [ ] **Step 1.2: Add the three new sections to the JSON schema block**
+
+  In the JSON block, find the `storybook` block and the trailing `completedSkills`
+  line (lines 81–86):
+
+  ```json
+    "storybook": {
+      "initialized": false,
+      "chromatic": false,
+      "codeConnect": false
+    },
+    "completedSkills": []
+  }
+  ```
+
+  Replace it with (insert the three new sections before `completedSkills`):
+
+  ```json
+    "storybook": {
+      "initialized": false,
+      "chromatic": false,
+      "codeConnect": false
+    },
+    "audit": {
+      "ranAt": null,
+      "codeSurface": null,
+      "figmaInventory": null,
+      "percentSemantic": null
+    },
+    "tokenCrosswalk": {
+      "path": null,
+      "statusCounts": null,
+      "validatorPassing": null
+    },
+    "retrofit": {
+      "phase": null,
+      "startedAt": null,
+      "completedAt": null,
+      "journalScaffolded": false
+    },
+    "completedSkills": []
+  }
+  ```
+
+  Defaults are `null` ("not yet run") rather than `false`/`{}` so downstream skills
+  can distinguish "audit has never run" from "audit ran and found nothing" — the
+  same `null`-vs-`false` discipline already used for `workspace.detectedLayers`.
+
+- [ ] **Step 1.3: Add `"retrofit"` to the `tokens.intakeMode` documentation**
+
+  In the `### tokens` field reference, find the `intakeMode` bullet (lines 171–173):
+
+  ```markdown
+  - `intakeMode` — how the user started: `"generative"` (seed expanded by AI),
+    `"descriptive"` (from aesthetic direction), or `"import"` (existing set
+    organized). Recorded so later runs know how the system was built.
+  ```
+
+  Replace it with:
+
+  ```markdown
+  - `intakeMode` — how the user started: `"generative"` (seed expanded by AI),
+    `"descriptive"` (from aesthetic direction), `"import"` (existing set
+    organized), or `"retrofit"` (a mature codebase **and** a populated Figma file
+    reconciled onto tokens — the brownfield path; differs from `"import"` by having
+    existing code bindings to inspect and converge). Recorded so later runs know how
+    the system was built.
+  ```
+
+- [ ] **Step 1.4: Clarify the B3 publish-state field docs**
+
+  In the `### figma` field reference, find the `canPublish` and `libraryPublished`
+  bullets (lines 160–166):
+
+  ```markdown
+  - `canPublish` — whether the user can publish a Figma **team library** (requires
+    a paid plan, Professional+). `true` / `false` / `null` (unknown / not yet
+    asked). Asked once and recorded; gates the typed instance-swap dropdown path.
+    See `${CLAUDE_PLUGIN_ROOT}/references/figma-publishing.md`.
+  - `libraryPublished` — whether the user has published the file as a library at
+    least once (so local component keys resolve for `INSTANCE_SWAP`). User-driven
+    and manual; the plugin verifies, never publishes.
+  ```
+
+  Replace with:
+
+  ```markdown
+  - `canPublish` — whether the user can publish a Figma **team library** (requires
+    a paid plan, Professional+). `true` / `false` / `null` (unknown / not yet
+    asked). Asked once and recorded; gates the typed instance-swap dropdown path.
+    See `${CLAUDE_PLUGIN_ROOT}/references/figma-publishing.md`.
+  - `libraryPublished` — whether the user has published the file as a library at
+    least once (so local component keys resolve for `INSTANCE_SWAP`). User-driven
+    and manual; the plugin verifies, never publishes. **Treat the default `false`
+    as _unverified_, not "definitely not published" (bug B3): before asserting a
+    library is unpublished, attempt detection (`figma_get_library_components` /
+    `figma_get_library_variables`); if detection is inconclusive, ask the user once
+    and record the answer here. Never silently assume unpublished — see the read
+    discipline in `${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md`.**
+  ```
+
+- [ ] **Step 1.5: Add field-reference docs for the three new sections**
+
+  In the field reference, find the `### storybook` block (lines 247–250) and insert
+  three new field-reference blocks immediately after it, before `### completedSkills`:
+
+  ```markdown
+  ### `audit`
+  Populated by the `design-system-audit` skill (brownfield front door). `null` in
+  every field until that skill runs. Records the measured state of a pre-existing
+  system so the retrofit can be right-sized.
+  - `ranAt` — ISO timestamp the audit last ran.
+  - `codeSurface` — object of counts sizing the code-side retrofit, e.g.
+    `{ "scssColorVars": 692, "tailwindColorClasses": 230, "jsColorsUsages": 74,
+    "rawHexRgba": 143, "svgFills": 430 }`. Keys vary by what the repo actually uses.
+  - `figmaInventory` — object snapshot of the existing Figma file from explicit
+    per-class reads, e.g. `{ "variables": 0, "bindings": 0, "textStyles": 0,
+    "effectStyles": 0, "modes": [] }`. Each count comes from a verified read, never
+    an assumption (see `brownfield-retrofit.md`).
+  - `percentSemantic` — integer 0–100: how much of the existing system is already
+    semantic. The single number that decides rename+cleanup vs. rewrite.
+
+  ### `tokenCrosswalk`
+  Populated by the `token-crosswalk-builder` skill. Points at the backbone artifact
+  that maps new token ↔ old Figma token ↔ code identifier.
+  - `path` — repo-relative path to the crosswalk file (e.g. `"tokens/crosswalk.json"`),
+    or `null` if not yet built. The manifest stores the pointer, not the map.
+  - `statusCounts` — object counting crosswalk rows by `status`, e.g.
+    `{ "aligned": 12, "renamed": 151, "driftFix": 2, "added": 42, "mappedNearest": 3 }`.
+  - `validatorPassing` — `true`/`false`/`null`: whether the last crosswalk validator
+    run passed (resolved value == new value for every row).
+
+  ### `retrofit`
+  Populated by the `retrofit-planner` orchestrator. Tracks where a multi-phase
+  retrofit stands so a later session can resume.
+  - `phase` — one of `"audit"`, `"refine"`, `"rebind"`, `"sync"`, `"baseline"`,
+    `"code"`, `"cleanup"`, `"done"`, or `null` (no retrofit in progress). Phases run
+    in that order; see the safe sequence in
+    `${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md`.
+  - `startedAt` / `completedAt` — ISO timestamps bounding the retrofit.
+  - `journalScaffolded` — whether the `docs/design-system/` decision journal has been
+    created for this retrofit (offered default-on by `retrofit-planner`).
+  ```
+
+- [ ] **Step 1.6: Verify the JSON schema block is valid JSON**
+
+  Run (from the repo root):
+
+  ```bash
+  python3 -c "import json,re,sys; t=open('references/manifest-schema.md').read(); m=re.search(r'\`\`\`json\n(\{.*?\n\})\n\`\`\`', t, re.S); json.loads(m.group(1)); print('valid JSON, schemaVersion =', json.loads(m.group(1))['schemaVersion'])"
+  ```
+
+  Expected output:
+
+  ```
+  valid JSON, schemaVersion = 4
+  ```
+
+  If it errors, fix the trailing-comma / brace problem it reports and re-run.
+
+- [ ] **Step 1.7: Self-review the schema edit**
+
+  Confirm, by re-reading the changed regions:
+  - The JSON block and the field-reference prose agree on every new field name
+    (`audit.ranAt`, `audit.codeSurface`, `audit.figmaInventory`, `audit.percentSemantic`,
+    `tokenCrosswalk.path/statusCounts/validatorPassing`,
+    `retrofit.phase/startedAt/completedAt/journalScaffolded`).
+  - The migration rule already in the doc ("Migrate forward on `schemaVersion`
+    mismatch", rules section) still covers v3→v4 — it does, because it adds missing
+    fields with defaults. No edit needed there.
+
+- [ ] **Step 1.8: Commit**
+
+  ```bash
+  git add references/manifest-schema.md
+  git commit -m "feat: manifest schema v4 — audit, tokenCrosswalk, retrofit sections + B3 publish-state doc"
+  ```
+
+---
+
+## Task 2: Create the brownfield-retrofit reference
+
+**Files:**
+- Create: `references/brownfield-retrofit.md`
+
+- [ ] **Step 2.1: Create the file with the full canonical content**
+
+  Create `references/brownfield-retrofit.md` with exactly this content:
+
+  ```markdown
+  # Brownfield retrofit — read discipline, guardrails, safe sequence
+
+  Canonical reference for retrofitting a design system onto a **mature codebase and
+  an already-populated Figma file** (the brownfield path), as opposed to building
+  greenfield. Read this before running `design-system-audit`, `token-crosswalk-builder`,
+  `retrofit-planner`, or any brownfield branch of `token-builder`, `token-sync-layer`,
+  or `storybook-chromatic-builder`.
+
+  ## The read-discipline principle (fixes bugs B1–B4)
+
+  **Never assert that something is absent, empty, unpublished, or stale without an
+  explicit, completed read that returned that result.** "I didn't find X" must mean
+  "I queried for X and the result was empty (after the file and all pages fully
+  loaded)," never "I assumed X from Y." When a result is genuinely undetectable, ask
+  the user once and persist the answer in the manifest — never guess.
+
+  Concrete applications:
+
+  - **Variables (B1).** Before counting variables, `await figma.loadAllPagesAsync()`.
+    Treat a `0` count on a first read as suspect — re-read before reporting. An
+    unexpectedly-empty result is a possible read/cache error, not ground truth. Prefer
+    the dedicated `figma_get_variables` tool over a hand-written probe.
+  - **Styles vs. variables (B2).** Text styles, effect/paint styles, and variables are
+    **different surfaces**. Absence of variables says nothing about styles. Query each
+    independently — variables (`figma_get_variables`), text styles
+    (`figma_get_text_styles`), effect/paint styles (`figma_get_styles`) — and only
+    report "none" for the specific class whose own read returned empty.
+  - **Publish state (B3).** Treat a default/`false` `figma.libraryPublished` as
+    _unverified_. Attempt detection first (`figma_get_library_components` /
+    `figma_get_library_variables`, library component keys). If inconclusive, ask once
+    ("Is this library published to a team library?") and persist to
+    `figma.libraryPublished` / `figma.canPublish`. Frame the unpublished path as a
+    graceful choice, not a failure.
+  - **Bridge ports (B4).** Distinguish *live* concurrent bridge instances from
+    *dead/stale* entries. Only block on genuinely live ones; reap or offer one-click
+    cleanup for stale ones. See the bridge-instance preflight in
+    `${CLAUDE_PLUGIN_ROOT}/references/figma-scripting.md`.
+
+  ## The 7 guardrails (hard "DON'T" rules)
+
+  Each cost real debugging time on a live retrofit. Treat each as a hard rule.
+
+  1. **Don't bind line-height / letter-spacing variables to text styles.** Figma stores
+     them as PERCENT; a unitless ratio var (`1.6`) rebinds as `1.6px` — catastrophic.
+     **Font-size binding only** (px→px is safe).
+  2. **Don't normalize float32 in Figma** — it is a no-op (Figma re-quantizes to float32
+     on store). Normalize at the export boundary instead (`Math.round(v*100)/100`).
+  3. **Don't delete-and-recreate variables to rename** — it unbinds everything. Rename
+     in place to preserve Figma IDs (and therefore every existing binding).
+  4. **Don't trust `tsc` / build to catch Tailwind color-utility removal** — deleted
+     utilities become *silent no-ops*. Guard repo-wide (all `.tsx/.ts` minus generated
+     + tests), and let Chromatic be the net.
+  5. **Don't assume `build-storybook` exercises all SCSS** — story-unreachable modules
+     (and a dead `@import` of a deleted partial) only fail when the real app renders.
+     Run the app and spot-check 5–7 routes before declaring an SCSS change done.
+  6. **Don't carry `/opacity` modifiers onto var-based tokens** — convert to
+     `color-mix(in srgb, var(--…) NN%, transparent)` or channel-based alpha.
+  7. **Don't hand-edit generated files** — change the source and re-run `tokens:sync`.
+
+  ## The safe retrofit sequence
+
+  Run these phases in order; `retrofit-planner` gates each one with a human
+  confirmation. The ordering rules are not arbitrary — each prevents a specific class
+  of damage.
+
+  1. **audit** — measure both sides (`design-system-audit`). Size the code surface and
+     inventory the Figma file with verified per-class reads.
+  2. **refine** — rename/realign variables **in place** (`token-builder` brownfield
+     branch). Never delete-and-recreate (guardrail 3); run a binding-survival audit.
+  3. **rebind** — reconcile components onto the refined variables, preserving IDs.
+  4. **sync** — run the sync layer with the brownfield transforms (alpha channels,
+     opacity 0–100→0–1, float32 rounding at the export boundary).
+  5. **baseline** — capture a Chromatic baseline **before** any code retrofit, so
+     intended drift-fixes are distinguishable from regressions.
+  6. **code** — retrofit the codebase with **dual output**: new and old tokens coexist
+     during the transition.
+  7. **cleanup** — remove old outputs **only** after a zero-reference grep passes (the
+     repo-wide token-removal guard).
+
+  ## The verification triad
+
+  No single check catches everything; all three are necessary on every retrofit:
+
+  1. **`check-types`** (TypeScript) — blind to Tailwind silent no-ops.
+  2. **`build-storybook` + Chromatic snapshots** — the visual-regression net; blind to
+     story-unreachable code. **Chromatic, not `tsc`/build, is the source of truth** for
+     color-utility removal.
+  3. **Run the actual app** + spot-check real routes — the only thing that exercises
+     story-unreachable SCSS.
+  ```
+
+- [ ] **Step 2.2: Self-review against the spec**
+
+  Open `docs/superpowers/specs/2026-06-25-brownfield-retrofit-design.md` §3 and §7.
+  Confirm the new reference contains: the unified principle with all four bug
+  applications (B1–B4), all 7 guardrails verbatim in intent, the 7-phase safe
+  sequence with the same phase names as the `retrofit.phase` enum in Task 1
+  (`audit/refine/rebind/sync/baseline/code/cleanup/done`), and the 3-part
+  verification triad. Fix any drift inline.
+
+- [ ] **Step 2.3: Commit**
+
+  ```bash
+  git add references/brownfield-retrofit.md
+  git commit -m "feat: add brownfield-retrofit reference — read discipline, 7 guardrails, safe sequence, verification triad"
+  ```
+
+---
+
+## Task 3: Harden figma-scripting.md (B4 + B1/B2)
+
+**Files:**
+- Modify: `references/figma-scripting.md`
+
+- [ ] **Step 3.1: Rewrite the bridge-instance preflight for live-vs-stale (B4)**
+
+  In `references/figma-scripting.md`, replace the entire
+  "## Preflight: one bridge instance per file (concurrent-write corruption)"
+  section (lines 10–18) with:
+
+  ```markdown
+  ## Preflight: one *live* bridge instance per file (concurrent-write corruption)
+
+  Before any write, call **`figma_get_status`** and inspect `otherInstances`.
+  Concurrent writes from two **live** Desktop Bridge instances connected to the same
+  `fileKey` collide and produce **truncated parent frames and orphaned node
+  fragments** at negative coordinates — damage a screenshot won't reveal. So a second
+  *live* instance is a hard stop.
+
+  **But do not hard-block on _stale_ entries (bug B4).** Users routinely hit a wall
+  where `otherInstances` lists ports they never opened — phantom/stale connections
+  left by a plugin reload, a file switch, or an MCP reconnect that spawned a new port
+  without reaping the old one. Telling them to "close the other instance" is useless
+  when they never opened one. Distinguish the two cases before blocking:
+
+  1. **Verify liveness, don't assume it.** Treat an `otherInstances` entry as
+     *suspected stale* until confirmed live. If the MCP exposes a liveness/heartbeat
+     signal, use it; otherwise attempt a `figma_reconnect` (or re-read
+     `figma_get_status`) — stale ports typically drop out after a reconnect.
+  2. **Only the genuinely-live count blocks.** If exactly one live instance remains
+     after reaping stale entries, proceed. Only block when **two or more** instances
+     are confirmed live.
+  3. **If you must block, be actionable.** Name the exact ports, state which are
+     suspected stale vs. live, and give a concrete clear path (run `figma_reconnect`,
+     reload the bridge plugin, or restart the MCP client) — never a bare "shut down
+     the others." If only stale entries remain and they won't clear, say so plainly
+     and let the user proceed rather than dead-ending them.
+
+  This is the bridge-side application of the read-discipline principle
+  (`${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md`): don't assert "another
+  instance is active" without confirming it's actually live.
+  ```
+
+- [ ] **Step 3.2: Add a read-discipline section (B1/B2)**
+
+  Immediately after the section you just rewrote (before
+  "## `dynamic-page` mode: use the async APIs"), insert:
+
+  ```markdown
+  ## Read discipline: never report "empty" without a verified read (B1/B2)
+
+  Before reporting that a file has no variables, no text styles, or no effect styles,
+  you MUST have run an explicit read **for that specific class** that returned empty —
+  after the file is fully loaded. Two real bugs came from violating this:
+
+  - **B1** — a first read returned `0` variables on a fully-populated file (stale/early
+    read) and was reported as fact. **Fix:** `await figma.loadAllPagesAsync()` before
+    counting; treat a `0` on first read as suspect and re-read before reporting; prefer
+    the dedicated `figma_get_variables` tool (handles `dynamic-page`, resolves aliases).
+  - **B2** — "no text styles" was asserted because no text *variables* were found —
+    styles were never read. **Fix:** variables and styles are different surfaces. Read
+    each independently: variables (`figma_get_variables`), text styles
+    (`figma_get_text_styles`), effect/paint styles (`figma_get_styles`). Report "none"
+    only for the class whose own read came back empty.
+
+  An unexpectedly-empty result is a possible read error, not ground truth. See the
+  full principle in `${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md`.
+  ```
+
+- [ ] **Step 3.3: Self-review**
+
+  Re-read the two new/changed sections. Confirm: the preflight no longer instructs an
+  unconditional "stop and warn"; it blocks only on ≥2 confirmed-live instances and
+  gives actionable guidance otherwise. Confirm the read-discipline section names the
+  three distinct read tools and cross-links `brownfield-retrofit.md`. Confirm the file
+  still reads coherently top-to-bottom (the intro paragraph on lines 3–8 still fits).
+
+- [ ] **Step 3.4: Commit**
+
+  ```bash
+  git add references/figma-scripting.md
+  git commit -m "fix: bridge-port live-vs-stale discipline (B4) + read discipline section (B1/B2)"
+  ```
+
+---
+
+## Task 4: Fix the figma-environment-setup liveness read (B1/B2)
+
+**Files:**
+- Modify: `skills/figma-environment-setup/SKILL.md`
+
+- [ ] **Step 4.1: Rewrite the Step 6 liveness probe so it never reports inventory counts**
+
+  In `skills/figma-environment-setup/SKILL.md`, find the opening paragraph of
+  "## Step 6 — Liveness check (prove it actually works)" (lines 322–326):
+
+  ```markdown
+  Don't declare success on faith. Run one trivial **read** against Figma to prove
+  the connection is live — for example, fetch a quick summary of the file's
+  existing variables/styles (a low-cost call). If it succeeds:
+  ```
+
+  Replace with:
+
+  ```markdown
+  Don't declare success on faith. Run one trivial **read** against Figma to prove
+  the connection is live — for example, a low-cost call such as reading the file
+  name or a single variable collection. This probe proves *connectivity only*.
+
+  **Do not report an inventory from this probe (bugs B1/B2).** A cheap or early read
+  can come back empty on a fully-populated file (pages not yet loaded, cache/read
+  error), and reporting "0 variables" or "no text styles" off the back of it is a
+  confidence-destroying first impression. Proving the connection is live is a
+  separate concern from inventorying what's in the file — the full per-class
+  inventory (with `loadAllPagesAsync` and independent reads for variables, text
+  styles, and effect styles) belongs to the `design-system-audit` skill, which
+  applies the read discipline in
+  `${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md`. Here, only confirm the
+  call succeeded — never announce counts.
+
+  If the liveness probe succeeds:
+  ```
+
+- [ ] **Step 4.2: Self-review**
+
+  Re-read Step 6 end-to-end. Confirm: the success branch (set `figma.connected`,
+  `lastVerified`, append to `completedSkills`) and both failure branches (A: server
+  never started; B: connection failed) are unchanged and still flow correctly after
+  the rewritten opening. Confirm the skill no longer instructs reporting a
+  variable/style summary to the user at this step.
+
+- [ ] **Step 4.3: Commit**
+
+  ```bash
+  git add skills/figma-environment-setup/SKILL.md
+  git commit -m "fix: env-setup liveness proves connectivity only, never reports inventory (B1/B2)"
+  ```
+
+---
+
+## Self-Review (run after all tasks)
+
+**1. Spec coverage** (against `docs/superpowers/specs/2026-06-25-brownfield-retrofit-design.md`):
+- §3 unified principle (B1–B4) → Task 2 (reference) + Task 3 (figma-scripting) + Task 4 (env-setup). ✓
+- §7 guardrails + safe sequence + verification triad → Task 2. ✓
+- §8 manifest v4 (`audit`, `tokenCrosswalk`, `retrofit`, `intakeMode` retrofit, B3 doc) → Task 1. ✓
+- §4/§5 new skills, branches, routing, baseline, scripts, journal → **deferred to Plans 2 & 3** (out of scope here, by design). Confirm none were accidentally required by Plan 1's edits — they are not; Plan 1 only references the future skills by name in docs.
+
+**2. Placeholder scan:** No "TBD"/"TODO"/"implement later" in any task. Every edit shows the exact before/after text.
+
+**3. Type/name consistency:** The `retrofit.phase` enum values in Task 1 Step 1.5
+(`audit/refine/rebind/sync/baseline/code/cleanup/done`) match the safe-sequence phase
+names in Task 2 Step 2.1. The new manifest field names in the JSON block (Task 1
+Step 1.2) match the field-reference prose (Task 1 Step 1.5). The reference filename
+`brownfield-retrofit.md` is identical across Tasks 1, 3, and 4 cross-links.
+
+---
+
+## Execution Handoff
+
+Plan 1 of 3. After this ships, Plan 2 (scripts + crosswalk skill) and Plan 3 (audit/
+retrofit-planner skills, existing-skill brownfield branches, env-setup routing+baseline,
+journal) get written and executed in turn.

--- a/docs/superpowers/plans/2026-06-26-brownfield-skills.md
+++ b/docs/superpowers/plans/2026-06-26-brownfield-skills.md
@@ -1,0 +1,1537 @@
+# Brownfield Retrofit — Plan 3: Audit + Retrofit-Planner Skills, Brownfield Branches Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the rest of the brownfield capability — the `design-system-audit` front-door skill, the `retrofit-planner` orchestrator, the color-usage grep scaffold + binding-survival audit snippet, the brownfield branches of the four existing skills (`figma-environment-setup`, `token-builder`, `token-sync-layer`, `storybook-chromatic-builder`), the B3 detect-or-ask publish-state behavioral fix, and the `/design-system-status` + `/start` surfacing — closing every carry-forward risk the spec assigned to Plan 3.
+
+**Architecture:** Plan 1 laid the foundation (manifest v4 with `audit`/`tokenCrosswalk`/`retrofit` sections, `references/brownfield-retrofit.md`, the B1/B2/B4 read-discipline docs in `figma-scripting.md`). Plan 2 shipped the crosswalk backbone (schema, scripts, `token-crosswalk-builder`). Plan 3 wires the brownfield path end-to-end so a real retrofit can run: a new PROCESS skill (`design-system-audit`) measures both sides of a mature system, a new orchestrator (`retrofit-planner`) sequences the safe 7-phase retrofit with a human gate per phase, and the four greenfield skills gain *additive* brownfield branches that all read the canonical `brownfield-retrofit.md` at the right moment. The one new executable is `scripts/grep-color-usage.mjs` — a repo-shaped scaffold (ships sensible default patterns, logs assumed-vs-detected) that the audit skill runs against the user's repo; everything else is markdown skill/reference/command edits. Greenfield paths stay untouched; brownfield is added strictly as branches.
+
+**Tech Stack:** Node.js (≥18) ESM for the one new script, `node:test` + `node:assert` (zero deps, matching `scripts/` house style). Markdown for the skills, references, and commands, matching the house style in `skills/`, `references/`, and `commands/`. The audit skill consumes the Figma Console MCP per-class read tools (`figma_get_variables`, `figma_get_text_styles`, `figma_get_styles`) under the read discipline; `retrofit-planner` invokes sub-skills via the Skill tool (mirroring `component-pipeline`).
+
+---
+
+## Scope & boundaries
+
+**In scope (this plan — closes §4.1, §4.3, §5, §6 remainder, and all Plan-3 carry-forward risks in §11):**
+- `scripts/grep-color-usage.mjs` + `scripts/grep-color-usage.test.mjs` — the color-usage grep scaffold (§6 skill-adapted).
+- `references/figma-scripting.md` — add the binding-survival audit `figma_execute` snippet (§6 "stays in references/").
+- `skills/design-system-audit/SKILL.md` — the brownfield front-door PROCESS skill (§4.1).
+- `skills/retrofit-planner/SKILL.md` — the orchestrator (§4.3).
+- Brownfield branches (§5): `figma-environment-setup` (detection + routing + baseline), `token-builder` (refine-in-place), `token-sync-layer` + `references/sync-adapters.md` (transforms), `storybook-chromatic-builder` (baseline-before-retrofit + verification triad).
+- B3 behavioral fix (§10/§11): `references/figma-publishing.md` + `skills/component-builder/SKILL.md` — detect-or-ask publish state.
+- `commands/design-system-status.md` — surface `audit` / `tokenCrosswalk` / `retrofit` (§11).
+- `commands/start.md` — brownfield/resume routing note (§11; substantive routing lands in `figma-environment-setup`, Task 4).
+- `CHANGELOG.md` — `[Unreleased]` entry.
+
+**Deliberately out of scope:**
+- **Plugin CI / automated SKILL.md + manifest-schema validation** — §11 marks this "cross-cutting (not plan-specific)". Markdown self-checks + review remain the net, as in Plans 1–2. Noted, not built.
+- **Automating Figma library publishing** — §9: never publish, only detect-or-ask (that *is* in scope, via B3).
+- **Non-color token retrofits** beyond the crosswalk pattern already shipped (§9).
+- **Rewriting greenfield skill paths** — §9: brownfield is added as branches only.
+
+---
+
+## File Map
+
+| Action | File | What changes |
+|---|---|---|
+| Create | `scripts/grep-color-usage.mjs` | `DEFAULT_CATEGORIES`, `walk`, `scanFile`, `grepColorUsage`, CLI `main()` — repo-shaped color-surface sizer (logs assumed vs detected patterns) |
+| Create | `scripts/grep-color-usage.test.mjs` | Tests: per-category counting, file-type gating, excludes, custom-config override |
+| Modify | `references/figma-scripting.md` | Add the **binding-survival audit** `figma_execute` snippet (count bindings before/after a rename) |
+| Create | `skills/design-system-audit/SKILL.md` | The brownfield front-door PROCESS skill — sizes code surface, inventories Figma per-class, computes `percentSemantic`, owns `audit.*`, sets `tokens.intakeMode: "retrofit"` |
+| Create | `skills/retrofit-planner/SKILL.md` | The orchestrator — gated 7-phase safe sequence, decision-journal offer, owns `retrofit.*`, appends `completedSkills` |
+| Modify | `skills/figma-environment-setup/SKILL.md` | Brownfield detection + routing to `design-system-audit`, resume routing on `retrofit.phase`, pre-mutation baseline checkpoint |
+| Modify | `skills/token-builder/SKILL.md` | Refine-in-place branch (rename preserving IDs, binding-survival audit, never delete-and-recreate) |
+| Modify | `skills/token-sync-layer/SKILL.md` | Brownfield transforms: alpha channels, float32 rounding at export boundary, `/opacity`→`color-mix` |
+| Modify | `references/sync-adapters.md` | Document the brownfield value transforms (channel alpha, float rounding, `color-mix`) |
+| Modify | `skills/storybook-chromatic-builder/SKILL.md` | Baseline-before-retrofit guidance + the verification triad + the `tsc`-blind / story-unreachable warnings |
+| Modify | `references/figma-publishing.md` | B3: detect-first (`figma_get_library_components`/`_variables`), then ask-once, then persist |
+| Modify | `skills/component-builder/SKILL.md` | B3: treat default/`false` `libraryPublished` as *unverified*; gate the upgrade pass on confirmed-true |
+| Modify | `commands/design-system-status.md` | Report `audit` / `tokenCrosswalk` / `retrofit`; suggest next brownfield step |
+| Modify | `commands/start.md` | Note that an existing/in-progress system routes into the audit / resumes mid-retrofit |
+| Modify | `CHANGELOG.md` | `[Unreleased]` entry for the Plan-3 skills, branches, script, and B3 fix |
+
+---
+
+## Dependency order (why the tasks run in this sequence)
+
+1. **Task 1** (color-usage grep) — a dependency of `design-system-audit` (it runs the script). Build and test it first.
+2. **Task 2** (binding-survival audit snippet) — a dependency of both `design-system-audit` (feeds `figmaInventory.bindings`) and the `token-builder` brownfield branch. Doc-only.
+3. **Task 3** (`design-system-audit`) — consumes Tasks 1 & 2; writes `audit.*`; the front door every later skill reads.
+4. **Task 4** (`figma-environment-setup` branch) — routes *into* `design-system-audit` (Task 3 must exist to name it) and resumes on `retrofit.phase`.
+5. **Tasks 5–7** (brownfield branches in `token-builder`, `token-sync-layer`, `storybook-chromatic-builder`) — independent of each other; all read `brownfield-retrofit.md`.
+6. **Task 8** (B3 fix) — independent; touches `figma-publishing.md` + `component-builder`.
+7. **Task 9** (`retrofit-planner`) — orchestrates Tasks 3, 5, 6, 7 and the existing `token-crosswalk-builder`; written after the skills it sequences exist.
+8. **Task 10** (`/design-system-status` + `/start` surfacing) — reports sections the earlier tasks populate.
+9. **Task 11** (CHANGELOG + plugin-level self-review).
+
+---
+
+## Task 1: Color-usage grep scaffold (`scripts/grep-color-usage.mjs`)
+
+The surface-measurement worklist generator (spec §4.1 step 1, §6 "skill-adapted scaffold"). Counts the five color-decision categories from the case study (SCSS color vars 692, Tailwind color classes 230, `Colors.*` 74, raw hex+rgba ~143, SVG fills 430). It is **inherently repo-shaped**, so it ships sensible default patterns **and** accepts a `--config` override; per §11 it must **log plainly which categories used the assumed defaults vs. a detected/override pattern**, so coverage is never silently partial. Matches the zero-dependency `node:test` house style of the existing `scripts/`.
+
+**Files:**
+- Create: `scripts/grep-color-usage.mjs`
+- Test: `scripts/grep-color-usage.test.mjs`
+
+- [ ] **Step 1.1: Write the failing test**
+
+  Create `scripts/grep-color-usage.test.mjs`:
+
+  ```javascript
+  import { test } from 'node:test';
+  import assert from 'node:assert/strict';
+  import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+  import { tmpdir } from 'node:os';
+  import { join } from 'node:path';
+  import { grepColorUsage, scanFile, DEFAULT_CATEGORIES } from './grep-color-usage.mjs';
+
+  function fixtureTree() {
+    const root = mkdtempSync(join(tmpdir(), 'grep-color-'));
+    // SCSS color vars + a raw hex literal on the same file
+    writeFileSync(join(root, 'theme.scss'), '$primary-red: #ff0000;\n$grey-900: #111827;\n.x { color: $primary-red; }\n');
+    // Tailwind color classes + a Colors.* usage
+    writeFileSync(join(root, 'App.tsx'), 'const c = "bg-primary-red text-grey-900";\nconst d = Colors.primaryRed;\n');
+    // SVG hardcoded fill (and one that must be ignored)
+    writeFileSync(join(root, 'logo.svg'), '<path fill="#ff0000"/><path fill="none"/><path fill="currentColor"/>\n');
+    // excluded surfaces
+    mkdirSync(join(root, 'node_modules', 'pkg'), { recursive: true });
+    writeFileSync(join(root, 'node_modules', 'pkg', 'index.ts'), 'const m = "bg-primary-red";\n');
+    mkdirSync(join(root, 'generated'), { recursive: true });
+    writeFileSync(join(root, 'generated', 'tokens.scss'), '$primary-red: #ff0000;\n');
+    writeFileSync(join(root, 'App.test.tsx'), 'const t = "bg-primary-red";\n');
+    return root;
+  }
+
+  test('scanFile counts SCSS color vars in a .scss file', () => {
+    const root = fixtureTree();
+    const counts = scanFile(join(root, 'theme.scss'), DEFAULT_CATEGORIES);
+    // $primary-red (decl + usage) + $grey-900 = 3 occurrences
+    assert.equal(counts.scssColorVars, 3);
+  });
+
+  test('scanFile counts raw hex + rgba in any source file', () => {
+    const root = fixtureTree();
+    const counts = scanFile(join(root, 'theme.scss'), DEFAULT_CATEGORIES);
+    assert.equal(counts.rawHexRgba, 2); // #ff0000 and #111827
+  });
+
+  test('scanFile counts Tailwind color classes and Colors.* usages in .tsx', () => {
+    const root = fixtureTree();
+    const counts = scanFile(join(root, 'App.tsx'), DEFAULT_CATEGORIES);
+    assert.equal(counts.tailwindColorClasses, 2); // bg-primary-red, text-grey-900
+    assert.equal(counts.jsColorsUsages, 1);        // Colors.primaryRed
+  });
+
+  test('scanFile counts SVG fills but ignores none/currentColor', () => {
+    const root = fixtureTree();
+    const counts = scanFile(join(root, 'logo.svg'), DEFAULT_CATEGORIES);
+    assert.equal(counts.svgFills, 1); // only fill="#ff0000"
+  });
+
+  test('file-type gating: tailwind pattern does not apply to .scss', () => {
+    const root = fixtureTree();
+    const counts = scanFile(join(root, 'theme.scss'), DEFAULT_CATEGORIES);
+    assert.equal(counts.tailwindColorClasses, 0);
+  });
+
+  test('grepColorUsage aggregates counts and honors excludes', () => {
+    const root = fixtureTree();
+    const { counts } = grepColorUsage(root, DEFAULT_CATEGORIES);
+    assert.equal(counts.scssColorVars, 3);      // generated/tokens.scss excluded
+    assert.equal(counts.tailwindColorClasses, 2); // node_modules + .test.tsx excluded
+    assert.equal(counts.jsColorsUsages, 1);
+    assert.equal(counts.rawHexRgba, 3);          // 2 in theme.scss + 1 in logo.svg
+    assert.equal(counts.svgFills, 1);
+  });
+
+  test('grepColorUsage reports per-file hits only for files with matches', () => {
+    const root = fixtureTree();
+    const { byFile } = grepColorUsage(root, DEFAULT_CATEGORIES);
+    const files = byFile.map((f) => f.file).sort();
+    assert.deepEqual(files, ['App.tsx', 'logo.svg', 'theme.scss']);
+  });
+
+  test('a custom category config overrides the defaults', () => {
+    const root = fixtureTree();
+    const custom = { brandColors: { files: /\.scss$/, pattern: /\$primary-[\w-]+/g } };
+    const { counts } = grepColorUsage(root, custom);
+    assert.deepEqual(Object.keys(counts), ['brandColors']);
+    assert.equal(counts.brandColors, 2); // decl + usage of $primary-red
+  });
+  ```
+
+- [ ] **Step 1.2: Run the test to verify it fails**
+
+  Run: `node --test scripts/grep-color-usage.test.mjs`
+  Expected: FAIL — `Cannot find module '.../scripts/grep-color-usage.mjs'`.
+
+- [ ] **Step 1.3: Write the implementation**
+
+  Create `scripts/grep-color-usage.mjs`:
+
+  ```javascript
+  // Color-usage grep scaffold: size a codebase's color-decision surface by category.
+  // Repo-shaped by nature — ships sensible DEFAULT_CATEGORIES and accepts a --config
+  // override; logs which categories used the assumed default vs. a detected pattern so
+  // coverage is never silently partial. Zero dependencies.
+  //
+  // Usage:
+  //   node grep-color-usage.mjs --root <dir> [--config <patterns.json>] [--out <counts.json>]
+  //     patterns.json: { "<category>": { "files": "<regex>", "pattern": "<regex with g flag>" }, ... }
+  import { readFileSync, readdirSync, statSync } from 'node:fs';
+  import { join, relative } from 'node:path';
+  import { parseArgs } from 'node:util';
+  import { pathToFileURL } from 'node:url';
+
+  // The five categories from the case study. Each: which files it applies to, and the
+  // (global) match pattern. Tuned defaults — design-system-audit may override per repo.
+  export const DEFAULT_CATEGORIES = {
+    scssColorVars: {
+      files: /\.(scss|sass|css)$/,
+      pattern: /\$[\w-]*(?:color|colour|primary|secondary|tertiary|grey|gray|red|blue|green|yellow|orange|purple|pink|teal|cyan|black|white|brand|accent|surface|ink)[\w-]*/gi,
+    },
+    tailwindColorClasses: {
+      files: /\.(tsx?|jsx?|html|vue|svelte)$/,
+      pattern: /\b(?:bg|text|border|ring|fill|stroke|from|via|to|outline|divide|placeholder|caret|accent|shadow)-(?:primary|secondary|tertiary|grey|gray|red|blue|green|yellow|orange|purple|pink|teal|cyan|brand|accent|surface|ink)[\w-]*/g,
+    },
+    jsColorsUsages: {
+      files: /\.(tsx?|jsx?|mjs|cjs)$/,
+      pattern: /\bColors\.[A-Za-z_$][\w$]*/g,
+    },
+    rawHexRgba: {
+      files: /\.(scss|sass|css|tsx?|jsx?|vue|svelte|html|svg)$/,
+      pattern: /#[0-9a-fA-F]{3,8}\b|rgba?\([^)]*\)/g,
+    },
+    svgFills: {
+      files: /\.svg$/,
+      pattern: /(?:fill|stroke)="(?!none|currentColor|url\()[^"]+"/g,
+    },
+  };
+
+  export const DEFAULT_EXCLUDES = [
+    /(^|\/)node_modules(\/|$)/,
+    /(^|\/)generated(\/|$)/,
+    /\.generated\./,
+    /\.test\./,
+    /\.spec\./,
+    /(^|\/)__tests__(\/|$)/,
+    /(^|\/)dist(\/|$)/,
+    /(^|\/)\.next(\/|$)/,
+  ];
+
+  // Source extensions worth opening at all (union of every category's `files`).
+  const SOURCE_EXT = /\.(scss|sass|css|tsx?|jsx?|mjs|cjs|vue|svelte|html|svg)$/;
+
+  export function* walk(root, excludes = DEFAULT_EXCLUDES) {
+    for (const entry of readdirSync(root)) {
+      const full = join(root, entry);
+      if (excludes.some((re) => re.test(full))) continue;
+      const st = statSync(full);
+      if (st.isDirectory()) {
+        yield* walk(full, excludes);
+      } else if (SOURCE_EXT.test(full)) {
+        yield full;
+      }
+    }
+  }
+
+  // Count matches per category in one file. A category contributes only if its `files`
+  // regex matches this path. Returns { <category>: count } for every category key.
+  export function scanFile(path, categories) {
+    const counts = {};
+    for (const key of Object.keys(categories)) counts[key] = 0;
+    const text = readFileSync(path, 'utf8');
+    for (const [key, { files, pattern }] of Object.entries(categories)) {
+      if (!files.test(path)) continue;
+      const re = new RegExp(pattern.source, pattern.flags.includes('g') ? pattern.flags : pattern.flags + 'g');
+      const m = text.match(re);
+      counts[key] = m ? m.length : 0;
+    }
+    return counts;
+  }
+
+  export function grepColorUsage(root, categories = DEFAULT_CATEGORIES, excludes = DEFAULT_EXCLUDES) {
+    const counts = {};
+    for (const key of Object.keys(categories)) counts[key] = 0;
+    const byFile = [];
+    for (const file of walk(root, excludes)) {
+      const fileCounts = scanFile(file, categories);
+      const total = Object.values(fileCounts).reduce((a, b) => a + b, 0);
+      if (total > 0) {
+        byFile.push({ file: relative(root, file), counts: fileCounts });
+        for (const key of Object.keys(fileCounts)) counts[key] += fileCounts[key];
+      }
+    }
+    return { counts, byFile };
+  }
+
+  // Parse a --config JSON of { category: { files, pattern } } string regexes into RegExp.
+  function loadCategories(path) {
+    const raw = JSON.parse(readFileSync(path, 'utf8'));
+    const out = {};
+    for (const [key, { files, pattern }] of Object.entries(raw)) {
+      out[key] = { files: new RegExp(files), pattern: new RegExp(pattern, 'g') };
+    }
+    return out;
+  }
+
+  function main() {
+    const { values } = parseArgs({
+      options: {
+        root: { type: 'string' },
+        config: { type: 'string' },
+        out: { type: 'string' },
+      },
+    });
+    if (!values.root) {
+      console.error('usage: grep-color-usage.mjs --root <dir> [--config <patterns.json>] [--out <counts.json>]');
+      process.exit(2);
+    }
+    const categories = values.config ? loadCategories(values.config) : DEFAULT_CATEGORIES;
+    // §11: never let coverage be silently partial — say which patterns were assumed.
+    const source = values.config ? `detected (from ${values.config})` : 'ASSUMED defaults';
+    console.log(`color-usage grep — pattern source: ${source}`);
+    console.log(`categories: ${Object.keys(categories).join(', ')}`);
+
+    const { counts, byFile } = grepColorUsage(values.root, categories);
+    const total = Object.values(counts).reduce((a, b) => a + b, 0);
+    console.log('\ncolor-decision surface:');
+    for (const [key, n] of Object.entries(counts)) {
+      console.log(`  ${key.padEnd(24)} ${n}`);
+    }
+    console.log(`  ${'TOTAL'.padEnd(24)} ${total}  (across ${byFile.length} file(s))`);
+    if (!values.config) {
+      console.log('\nnote: patterns are the shipped defaults. Tune them to this repo and re-run with --config for accurate counts.');
+    }
+
+    if (values.out) {
+      const { writeFileSync } = require('node:fs');
+      writeFileSync(values.out, JSON.stringify({ counts, byFile }, null, 2) + '\n');
+      console.log(`\nwrote ${values.out}`);
+    }
+  }
+
+  if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    main();
+  }
+  ```
+
+  > **Note on `--out`:** `require` is not available in ESM. Replace the `--out` write block with a top-level `import { writeFileSync } from 'node:fs';` — add `writeFileSync` to the existing `node:fs` import line (`import { readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';`) and drop the inner `const { writeFileSync } = require('node:fs');`. (Kept explicit here so the engineer doesn't miss it — ESM has no `require`.)
+
+- [ ] **Step 1.4: Apply the ESM `writeFileSync` fix from the note above**
+
+  Edit the import line to:
+
+  ```javascript
+  import { readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+  ```
+
+  And replace the `--out` block body with:
+
+  ```javascript
+    if (values.out) {
+      writeFileSync(values.out, JSON.stringify({ counts, byFile }, null, 2) + '\n');
+      console.log(`\nwrote ${values.out}`);
+    }
+  ```
+
+- [ ] **Step 1.5: Run the test to verify it passes**
+
+  Run: `node --test scripts/grep-color-usage.test.mjs`
+  Expected: PASS (`# pass 8`, `# fail 0`).
+
+- [ ] **Step 1.6: Run the full script suite (no regressions)**
+
+  Run (from the repo root): `node --test`
+  Expected: all green — `# tests 43`, `# pass 43`, `# fail 0` (the 35 from Plan 2 + 8 here).
+  Use bare `node --test` (auto-discovers `**/*.test.mjs`); not `node --test scripts/`.
+
+- [ ] **Step 1.7: Commit**
+
+  ```bash
+  git add scripts/grep-color-usage.mjs scripts/grep-color-usage.test.mjs
+  git commit -m "feat: color-usage grep scaffold — sizes the color-decision surface by category"
+  ```
+
+---
+
+## Task 2: Binding-survival audit snippet (`references/figma-scripting.md`)
+
+Per spec §6, the binding-survival audit **stays in `references/`** because it runs in Figma via `figma_execute`, not in the repo. It counts variable bindings before and after a rename so the `token-builder` refine-in-place branch (Task 5) can prove guardrail 3 held (delete-and-recreate would zero the count). It also feeds `audit.figmaInventory.bindings` (Task 3). Add it in the existing gotcha/snippet format.
+
+**Files:**
+- Modify: `references/figma-scripting.md`
+
+- [ ] **Step 2.1: Add the binding-survival audit section**
+
+  Open `references/figma-scripting.md`. It currently ends with the section
+  `## Large wrapped auto-layout (`layoutWrap = "WRAP"`) is expensive — chunk it`.
+  Append this new section at the end of the file:
+
+  ````markdown
+
+  ## Binding-survival audit: count variable bindings before and after a rename
+
+  A brownfield retrofit renames variables **in place** to preserve their Figma IDs
+  (guardrail 3 in `${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md` — a
+  delete-and-recreate unbinds every consumer). The only way to *prove* a rename kept
+  its bindings is to count consuming bindings before and after. Run this read with
+  the dedicated tooling where possible (`figma_get_variables`), or via `figma_execute`
+  when you need the raw consumer count.
+
+  A variable's bindings are not enumerable directly, so count **consumers**: nodes and
+  styles whose bound properties reference each variable id. The robust, `dynamic-page`-safe
+  approach is to snapshot the total consumer count across the file before the rename,
+  rename in place, then re-snapshot and assert equality.
+
+  ```js
+  // dynamic-page safe: load everything, then walk consumers counting variable refs.
+  await figma.loadAllPagesAsync();
+
+  function countBoundVariableRefs(node, tally) {
+    const bv = node.boundVariables;
+    if (bv) {
+      for (const key of Object.keys(bv)) {
+        const entry = bv[key];
+        const refs = Array.isArray(entry) ? entry : [entry];
+        for (const r of refs) {
+          if (r && r.id) tally[r.id] = (tally[r.id] || 0) + 1;
+        }
+      }
+    }
+    if ('children' in node) {
+      for (const child of node.children) countBoundVariableRefs(child, tally);
+    }
+    return tally;
+  }
+
+  const tally = {};
+  for (const page of figma.root.children) countBoundVariableRefs(page, tally);
+  const totalBindings = Object.values(tally).reduce((a, b) => a + b, 0);
+  // Report totalBindings (and tally per id) BEFORE the rename; re-run AFTER and
+  // assert the total is unchanged. A drop means a binding was severed — STOP and
+  // investigate (almost always a delete-and-recreate slipped in).
+  ```
+
+  - **Pass an explicit `timeout`** (this walks every node — size it per the batch-timeout
+    rule above; a large file needs tens of seconds).
+  - **Style bindings count too.** Text/effect/paint styles can bind variables; include a
+    pass over `getLocalTextStylesAsync()` / `getLocalPaintStylesAsync()` /
+    `getLocalEffectStylesAsync()` and their `boundVariables` if the file uses style-level
+    bindings.
+  - **This is the number `design-system-audit` records** as
+    `audit.figmaInventory.bindings`, and the before/after gate the `token-builder`
+    brownfield branch runs around every rename.
+  ````
+
+- [ ] **Step 2.2: Self-review**
+
+  Confirm: the snippet uses `await figma.loadAllPagesAsync()` (read discipline / B1),
+  the async `dynamic-page`-safe forms, and mentions the explicit `timeout` (consistent
+  with the existing batch-timeout section). Confirm it cross-links
+  `brownfield-retrofit.md` guardrail 3 and names the `audit.figmaInventory.bindings`
+  field exactly as in `references/manifest-schema.md`. Fix any drift inline.
+
+- [ ] **Step 2.3: Commit**
+
+  ```bash
+  git add references/figma-scripting.md
+  git commit -m "docs: binding-survival audit snippet — count variable bindings before/after a rename"
+  ```
+
+---
+
+## Task 3: `design-system-audit` skill — the brownfield front door
+
+Spec §4.1. A PROCESS skill that runs after `figma-environment-setup` detects brownfield, before any building. Sizes the code surface (Task 1's grep), inventories the Figma file with **verified per-class reads** (read discipline), computes `percentSemantic`, writes the `audit` section, sets `tokens.intakeMode: "retrofit"`, and recommends the next step. Per §11, it must **detect the repo's actual tooling rather than assume the case-study stack**, and **log assumed-vs-detected** grep patterns.
+
+**Files:**
+- Create: `skills/design-system-audit/SKILL.md`
+
+- [ ] **Step 3.1: Create the skill**
+
+  Create `skills/design-system-audit/SKILL.md` with exactly this content:
+
+  ````markdown
+  ---
+  name: design-system-audit
+  description: Measure a pre-existing design system before retrofitting it onto tokens — size the code-side color surface and inventory the existing Figma file with verified per-class reads, then compute how semantic the system already is so the retrofit is right-sized. This is a PROCESS skill and the brownfield front door. Use this when retrofitting a design system onto a mature codebase and an already-populated Figma file, when the user wants to audit an existing system, size a retrofit, count existing tokens/variables/bindings, or figure out how much work a migration is. Also trigger when figma-environment-setup detects a brownfield situation (existing repo or populated Figma file), before any building. Make sure to use this whenever someone is converging two mature, drifted artifacts rather than building greenfield.
+  ---
+
+  # Design-system audit (brownfield front door)
+
+  Measures **both sides** of a pre-existing system so a retrofit can be right-sized,
+  before anything is built or changed. It is the brownfield analog of
+  `/design-system-status`: where status reports a *local* manifest, this assesses an
+  *external, mature* system — a real codebase and an already-populated Figma file.
+
+  This is a brownfield skill. **Before doing anything, read**
+  `${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md` — especially the
+  read-discipline principle (never assert absence without a verified read) and the
+  `audit` phase of the safe sequence. Greenfield builds skip this skill entirely.
+
+  ## Calibrate
+
+  Read `user.codingLevel` (`${CLAUDE_PLUGIN_ROOT}/references/coding-level.md`) and scale
+  explanation accordingly. The audit surfaces grep counts and a `percentSemantic`
+  number — for `new` users explain what each means and why it matters (it decides
+  rename-vs-rewrite); for `comfortable` users be terse. The measurements are identical
+  across levels.
+
+  ## Prerequisites
+
+  Read the manifest. This skill needs Figma connected (`figma.connected: true`) for the
+  inventory step, and a repo path for the code-surface step (`workspace.localPath`). If
+  Figma isn't connected, offer to run `figma-environment-setup` first. The code-surface
+  step works on any repo regardless of `workspace.stage`.
+
+  ## Step 1 — Size the code surface
+
+  Measure how many color decisions live in the codebase. Run the color-usage grep
+  scaffold against the user's repo:
+
+  ```bash
+  node ${CLAUDE_PLUGIN_ROOT}/scripts/grep-color-usage.mjs --root <workspace.localPath>
+  ```
+
+  It counts five categories: SCSS color vars, Tailwind color classes, `Colors.*` JS
+  usages, raw hex + `rgba()` literals, and SVG hardcoded fills — producing the
+  case-study worklist shape.
+
+  **Tune the patterns to the actual repo, and say what you assumed (read discipline +
+  §11).** The shipped patterns are *defaults*, not ground truth. Before trusting the
+  counts:
+  1. Look at the repo's real conventions — open a few SCSS/TS files, check the actual
+     color-variable prefixes (`$primary-*`, `$grey-*`, a custom prefix), the Tailwind
+     color-class names, and whether colors come through a `Colors.*` object or some other
+     accessor.
+  2. If the defaults don't fit, write a `--config <patterns.json>` of
+     `{ "<category>": { "files": "<regex>", "pattern": "<regex>" } }` tuned to this repo
+     and re-run with it.
+  3. **Report which categories used the assumed defaults vs. a tuned pattern** — never
+     present default-pattern counts as if they were measured. The script prints this; pass
+     it through to the user so partial coverage is visible, not hidden.
+
+  **Don't assume the stack.** The categories are color-specific but framework-agnostic; a
+  repo with no Tailwind simply scores `0` there. Detect what the repo actually uses (is
+  there a `tailwind.config`? SCSS? CSS-in-JS?) and explain the counts in those terms.
+
+  ## Step 2 — Inventory the Figma file (verified per-class reads)
+
+  Variables, text styles, and effect/paint styles are **different surfaces** — read each
+  independently and report "none" only for the class whose own read came back empty
+  (read discipline, fixes B2). Before counting variables, ensure all pages are loaded
+  (`await figma.loadAllPagesAsync()`); treat a `0` on first read as suspect and re-read
+  before reporting (fixes B1).
+
+  - **Variables** — `figma_get_variables` (handles `dynamic-page`, resolves aliases).
+    Record the count.
+  - **Bindings** — run the binding-survival audit snippet in
+    `${CLAUDE_PLUGIN_ROOT}/references/figma-scripting.md` to count consuming bindings.
+    This is the load-bearing number: it's what a careless rename would destroy.
+  - **Text styles** — `figma_get_text_styles`. Record the count.
+  - **Effect/paint styles** — `figma_get_styles`. Record the count.
+  - **Modes** — record the mode names per collection (e.g. `["Light", "Dark"]`).
+
+  Never report a count you didn't read. If a read genuinely returns empty after a
+  reliable load, that's a real `0`; if it's suspect, re-read or ask the user once and
+  persist — never guess.
+
+  ## Step 3 — Compute "% semantic"
+
+  From the inventory, estimate how much of the existing system is already **semantic**
+  (named by role — `text/default`, `surface/raised`) vs. **raw/primitive** (named by
+  value — `grey-900`, or bare hex). Report it as an integer 0–100 (`audit.percentSemantic`).
+
+  This single number right-sizes the retrofit: a largely-semantic system (~90%) is a
+  **rename-in-place + cleanup** job; a low-semantic one is closer to a **rewrite**.
+  Surface it early and plainly — "you're ~90% semantic, so this is mostly renames and a
+  cleanup, not a rebuild" — so the user calibrates effort before committing.
+
+  ## Step 4 — Write the manifest and recommend the next step
+
+  Write the `audit` section (this skill owns it):
+
+  - `codeSurface` — the per-category counts from Step 1 (keys vary by what the repo uses;
+    omit categories that don't apply rather than reporting a misleading `0`).
+  - `figmaInventory` — `{ variables, bindings, textStyles, effectStyles, modes }` from
+    Step 2's verified reads.
+  - `percentSemantic` — the integer from Step 3.
+  - `ranAt` — the current ISO timestamp.
+
+  Set `tokens.intakeMode: "retrofit"` (this skill establishes the brownfield path — it
+  owns this transition). Append `design-system-audit` to `completedSkills`.
+
+  Then recommend the next step:
+  - If the user wants the guided, gated end-to-end retrofit → **`retrofit-planner`**
+    (the orchestrator; recommended for multi-session retrofits).
+  - If they only want the crosswalk backbone next → **`token-crosswalk-builder`** (it
+    reads this `audit` section to seed its rows).
+
+  ## What this skill must NOT do
+
+  - Never build, rename, or delete anything — this is a **measurement** skill. Changes
+    belong to `token-builder` (refine), the retrofit phases, and cleanup.
+  - Never report a count without a verified read (read discipline). An unexpectedly-empty
+    read is a suspected error, not ground truth.
+  - Never present default grep patterns as measured truth — say what was assumed.
+  - Never assume the case-study stack (Tailwind/SCSS/Chromatic). Detect what the repo
+    actually uses and degrade gracefully.
+  - Never write another skill's manifest fields (e.g. `tokenCrosswalk`, `retrofit.phase`).
+  - Never overwrite `workspace.origin` — it is immutable after intake.
+  ````
+
+- [ ] **Step 3.2: Self-review against the spec**
+
+  Open spec §4.1 and §8. Confirm: the four steps match (size code surface → inventory
+  per-class → compute % semantic → write `audit` + recommend); the skill writes only
+  `audit.*` and sets `tokens.intakeMode: "retrofit"` and appends `completedSkills`
+  (ownership honored); the `audit` field names match `references/manifest-schema.md`
+  (`ranAt`, `codeSurface`, `figmaInventory.{variables,bindings,textStyles,effectStyles,modes}`,
+  `percentSemantic`). Confirm the description marks it PROCESS and triggers on brownfield
+  detection (compare house style to other skills' frontmatter). Confirm §11 carry-forwards
+  are honored: assumed-vs-detected logging (Step 1), don't-hardcode-stack (Steps 1, 4,
+  must-NOT), read discipline (Step 2). Fix any drift inline.
+
+- [ ] **Step 3.3: Commit**
+
+  ```bash
+  git add skills/design-system-audit/SKILL.md
+  git commit -m "feat: design-system-audit skill — brownfield front door (size + inventory + % semantic)"
+  ```
+
+---
+
+## Task 4: Brownfield branch in `figma-environment-setup` (detection + routing + baseline)
+
+Spec §5 row 1, and §11 "close the interim inventory gap" / "surface in /start". Now that `design-system-audit` exists (Task 3), wire the front door: route a mature codebase (and, once connected, a populated Figma file) into the audit; resume an in-progress retrofit at its `retrofit.phase`; and capture a rollback baseline **before any mutation** of a populated file. The B1/B2/B4 read-discipline already lives in this skill's Step 6 and in `figma-scripting.md` (Plan 1) — this task adds routing and the baseline, not the read fixes.
+
+**Files:**
+- Modify: `skills/figma-environment-setup/SKILL.md`
+
+- [ ] **Step 4.1: Add a brownfield line to the Phase 3 brief (existing-repo / existing-monorepo)**
+
+  In `skills/figma-environment-setup/SKILL.md`, find the Phase 3 brief block for the
+  existing-repo scenario. It currently contains this line:
+
+  ```
+  through that step-by-step when we get there — it's a one-time setup.
+  ```
+
+  Immediately after the existing-repo "what that means for us" paragraph (and the
+  analogous existing-monorepo one), the brief should set the expectation that a mature
+  system gets *audited* first. Add this sentence to both the existing-repo and
+  existing-monorepo briefs (append to the "what that means for us" paragraph):
+
+  ```
+  Because you already have a system here, we'll start by **auditing** what exists —
+  measuring your current colors in code and what's in your Figma file — so we right-size
+  the work before changing anything. That's the `design-system-audit` step.
+  ```
+
+  (Insert it as the closing sentence of each of those two scenarios' "what that means
+  for us" paragraphs. Leave the greenfield and unknown scenarios unchanged.)
+
+- [ ] **Step 4.2: Add the brownfield routing + baseline section before "What this skill must NOT do"**
+
+  Find the final section, which begins exactly:
+
+  ```
+  ## What this skill must NOT do
+
+  - Never set up git or GitHub (wrong phase — that's repository-builder).
+  ```
+
+  Insert this new section **immediately before** that `## What this skill must NOT do`
+  heading:
+
+  ````markdown
+  ## Step 8 — Brownfield routing + rollback baseline (existing systems)
+
+  After the liveness check passes, decide where to send the user. Most greenfield runs
+  continue to token building. A **brownfield** run — a mature codebase and/or an
+  already-populated Figma file — routes into the audit first, and an **in-progress
+  retrofit** resumes where it left off. This is the front-door routing the spec calls
+  for; apply the read discipline in
+  `${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md` to every read here.
+
+  **Read the manifest and route:**
+
+  1. **Resume an in-progress retrofit.** If `retrofit.phase` is set and not `"done"`,
+     a retrofit is already underway — hand back to **`retrofit-planner`** to resume at
+     that phase, rather than starting anything new. Say plainly where it left off
+     (e.g. "Looks like we're mid-retrofit at the `sync` phase — want to pick up there?").
+  2. **Route a mature system to the audit.** If `workspace.origin` is `"existing-repo"`
+     or `"existing-monorepo"` (a mature codebase), recommend **`design-system-audit`**
+     as the next step instead of `token-builder`: "You've got an existing system — let's
+     audit it first so we right-size the retrofit." The audit also covers a populated
+     Figma file via its verified per-class reads.
+  3. **Greenfield stays greenfield.** If `workspace.origin` is `"greenfield"`, continue
+     the normal path (brainstorm → token-builder). Don't push greenfield users through
+     the audit.
+
+  **Capture a rollback baseline before any mutation (brownfield only).** A retrofit
+  changes a file that already has value in it, so before *any* write lands, capture a
+  restore point:
+  - **Figma version checkpoint** — note the current version (e.g. via
+    `figma_get_file_versions`) or have the user name a Figma version so there's a known-good
+    point to restore to. The plugin can read versions; it does not auto-create named
+    versions, so if none exists, ask the user to add one ("File → Save to version
+    history") and record that you did.
+  - **Token export** — if the repo already emits tokens, snapshot the current generated
+    output (git is the natural baseline once `workspace.stage` is `local-git`+).
+
+  Do this **before** routing into any skill that writes (the audit only reads, so the
+  baseline must be in place before `token-builder`'s refine phase runs). Frame it as
+  cheap insurance, not alarm.
+  ````
+
+- [ ] **Step 4.3: Self-review against the spec**
+
+  Confirm: routing names `design-system-audit` and `retrofit-planner` exactly; the
+  resume path reads `retrofit.phase` (matching `references/manifest-schema.md` values);
+  the baseline step precedes any mutation; `workspace.origin` is read, never written
+  (immutable). Confirm this honors §11 "surface in /start" (the `/start` command invokes
+  this skill, so resume + audit routing now surface there) and "close the interim
+  inventory gap" (mature systems now reach the audit). Confirm it links
+  `brownfield-retrofit.md`. Fix any drift inline.
+
+- [ ] **Step 4.4: Commit**
+
+  ```bash
+  git add skills/figma-environment-setup/SKILL.md
+  git commit -m "feat: figma-environment-setup brownfield routing + rollback baseline"
+  ```
+
+---
+
+## Task 5: Brownfield branch in `token-builder` (refine-in-place)
+
+Spec §5 row 2 + guardrail 3. Add a refine-in-place path: detect existing variables, rename **preserving IDs**, run the binding-survival audit (Task 2) around every rename, never delete-and-recreate.
+
+**Files:**
+- Modify: `skills/token-builder/SKILL.md`
+
+- [ ] **Step 5.1: Add the refine-in-place section before Step 2**
+
+  In `skills/token-builder/SKILL.md`, find the heading exactly:
+
+  ```
+  ## Step 2 — Build the PRIMITIVE tier, then PAUSE
+  ```
+
+  Insert this new section **immediately before** it:
+
+  ````markdown
+  ## Step 1.5 — Brownfield: refine existing variables in place (don't rebuild)
+
+  If this is a **retrofit** (`tokens.intakeMode: "retrofit"`, or the file already has
+  variables), do **not** create a fresh set on top of the old one. Refine what exists,
+  in place. **Read `${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md` first** —
+  guardrail 3 is the whole point of this branch.
+
+  **The hard rule (guardrail 3):** rename and realign variables **in place** to preserve
+  their Figma IDs. **Never delete-and-recreate** — every binding (a populated file can
+  have thousands) references the variable *id*, so recreating under the same name still
+  unbinds everything. A rename keeps the id; a delete+create does not.
+
+  **The refine loop:**
+
+  1. **Read what exists** (read discipline). Use `figma_get_variables` after
+     `await figma.loadAllPagesAsync()`. List the existing collections, variables, and
+     values. Treat a `0`/empty first read as suspect — re-read before concluding the file
+     is empty.
+  2. **Snapshot bindings before.** Run the binding-survival audit in
+     `${CLAUDE_PLUGIN_ROOT}/references/figma-scripting.md` to record the total consuming
+     binding count *before* any change. This is your guardrail-3 tripwire.
+  3. **Rename / realign in place.** Use the rename operation that keeps the id (e.g.
+     `figma_rename_variable` / setting `variable.name`), and update values in place. Map
+     old names to the new two-tier scheme; record each old→new mapping (the crosswalk
+     consumes it later via `token-crosswalk-builder`).
+  4. **Snapshot bindings after, and assert equality.** Re-run the binding-survival audit.
+     The total **must be unchanged**. A drop means a binding was severed — STOP, find the
+     delete-and-recreate that slipped in, and restore from the baseline.
+  5. **Add genuinely-new variables** (the `added` rows) as normal creates — only the
+     *existing* ones must be renamed rather than recreated.
+
+  After the refine loop, continue with the normal tiers below for any net-new structure,
+  but **skip recreating anything that already exists**. The primitive/semantic checkpoint
+  (Step 2's PAUSE) still applies: lock names before building dependent semantics.
+  ````
+
+- [ ] **Step 5.2: Add a "must NOT" guardrail**
+
+  Find the `## Notes that matter` section near the end. Add this bullet to the existing
+  bullet list (append after the last existing note):
+
+  ```
+  - **Brownfield: never delete-and-recreate to rename (guardrail 3).** On a retrofit,
+    rename variables in place to preserve their Figma IDs and every binding. Snapshot the
+    binding count before and after each rename and assert it's unchanged — see Step 1.5
+    and `${CLAUDE_PLUGIN_ROOT}/references/figma-scripting.md`.
+  ```
+
+- [ ] **Step 5.3: Self-review against the spec**
+
+  Confirm: the branch is gated on `tokens.intakeMode: "retrofit"` / existing variables;
+  it renames preserving IDs and explicitly forbids delete-and-recreate; it runs the
+  binding-survival audit before *and* after with an equality assertion; it reads
+  `brownfield-retrofit.md`. Confirm it doesn't touch greenfield behavior (the new section
+  is purely additive and conditional). Fix any drift inline.
+
+- [ ] **Step 5.4: Commit**
+
+  ```bash
+  git add skills/token-builder/SKILL.md
+  git commit -m "feat: token-builder brownfield refine-in-place branch (rename preserving IDs)"
+  ```
+
+---
+
+## Task 6: Brownfield branch in `token-sync-layer` + `sync-adapters.md` (transforms)
+
+Spec §5 row 3 + guardrails 2 & 6. Opacity 0–100→0–1 normalization is already documented in `token-sync-layer` Step 2 (Plan 1). Add the three remaining transforms: alpha as `rgb(… / <alpha-value>)` **channels** (so Tailwind `/opacity` survives), float32 rounding **at the export boundary**, and `/opacity` on var-based tokens → `color-mix`. Document them in both the skill and `sync-adapters.md`.
+
+**Files:**
+- Modify: `skills/token-sync-layer/SKILL.md`
+- Modify: `references/sync-adapters.md`
+
+- [ ] **Step 6.1: Add the brownfield-transforms subsection to the skill**
+
+  In `skills/token-sync-layer/SKILL.md`, find the heading exactly:
+
+  ```
+  ## Step 3 — Set up Style Dictionary + adapters
+  ```
+
+  Insert this new subsection **immediately before** it (so it sits at the end of Step 2,
+  beside the existing opacity-normalization rule):
+
+  ````markdown
+  ### Brownfield transforms (learned the hard way)
+
+  On a **retrofit** (`tokens.intakeMode: "retrofit"`), apply these transforms in
+  addition to the opacity normalization above. Each cost real debugging time on a live
+  retrofit — see the guardrails in
+  `${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md`.
+
+  - **Alpha as channels, not baked CSS vars (so Tailwind `/opacity` survives).** Emit
+    colors as space-separated channels with a slash-alpha slot —
+    `--color-x: 239 68 68;` consumed as `rgb(var(--color-x) / <alpha-value>)` — rather
+    than a finished `rgba(...)`. A baked `rgba()` can't accept Tailwind's `/opacity`
+    modifier; the channel form keeps `bg-x/50` working after the retrofit.
+  - **`/opacity` on var-based tokens → `color-mix` or channel alpha (guardrail 6).**
+    Where existing code applies a `/opacity` modifier to a token that is now a CSS var,
+    you can't fold the alpha into the var. Convert to
+    `color-mix(in srgb, var(--color-x) NN%, transparent)` (or the channel-alpha form
+    above). Never carry a raw `/opacity` onto a var-based token.
+  - **Round float32 noise at the export boundary (guardrail 2).** Figma stores values as
+    float32 and re-quantizes on write, so normalizing *inside* Figma is a no-op. Round at
+    the **export boundary** instead — `Math.round(v * 100) / 100` as values leave the
+    pipeline — so `0.30000001192092896` lands as `0.3` in the generated files. Do this in
+    the extraction/transform step, never by hand-editing the generated output (guardrail 7).
+
+  These are transforms on the *values* the adapters emit; the adapter presets themselves
+  are unchanged. See `${CLAUDE_PLUGIN_ROOT}/references/sync-adapters.md` for where they
+  fit in the adapter output.
+  ````
+
+- [ ] **Step 6.2: Add a "must NOT" guardrail to the skill**
+
+  Find the `## What this skill must NOT do` section. Add these bullets to the list:
+
+  ```
+  - Never bake alpha into finished `rgba(...)` on a retrofit — emit channels
+    (`rgb(var(--x) / <alpha-value>)`) so Tailwind `/opacity` modifiers survive.
+  - Never carry a `/opacity` modifier onto a var-based token — convert to `color-mix`
+    or channel alpha (guardrail 6).
+  - Never normalize float32 inside Figma (it re-quantizes) — round at the export
+    boundary (`Math.round(v*100)/100`, guardrail 2).
+  ```
+
+- [ ] **Step 6.3: Document the transforms in `sync-adapters.md`**
+
+  In `references/sync-adapters.md`, find the heading exactly:
+
+  ```
+  ## Output location
+  ```
+
+  Insert this new section **immediately before** it:
+
+  ````markdown
+  ## Brownfield value transforms
+
+  On a retrofit, the values flowing into the adapters get three extra transforms (the
+  opacity 0–100→0–1 normalization happens earlier, at extraction). These affect what the
+  web adapters emit; native adapters resolve to literals so the channel/`color-mix` forms
+  apply to web targets. Full rationale: the 7 guardrails in
+  `${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md`.
+
+  - **Channel alpha (web).** Color tokens emit as space-separated channels
+    (`--color-bg-default: 239 68 68;`) consumed via
+    `rgb(var(--color-bg-default) / <alpha-value>)`, so Tailwind's `/opacity` modifiers
+    keep working. A finished `rgba(...)` would break them.
+  - **`/opacity` → `color-mix` (web).** A `/opacity` modifier on a var-based token can't
+    fold its alpha into the var; emit `color-mix(in srgb, var(--token) NN%, transparent)`
+    instead (or the channel-alpha form).
+  - **Float32 rounding at the export boundary.** Round values as they leave the pipeline
+    (`Math.round(v*100)/100`) — normalizing inside Figma is a no-op because Figma
+    re-quantizes to float32 on store.
+
+  These are applied in `token-sync-layer`'s extraction/transform step (its "Brownfield
+  transforms" subsection), not in the adapter presets.
+  ````
+
+- [ ] **Step 6.4: Self-review against the spec**
+
+  Confirm: all three transforms match spec §5 row 3 and guardrails 2 & 6 verbatim in
+  intent (channel alpha `rgb(… / <alpha-value>)`, float rounding `Math.round(v*100)/100`
+  at the export boundary, `/opacity`→`color-mix(in srgb, var(--…) NN%, transparent)`);
+  the skill and `sync-adapters.md` agree; both cross-link `brownfield-retrofit.md`;
+  opacity normalization is *not* re-documented (it already exists). Fix any drift inline.
+
+- [ ] **Step 6.5: Commit**
+
+  ```bash
+  git add skills/token-sync-layer/SKILL.md references/sync-adapters.md
+  git commit -m "feat: token-sync-layer brownfield transforms (channel alpha, float rounding, color-mix)"
+  ```
+
+---
+
+## Task 7: Brownfield branch in `storybook-chromatic-builder` (baseline + verification triad)
+
+Spec §5 row 4 + §7 verification triad + guardrails 4 & 5. Add: capture a Chromatic baseline **before** the code retrofit (so intended drift-fixes are distinguishable from regressions), the three-check verification triad, and the explicit warnings that `build-storybook` only compiles story-reachable SCSS and that **Chromatic — not `tsc`/build — is the source of truth** for color-utility removal. Per §11, detect the repo's actual test/CI tooling rather than asserting Chromatic.
+
+**Files:**
+- Modify: `skills/storybook-chromatic-builder/SKILL.md`
+
+- [ ] **Step 7.1: Add the baseline + triad section before "What this skill must NOT do"**
+
+  In `skills/storybook-chromatic-builder/SKILL.md`, find the final section beginning
+  exactly:
+
+  ```
+  ## What this skill must NOT do
+
+  - Never finish a finalized component while leaving its Figma doc card on `draft`
+  ```
+
+  Insert this new section **immediately before** that heading:
+
+  ````markdown
+  ## Brownfield: baseline before retrofit + the verification triad
+
+  On a **retrofit** (`tokens.intakeMode: "retrofit"`), the order of operations and the
+  verification bar are stricter than greenfield. **Read
+  `${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md`** — the safe sequence and the
+  verification triad live there.
+
+  **Capture the Chromatic baseline BEFORE the code retrofit.** Run `build-storybook` +
+  Chromatic to establish a green baseline *before* any token/color code is changed. Then,
+  when the retrofit lands, every diff is either an **intended drift-fix** (a color the
+  audit flagged as wrong) or a **regression** — and the baseline is the only thing that
+  tells them apart. Baseline *after* the retrofit and you've thrown away that signal.
+
+  **The verification triad — all three are necessary; no single check catches everything:**
+  1. **`check-types` (TypeScript)** — catches type errors, but is **blind to Tailwind
+     silent no-ops**: a deleted color utility just stops applying, with no type error
+     (guardrail 4).
+  2. **`build-storybook` + Chromatic snapshots** — the visual-regression net, but **blind
+     to story-unreachable code**. `build-storybook` only compiles SCSS that some story
+     actually imports; a dead `@import` of a deleted partial, or a route's styles no story
+     renders, compiles "fine" here and breaks only in the app. **Chromatic — not
+     `tsc`/build — is the source of truth** for whether a color-utility removal was safe.
+  3. **Run the actual app + spot-check 5–7 real routes** — the only thing that exercises
+     story-unreachable SCSS (guardrail 5). Don't declare an SCSS/color change done on the
+     strength of a green build alone.
+
+  **Don't assume the stack (§11).** This triad names Chromatic + `build-storybook`
+  because that's the case-study tooling. Detect what the repo actually uses — read its
+  `package.json` scripts for the real type-check / build / visual-test commands — and map
+  the triad onto them (or degrade gracefully and say so) rather than asserting commands
+  that may not exist.
+  ````
+
+- [ ] **Step 7.2: Add "must NOT" guardrails**
+
+  In the `## What this skill must NOT do` list, add these bullets:
+
+  ```
+  - Never capture the Chromatic baseline *after* a code retrofit — baseline before, so
+    intended drift-fixes are distinguishable from regressions.
+  - Never trust `tsc`/build to catch Tailwind color-utility removal — it's a silent
+    no-op; Chromatic is the source of truth (guardrail 4).
+  - Never declare an SCSS/color change done on a green build alone — run the app and
+    spot-check 5–7 real routes (guardrail 5).
+  ```
+
+- [ ] **Step 7.3: Self-review against the spec**
+
+  Confirm: baseline-before-retrofit is explicit; the triad's three checks match §7
+  exactly (check-types / build-storybook+Chromatic / run-the-app), each with its blind
+  spot; the "Chromatic not tsc is the source of truth" and "build-storybook only compiles
+  story-reachable SCSS" warnings are present (§5 row 4); §11 don't-hardcode-stack is
+  honored (detect real commands). Fix any drift inline.
+
+- [ ] **Step 7.4: Commit**
+
+  ```bash
+  git add skills/storybook-chromatic-builder/SKILL.md
+  git commit -m "feat: storybook-chromatic-builder baseline-before-retrofit + verification triad"
+  ```
+
+---
+
+## Task 8: B3 behavioral fix — detect-or-ask publish state
+
+Spec §3 (B3), §10, §11. Today `component-builder` and `figma-publishing.md` treat a
+default/`false` `figma.libraryPublished` as "not published" and fall straight to the
+toggle fallback. The fix is **behavioral**: treat default/`false` as *unverified* —
+attempt detection first (`figma_get_library_components` / `figma_get_library_variables`),
+ask once only if inconclusive, persist the answer, and frame the unpublished path as a
+graceful choice. No new manifest field (the field docs were already clarified in Plan 1).
+
+**Files:**
+- Modify: `references/figma-publishing.md`
+- Modify: `skills/component-builder/SKILL.md`
+
+- [ ] **Step 8.1: Rewrite the capability check in `figma-publishing.md`**
+
+  In `references/figma-publishing.md`, find the section exactly:
+
+  ```
+  ## Capability check (ask once, record it)
+
+  Before relying on publishing, establish whether the user *can* publish and
+  whether they *have*:
+
+  - If `figma.canPublish` is `null`, ask once, plainly: "Are you on a paid Figma
+    plan (Professional or higher)? Publishing a shared library — which unlocks the
+    nicer typed icon dropdowns on components — needs one." Record `true`/`false`.
+  - Record whether they've published in `figma.libraryPublished` (+ `publishedAt`).
+
+  Don't probe repeatedly; read the manifest and only re-ask if state is missing.
+  ```
+
+  Replace that entire section with:
+
+  ````markdown
+  ## Capability check (detect first, then ask once, record it)
+
+  Before relying on publishing, establish whether the user *can* publish and whether
+  they *have* — but **treat a default/`false` `figma.libraryPublished` as _unverified_,
+  not "definitely not published" (bug B3).** Apply the read discipline in
+  `${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md`: never assert "unpublished"
+  without a verified read.
+
+  1. **Detect first.** Before asking anything, attempt to detect publish state by reading
+     for published library artifacts: `figma_get_library_components` /
+     `figma_get_library_variables` (and library component keys). If those resolve, the
+     file *is* published — record `figma.libraryPublished: true` (+ `publishedAt`) and skip
+     the question.
+  2. **Ask once only if detection is inconclusive.** If the reads are empty or unreliable
+     (detection can't confirm either way), ask the user a single plain question — "Is this
+     file published to a team library?" — and, separately, if `figma.canPublish` is `null`:
+     "Are you on a paid Figma plan (Professional or higher)? Publishing a shared library —
+     which unlocks the nicer typed icon dropdowns — needs one." Record `true`/`false` for
+     each.
+  3. **Persist.** Record `figma.libraryPublished` (+ `publishedAt`) and `figma.canPublish`.
+     Don't probe repeatedly; read the manifest and only re-detect/re-ask if state is
+     genuinely missing.
+
+  Frame the unpublished path as a **graceful choice**, never a failure — the toggle +
+  manual-swap slot is fully functional.
+  ````
+
+- [ ] **Step 8.2: Update "What `component-builder` does with this" in `figma-publishing.md`**
+
+  Find the section exactly:
+
+  ```
+  ## What `component-builder` does with this
+
+  For each slot that would be a typed `INSTANCE_SWAP`:
+
+  1. **Can the swap targets resolve** (library published, `canPublish` true,
+     `libraryPublished` true)? →
+  2. **Yes:** add the typed `INSTANCE_SWAP` dropdown with preferred values.
+  3. **No (free plan, or not yet published):** build the **toggle + manual-swap**
+     slot instead, tell the user *why* in plain terms, and add the component name to
+     `components.instanceSwapUpgradePending` in the manifest.
+  ```
+
+  Replace it with:
+
+  ````markdown
+  ## What `component-builder` does with this
+
+  For each slot that would be a typed `INSTANCE_SWAP`:
+
+  1. **Resolve publish state via the capability check above** — detect first
+     (`figma_get_library_components` / `figma_get_library_variables`), ask once only if
+     inconclusive, then persist. A default/`false` `libraryPublished` is *unverified*
+     until this runs — never treat it as a final "no".
+  2. **Confirmed published** (`libraryPublished` true after detect-or-ask, `canPublish`
+     true): add the typed `INSTANCE_SWAP` dropdown with preferred values.
+  3. **Confirmed not published** (free plan, or the user said not yet): build the
+     **toggle + manual-swap** slot instead, tell the user *why* in plain terms, and add
+     the component name to `components.instanceSwapUpgradePending` in the manifest. This
+     is a graceful choice, not a failure.
+  ```` 
+
+- [ ] **Step 8.3: Update `component-builder` typed-dropdown gate**
+
+  In `skills/component-builder/SKILL.md`, find the typed-dropdown-vs-fallback block,
+  which contains exactly:
+
+  ```
+  - **Published (`figma.libraryPublished` true):** add the typed `INSTANCE_SWAP`
+    dropdown with preferred values.
+  ```
+
+  Replace the gate so default/`false` is treated as unverified. Replace that bullet
+  (and keep the not-published bullet that follows it) with:
+
+  ```
+  - **Resolve publish state first (detect-or-ask, bug B3):** a default/`false`
+    `figma.libraryPublished` is *unverified* — attempt detection
+    (`figma_get_library_components` / `figma_get_library_variables`) and ask once only if
+    inconclusive, per `${CLAUDE_PLUGIN_ROOT}/references/figma-publishing.md`. Never treat
+    a `false` as a final "not published" without that check.
+  - **Confirmed published (`figma.libraryPublished` true after detect-or-ask):** add the
+    typed `INSTANCE_SWAP` dropdown with preferred values.
+  ```
+
+- [ ] **Step 8.4: Gate the upgrade pass on confirmed-true**
+
+  In `skills/component-builder/SKILL.md`, find the upgrade-pass text containing exactly:
+
+  ```
+  **Upgrade pass:** if `components.instanceSwapUpgradePending` is non-empty and the
+  library is now published (`figma.libraryPublished` true), offer to add the typed
+  `INSTANCE_SWAP` dropdowns to those components and clear each from the list.
+  ```
+
+  Replace it with:
+
+  ```
+  **Upgrade pass:** if `components.instanceSwapUpgradePending` is non-empty, re-resolve
+  publish state (detect-or-ask per `${CLAUDE_PLUGIN_ROOT}/references/figma-publishing.md`);
+  only when it is **confirmed published** (`figma.libraryPublished` true via a verified
+  detect-or-ask, not a stale default) offer to add the typed `INSTANCE_SWAP` dropdowns to
+  those components and clear each from the list.
+  ```
+
+- [ ] **Step 8.5: Self-review against the spec**
+
+  Confirm against §3 (B3) and §10: detection is attempted first
+  (`figma_get_library_components` / `figma_get_library_variables`), the question is asked
+  *once* only when inconclusive, the answer persists to `figma.libraryPublished` /
+  `figma.canPublish` (no new field), and the unpublished path is framed as graceful.
+  Confirm `figma-publishing.md` and `component-builder` agree and both link the read
+  discipline. Confirm no greenfield behavior regressed (a genuinely-published greenfield
+  file still gets the typed dropdown). Fix any drift inline.
+
+- [ ] **Step 8.6: Commit**
+
+  ```bash
+  git add references/figma-publishing.md skills/component-builder/SKILL.md
+  git commit -m "fix: B3 detect-or-ask publish state (treat default libraryPublished as unverified)"
+  ```
+
+---
+
+## Task 9: `retrofit-planner` skill — the orchestrator
+
+Spec §4.3. Mirrors `component-pipeline`: holds **zero domain logic of its own**, invokes
+sub-skills via the Skill tool, gates **every** phase on a human confirmation, owns only
+`retrofit.phase` + `completedSkills`. Encodes the safe 7-phase sequence with the
+non-obvious ordering rules as gates, offers the decision journal default-on, and (per
+§11) detects the repo's tooling rather than asserting the case-study stack.
+
+**Files:**
+- Create: `skills/retrofit-planner/SKILL.md`
+
+- [ ] **Step 9.1: Create the skill**
+
+  Create `skills/retrofit-planner/SKILL.md` with exactly this content:
+
+  ````markdown
+  ---
+  name: retrofit-planner
+  description: Orchestrate a full brownfield design-system retrofit end to end — audit, refine variables in place, rebind components, sync, capture a Chromatic baseline, retrofit the code with dual output, then remove the old tokens only after a zero-reference grep — with a human confirmation gate between every phase. Use this when the user wants to run a complete retrofit, migrate a mature codebase and populated Figma file onto tokens, resume an in-progress retrofit, or be walked through the safe retrofit sequence. Also trigger after design-system-audit has sized the system, or when figma-environment-setup detects an in-progress retrofit. Make sure to use this whenever someone wants the guided, gated, multi-session brownfield retrofit rather than running the individual skills by hand.
+  ---
+
+  # Retrofit planner (orchestrator)
+
+  Sequences a brownfield retrofit through the safe 7-phase order, gating each phase on a
+  human confirmation. Like `component-pipeline`, this skill holds **zero domain logic of
+  its own** — it is a sequencer that invokes the real skills and the phase work, and only
+  updates the manifest fields it owns (`retrofit.phase`, `completedSkills`). All the
+  actual work lives in the skills it calls, so this orchestrator doesn't rot when they
+  improve.
+
+  **Before anything, read `${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md`** —
+  the read discipline, the 7 guardrails, the safe sequence, and the verification triad
+  are the rules this skill enforces as gates.
+
+  ## When to use vs. the individual skills
+
+  Use this for a **complete retrofit**, especially across multiple sessions. For a single
+  isolated step (just the audit, just the crosswalk), run that skill directly. This is the
+  "converge my mature system onto tokens, end to end, without breaking the live app" flow.
+
+  ## Calibrate
+
+  Read `user.codingLevel` (`${CLAUDE_PLUGIN_ROOT}/references/coding-level.md`). A retrofit
+  touches Figma, tokens, code, CI, and a live app — for `new` users explain each phase and
+  why its ordering matters the first time; for `comfortable` users be terse. The phases and
+  gates are identical across levels.
+
+  ## Prerequisites
+
+  Read the manifest. This orchestrator assumes a brownfield situation
+  (`tokens.intakeMode: "retrofit"`, or `workspace.origin` is an existing repo/monorepo). If
+  the audit hasn't run yet (`audit.ranAt` is `null`), start at the audit phase below. If
+  none of the brownfield markers are set, this is probably greenfield — point the user to
+  the normal build skills instead.
+
+  ## Decision-journal offer (default-on)
+
+  At the start of a retrofit, offer to scaffold a decision journal at `docs/design-system/`
+  with `specs/ plans/ spikes/ findings/ decisions/ handoffs/`. **Recommend yes** —
+  retrofits are multi-session and the journal is the human decision trail (complementary to
+  the manifest's machine state) — but allow the user to decline. Record the choice in
+  `retrofit.journalScaffolded`. This is the only artifact this skill creates directly.
+
+  ## Detect the stack, don't assume it (§11)
+
+  Before running phases that shell out (sync, baseline, code, cleanup), detect what the
+  repo actually uses — read its `package.json` scripts for the real type-check, build,
+  visual-test, and token commands. The case study used Chromatic + `build-storybook` +
+  `tokens:sync`/`tokens:validate`; a real repo may differ. Map each phase onto the repo's
+  actual commands, or degrade gracefully and say what's missing — never assert a command
+  that doesn't exist.
+
+  ## The safe sequence (confirm between EVERY phase)
+
+  Set `retrofit.phase` to the current phase as you enter it, so a later session can resume
+  exactly here. Confirm the goal first, then walk the phases. **Each gate is a hard stop:
+  do not advance without explicit confirmation** — the gates are what keep the live app
+  intact and make the retrofit resumable.
+
+  ### Phase 1 — `audit` (invoke `design-system-audit`)
+
+  Invoke `design-system-audit`: size the code surface, inventory the Figma file with
+  verified per-class reads, compute `percentSemantic`. **Gate:** show the audit results and
+  the right-sizing read ("~90% semantic → renames + cleanup, not a rewrite"). Confirm before
+  continuing. Capture the rollback baseline (Figma version checkpoint / token export) now if
+  `figma-environment-setup` didn't already.
+
+  ### Phase 2 — `refine` (invoke `token-builder` brownfield branch)
+
+  Invoke `token-builder`'s refine-in-place branch: rename/realign variables **in place**,
+  preserving IDs, with a binding-survival audit before and after each rename (guardrail 3).
+  **Gate:** show the before/after binding counts are equal (no bindings severed) and the
+  refined variable names. Confirm before continuing. **Never delete-and-recreate.**
+
+  ### Phase 3 — `rebind`
+
+  Reconcile components onto the refined variables, preserving their Figma IDs. There is no
+  dedicated skill for this — drive it directly here: verify components still reference the
+  (renamed, same-id) variables, and fix any that drifted. **Gate:** confirm components still
+  render bound. This is also the natural point to build the crosswalk if not yet done —
+  offer `token-crosswalk-builder` (it reads the `audit` section to seed rows and wires
+  `tokens:validate`).
+
+  ### Phase 4 — `sync` (invoke `token-sync-layer` brownfield branch)
+
+  Invoke `token-sync-layer` with the brownfield transforms (channel alpha, opacity
+  0–100→0–1, float32 rounding at the export boundary, `/opacity`→`color-mix`). It lands a
+  reviewable PR per its own rules. **Gate:** confirm the sync PR before continuing.
+
+  ### Phase 5 — `baseline` (invoke `storybook-chromatic-builder`)
+
+  Capture a Chromatic baseline **before** any code retrofit, so intended drift-fixes are
+  distinguishable from regressions. **Gate:** confirm the baseline is green and captured.
+  This ordering is not optional — baseline *after* the code change throws away the signal.
+
+  ### Phase 6 — `code` (dual output)
+
+  Retrofit the codebase with **dual output**: new and old tokens coexist during the
+  transition, so nothing breaks mid-migration. Use the crosswalk reverse index
+  (`tokens:reverse-index`) to semi-automate the SCSS/Tailwind swaps. Run the verification
+  triad as you go — `check-types`, `build-storybook` + Chromatic, **and run the actual app**
+  + spot-check 5–7 routes (the build alone is blind to story-unreachable SCSS). **Gate:**
+  confirm the triad passes before continuing.
+
+  ### Phase 7 — `cleanup`
+
+  Remove the old token outputs **only after** the repo-wide token-removal guard returns
+  **zero references** (`guard-token-removal.mjs`) — deleted Tailwind utilities are silent
+  no-ops that `tsc`/build won't catch (guardrail 4). **Gate:** show the guard reporting zero
+  references, then confirm removal. Re-run the verification triad after removal.
+
+  When cleanup is verified, set `retrofit.phase: "done"` and `retrofit.completedAt`, and
+  append `retrofit-planner` to `completedSkills`.
+
+  ## Resumability
+
+  Because each phase is gated and `retrofit.phase` is written on entry, a stop at any point
+  leaves a clean resume point. `figma-environment-setup` reads `retrofit.phase` on the next
+  `/start` and routes back here at the right phase. Never silently restart from the top —
+  resume where the manifest says.
+
+  ## What this skill must NOT do
+
+  - Never reimplement what the sub-skills do — only sequence them and drive the
+    no-dedicated-skill phases (rebind, code, cleanup). If you're writing token/sync logic
+    here, stop and invoke the real skill.
+  - Never skip a confirmation between phases — the gates keep the live app intact and make
+    the retrofit resumable.
+  - Never delete-and-recreate variables (guardrail 3), baseline after the code retrofit
+    (phase 5 before 6), or remove old outputs before the zero-reference grep passes
+    (guardrail 4).
+  - Never write another skill's manifest fields — own only `retrofit.*` and
+    `completedSkills`. The audit owns `audit.*`; the crosswalk owns `tokenCrosswalk`.
+  - Never assert the case-study toolchain — detect the repo's real commands or degrade
+    gracefully.
+  ````
+
+- [ ] **Step 9.2: Self-review against the spec**
+
+  Open spec §4.3 and §8. Confirm: the 7 phases match the safe sequence
+  (audit→refine→rebind→sync→baseline→code→cleanup→done) with a human gate each; the
+  non-obvious ordering rules are baked as gates (refine-in-place not delete-recreate;
+  baseline before code; dual output; delete only after zero-reference grep; verify with the
+  real app); it invokes sub-skills via the Skill tool (names match: `design-system-audit`,
+  `token-builder`, `token-crosswalk-builder`, `token-sync-layer`,
+  `storybook-chromatic-builder`); the decision-journal offer is default-on and recorded in
+  `retrofit.journalScaffolded`; it writes only `retrofit.*` + `completedSkills`; §11
+  don't-hardcode-stack is honored. Compare the orchestrator shape to
+  `skills/component-pipeline/SKILL.md`. Fix any drift inline.
+
+- [ ] **Step 9.3: Commit**
+
+  ```bash
+  git add skills/retrofit-planner/SKILL.md
+  git commit -m "feat: retrofit-planner orchestrator — gated 7-phase safe retrofit sequence"
+  ```
+
+---
+
+## Task 10: Surface the new manifest sections in `/design-system-status` and `/start`
+
+Spec §11 "Surface the new manifest sections in `/design-system-status` and `/start`. They
+currently ignore `audit` / `retrofit`." The substantive `/start` routing (resume on
+`retrofit.phase`, route mature systems to the audit) landed in Task 4 via
+`figma-environment-setup`, which `/start` invokes. This task adds the status reporting and a
+light note in `start.md`.
+
+**Files:**
+- Modify: `commands/design-system-status.md`
+- Modify: `commands/start.md`
+
+- [ ] **Step 10.1: Add brownfield reporting to `design-system-status.md`**
+
+  In `commands/design-system-status.md`, find the line that ends the report list — the
+  bullet about the coding level / UI framework on record (the last item before the
+  "suggest sensible next steps" instruction). Immediately after that bullet, add these
+  reporting lines (match the existing plain-prose bullet style):
+
+  ```
+  - Retrofit (brownfield only — skip the whole block if `tokens.intakeMode` isn't
+    `"retrofit"` and `audit.ranAt` is null):
+    - Audit: has it run (`audit.ranAt`)? If so, the code-surface counts
+      (`audit.codeSurface`), the Figma inventory (`audit.figmaInventory` — variables,
+      bindings, text/effect styles, modes), and how semantic the system is
+      (`audit.percentSemantic`).
+    - Crosswalk: is it built (`tokenCrosswalk.path`)? The status counts
+      (`tokenCrosswalk.statusCounts`) and whether the validator is passing
+      (`tokenCrosswalk.validatorPassing`).
+    - Retrofit progress: which phase (`retrofit.phase`), and whether the decision journal
+      was scaffolded (`retrofit.journalScaffolded`).
+  ```
+
+  Then, in the "suggest sensible next steps" guidance, add a brownfield example so the
+  command routes correctly. After the existing example, add:
+
+  ```
+  For a brownfield system, suggest the next retrofit step from the state: no audit yet
+  → "want to run `design-system-audit` to size the retrofit?"; audited but no crosswalk
+  → "want to build the crosswalk with `token-crosswalk-builder`?"; mid-retrofit
+  (`retrofit.phase` set, not `"done"`) → "want to resume the retrofit at the `<phase>`
+  phase with `retrofit-planner`?".
+  ```
+
+- [ ] **Step 10.2: Add a brownfield/resume note to `start.md`**
+
+  In `commands/start.md`, find the passage that says the setup skill will detect an
+  existing manifest and route the user to the right next step (the "If `design-system.json`
+  already exists…" sentence). Append to that paragraph:
+
+  ```
+  That routing now covers brownfield systems too: an existing/mature repo or populated
+  Figma file is sent to `design-system-audit` first, and an in-progress retrofit
+  (`retrofit.phase` set) resumes at its phase via `retrofit-planner` — the setup skill
+  makes that call.
+  ```
+
+- [ ] **Step 10.3: Self-review against the spec**
+
+  Confirm: `design-system-status` now reports `audit`, `tokenCrosswalk`, and `retrofit`
+  using the exact field names from `references/manifest-schema.md`, and only for brownfield
+  systems (greenfield output is unchanged); `start.md` notes the brownfield/resume routing
+  that Task 4 implemented. Confirm the next-step suggestions name real skills
+  (`design-system-audit`, `token-crosswalk-builder`, `retrofit-planner`). Fix any drift
+  inline.
+
+- [ ] **Step 10.4: Commit**
+
+  ```bash
+  git add commands/design-system-status.md commands/start.md
+  git commit -m "feat: surface audit/crosswalk/retrofit in /design-system-status + /start routing note"
+  ```
+
+---
+
+## Task 11: CHANGELOG + plugin-level self-review
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 11.1: Add the `[Unreleased]` entry**
+
+  Open `CHANGELOG.md`. Under the existing `[Unreleased]` → `### Added` heading (which
+  already carries the Plan 1 and Plan 2 entries), add these bullets:
+
+  ```markdown
+  - **Brownfield retrofit skills (Plan 3 of 3).** Completes the brownfield path end to end.
+    - **`design-system-audit` skill** — the brownfield front door: sizes the code-side
+      color surface (via the new color-usage grep), inventories the Figma file with verified
+      per-class reads, computes `percentSemantic`, and owns the `audit` manifest section
+      (sets `tokens.intakeMode: "retrofit"`).
+    - **`retrofit-planner` skill** — the orchestrator: sequences the safe 7-phase retrofit
+      (audit → refine → rebind → sync → baseline → code → cleanup) with a human gate per
+      phase, offers a decision journal default-on, and owns the `retrofit` manifest section.
+    - **`scripts/grep-color-usage.mjs`** — the repo-shaped color-usage grep scaffold
+      (ships default patterns, logs assumed-vs-detected coverage).
+  - **Brownfield branches in existing skills.** `figma-environment-setup` gains brownfield
+    detection + routing to the audit, retrofit resume, and a pre-mutation rollback baseline;
+    `token-builder` gains refine-in-place (rename preserving IDs, binding-survival audit);
+    `token-sync-layer` gains the brownfield transforms (channel alpha, float32 rounding at
+    the export boundary, `/opacity`→`color-mix`); `storybook-chromatic-builder` gains
+    baseline-before-retrofit + the verification triad. The binding-survival audit snippet is
+    added to `references/figma-scripting.md`.
+  - **`/design-system-status` + `/start`** now surface the `audit`, `tokenCrosswalk`, and
+    `retrofit` state and route brownfield/in-progress systems to the right next step.
+  ```
+
+  Then, under `[Unreleased]` → `### Fixed`, add:
+
+  ```markdown
+  - **Publish-state detection is now behavioral, not assumed (bug B3).** `component-builder`
+    and `references/figma-publishing.md` treat a default/`false` `figma.libraryPublished` as
+    *unverified*: they detect first (`figma_get_library_components` /
+    `figma_get_library_variables`), ask once only if inconclusive, persist the answer, and
+    frame the unpublished path as a graceful choice. No new manifest field.
+  ```
+
+- [ ] **Step 11.2: Verify the full script suite still passes**
+
+  Run (from the repo root): `node --test`
+  Expected: all green — `# tests 43`, `# pass 43`, `# fail 0`.
+
+- [ ] **Step 11.3: Verify every new/edited SKILL.md frontmatter `name` matches its directory**
+
+  Run:
+
+  ```bash
+  for d in design-system-audit retrofit-planner; do
+    echo "== $d =="; head -3 "skills/$d/SKILL.md" | grep '^name:'
+  done
+  ```
+
+  Expected: `name: design-system-audit` and `name: retrofit-planner` respectively
+  (frontmatter `name` must equal the directory name).
+
+- [ ] **Step 11.4: Commit**
+
+  ```bash
+  git add CHANGELOG.md
+  git commit -m "docs: CHANGELOG [Unreleased] — Plan 3 brownfield skills, branches, and B3 fix"
+  ```
+
+---
+
+## Self-Review (run after all tasks)
+
+**1. Spec coverage** (against `docs/superpowers/specs/2026-06-25-brownfield-retrofit-design.md`):
+- §3 unified principle / B1–B4 — B1/B2/B4 landed in Plan 1 (docs); **B3 behavioral fix → Task 8.** ✓
+- §4.1 `design-system-audit` (size surface, per-class inventory, % semantic, owns `audit`,
+  sets `intakeMode: retrofit`) → **Task 3** (consumes Task 1's grep + Task 2's binding audit). ✓
+- §4.2 `token-crosswalk-builder` — shipped in Plan 2. (Task 3 hands off to it; Task 9 invokes it.) ✓
+- §4.3 `retrofit-planner` (gated 7-phase sequence, ordering rules as gates, decision journal
+  default-on, owns `retrofit`) → **Task 9.** ✓
+- §5 brownfield branches: `figma-environment-setup` → **Task 4**; `token-builder` → **Task 5**;
+  `token-sync-layer` → **Task 6**; `storybook-chromatic-builder` → **Task 7.** ✓
+- §6 color-usage grep scaffold → **Task 1**; binding-survival audit in `references/` → **Task 2.**
+  (Crosswalk validator / reverse-index / token-removal guard shipped in Plan 2.) ✓
+- §7 references & guardrails — the guardrails + triad live in `brownfield-retrofit.md` (Plan 1);
+  Tasks 4–9 wire skills to **read** it at the right moments. ✓
+- §8 manifest — schemaVersion 4 + all sections shipped in Plan 1; Tasks 3/9/10 **write/read** the
+  `audit` / `retrofit` fields with the documented names. ✓
+- §10 bug traceability — B3 (Task 8). ✓
+- §11 Plan-3 carry-forwards: B3 (Task 8); close interim inventory gap (Task 3 + routing in Task 4);
+  wire `brownfield-retrofit.md` into the skills that need it (Tasks 3,4,5,6,7,9 all `Read` it);
+  don't hardcode the case-study stack (detect-tooling guidance in Tasks 3, 7, 9); surface new
+  manifest sections in `/design-system-status` + `/start` (Task 10 + Task 4). Plugin-CI is
+  explicitly out of scope (§11 "not plan-specific"). ✓
+
+**2. Placeholder scan:** No "TBD"/"TODO"/"implement later". Task 1 shows complete, runnable code +
+tests with exact expected output; every skill/branch task shows the exact text to insert/replace
+with a unique anchor; every run step shows the command and expected output. The one deliberate
+in-place correction (ESM has no `require`) is called out explicitly in Step 1.3's note and applied
+in Step 1.4.
+
+**3. Type/name consistency:**
+- Manifest field names used across tasks match `references/manifest-schema.md` exactly:
+  `audit.{ranAt, codeSurface, figmaInventory.{variables,bindings,textStyles,effectStyles,modes},
+  percentSemantic}`, `tokenCrosswalk.{path, statusCounts, validatorPassing}`,
+  `retrofit.{phase, startedAt, completedAt, journalScaffolded}`, `tokens.intakeMode: "retrofit"`,
+  `figma.{libraryPublished, canPublish, publishedAt}`, `workspace.origin`.
+- Skill identifiers are consistent everywhere they're named: `design-system-audit`,
+  `retrofit-planner`, `token-crosswalk-builder`, `token-builder`, `token-sync-layer`,
+  `storybook-chromatic-builder`, `component-builder`, `figma-environment-setup`.
+- Exported function names in the new script match between module and tests: `grepColorUsage`,
+  `scanFile`, `walk`, `DEFAULT_CATEGORIES`, `DEFAULT_EXCLUDES` (Task 1).
+- The `audit.codeSurface` category keys match the grep's `DEFAULT_CATEGORIES` keys:
+  `scssColorVars`, `tailwindColorClasses`, `jsColorsUsages`, `rawHexRgba`, `svgFills`.
+- The retrofit `phase` values match the manifest enum and the safe-sequence order:
+  `audit | refine | rebind | sync | baseline | code | cleanup | done`.
+- Figma read tools referenced consistently: `figma_get_variables`, `figma_get_text_styles`,
+  `figma_get_styles`, `figma_get_library_components`, `figma_get_library_variables`,
+  `figma_get_file_versions`, `figma_rename_variable`, `loadAllPagesAsync`.
+
+---
+
+## Execution Handoff
+
+Plan 3 of 3 — the final plan of the brownfield retrofit effort. After this ships, the plugin
+handles a full brownfield retrofit end to end (audit → gated 7-phase retrofit → cleanup), greenfield
+paths untouched, all four bugs (B1–B4) addressed.
+
+**Critical dependency note:** Plan 3 builds on Plan 1 (manifest v4, `references/brownfield-retrofit.md`,
+B1/B2/B4 docs) and Plan 2 (crosswalk schema + scripts + `token-crosswalk-builder`), both of which
+live on the PR #12 branch (`claude/infallible-colden-cd4503`). This worktree already has those
+artifacts present, so execution can proceed here; if executing elsewhere, branch off the Plan 1/2
+branch, not a stale `main`.
+
+**Remaining cross-cutting risks (not owned by this plan, per §11):** the B1/B2/B4 fixes remain
+unverified against a real system (case-study-authored, not reproduced); there is still no plugin CI
+validating SKILL.md frontmatter / `plugin.json` / the manifest schema. Both are tracked in the spec
+§11 as cross-cutting; neither blocks Plan 3.

--- a/docs/superpowers/plans/2026-06-27-plugin-ci.md
+++ b/docs/superpowers/plans/2026-06-27-plugin-ci.md
@@ -1,0 +1,695 @@
+# ThroughLine Plugin CI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the repository's first GitHub Actions workflow — zero-dependency Node validators for the plugin's metadata (`plugin.json`, `marketplace.json`, `SKILL.md` + command frontmatter, the manifest doc's example) plus wiring the existing 43-test suite into CI.
+
+**Architecture:** Plugin-internal validators live in a new top-level `ci/` directory (distinct from `scripts/`, which is copied into user repos). Each validator is a zero-dep ESM module exporting **pure functions** (input: strings/objects → output: `string[]` of problems) plus a thin CLI entry that reads the real repo files and resolves paths relative to the script location. Tests are colocated `*.test.mjs` exercising the pure functions against crafted inputs. The GitHub Actions workflow runs `node --test` (the existing 43 tests + the new logic tests) and the two validator CLIs against the real repo.
+
+**Tech Stack:** Node 20 (CI) / Node ≥18 stdlib only — `node:test`, `node:assert/strict`, `node:fs`, `node:path`, `node:url`. No dependencies, no `package.json`, no install step. GitHub Actions.
+
+**Conventions to match (from `scripts/`):** ESM `.mjs`; pure exported functions + a `main()` guarded by `if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href)`; success → `console.log` a one-line `✓` summary and return; failure → `console.error` each problem and `process.exit(1)`. Tests use `import { test } from 'node:test'` and `import assert from 'node:assert/strict'`. The suite is run with **bare `node --test` from the repo root** (never `node --test ci/` — pathed invocation errors on Node ≥21).
+
+---
+
+## Task 1: Frontmatter parser (`ci/lib/frontmatter.mjs`)
+
+**Files:**
+- Create: `ci/lib/frontmatter.mjs`
+- Test: `ci/lib/frontmatter.test.mjs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `ci/lib/frontmatter.test.mjs`:
+
+```js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseFrontmatter } from './frontmatter.mjs';
+
+test('parses name and description into data, returns body', () => {
+  const text = '---\nname: foo\ndescription: a thing\n---\n# Heading\nbody text\n';
+  const { data, body } = parseFrontmatter(text);
+  assert.equal(data.name, 'foo');
+  assert.equal(data.description, 'a thing');
+  assert.equal(body, '# Heading\nbody text\n');
+});
+
+test('strips wrapping double quotes from a value', () => {
+  const { data } = parseFrontmatter('---\ndescription: "quoted value"\n---\n');
+  assert.equal(data.description, 'quoted value');
+});
+
+test('strips wrapping single quotes from a value', () => {
+  const { data } = parseFrontmatter("---\ndescription: 'quoted value'\n---\n");
+  assert.equal(data.description, 'quoted value');
+});
+
+test('preserves colons inside a value (splits on first colon only)', () => {
+  const { data } = parseFrontmatter('---\ndescription: IMPORTANT: do the thing\n---\n');
+  assert.equal(data.description, 'IMPORTANT: do the thing');
+});
+
+test('throws when the opening fence is missing', () => {
+  assert.throws(() => parseFrontmatter('name: foo\n---\n'), /opening/);
+});
+
+test('throws when the closing fence is missing', () => {
+  assert.throws(() => parseFrontmatter('---\nname: foo\n'), /closing/);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `node --test ci/lib/frontmatter.test.mjs`
+Expected: FAIL — `Cannot find module './frontmatter.mjs'` (or similar import error).
+
+- [ ] **Step 3: Write the implementation**
+
+Create `ci/lib/frontmatter.mjs`:
+
+```js
+// Minimal, zero-dependency parser for the simple single-line `key: value`
+// frontmatter used by the plugin's SKILL.md and command files. Values may be
+// wrapped in matching single or double quotes. Splits each line on the FIRST
+// colon, so colons inside a value are preserved.
+//
+// This is intentionally NOT a full YAML parser: no nested maps, lists, or
+// multi-line scalars. The current corpus has none; if a future file needs
+// richer frontmatter, this throws (a missing/malformed fence) rather than
+// silently mis-parsing.
+
+export function parseFrontmatter(text) {
+  const lines = text.split('\n');
+  if (lines[0].trim() !== '---') {
+    throw new Error('missing opening --- frontmatter fence');
+  }
+  let end = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === '---') {
+      end = i;
+      break;
+    }
+  }
+  if (end === -1) {
+    throw new Error('missing closing --- frontmatter fence');
+  }
+  const data = {};
+  for (let i = 1; i < end; i++) {
+    const line = lines[i];
+    if (line.trim() === '') continue;
+    const colon = line.indexOf(':');
+    if (colon === -1) {
+      throw new Error(`malformed frontmatter line (no colon): ${line}`);
+    }
+    const key = line.slice(0, colon).trim();
+    const value = stripQuotes(line.slice(colon + 1).trim());
+    data[key] = value;
+  }
+  const body = lines.slice(end + 1).join('\n');
+  return { data, body };
+}
+
+function stripQuotes(s) {
+  if (
+    s.length >= 2 &&
+    ((s[0] === '"' && s[s.length - 1] === '"') ||
+      (s[0] === "'" && s[s.length - 1] === "'"))
+  ) {
+    return s.slice(1, -1);
+  }
+  return s;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `node --test ci/lib/frontmatter.test.mjs`
+Expected: PASS — 6 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ci/lib/frontmatter.mjs ci/lib/frontmatter.test.mjs
+git commit -m "feat(ci): zero-dep frontmatter parser for plugin metadata validation"
+```
+
+---
+
+## Task 2: Plugin manifest validator (`ci/validate-plugin.mjs`)
+
+**Files:**
+- Create: `ci/validate-plugin.mjs`
+- Test: `ci/validate-plugin.test.mjs`
+
+Validates `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `ci/validate-plugin.test.mjs`:
+
+```js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { validatePlugin } from './validate-plugin.mjs';
+
+const validPlugin = {
+  name: 'throughline',
+  description: 'a design system plugin',
+  version: '0.9.0',
+  author: { name: 'Jordan Pease' },
+  keywords: ['figma', 'tokens'],
+};
+
+const validMarketplace = {
+  name: 'throughline-marketplace',
+  owner: { name: 'Jordan Pease' },
+  plugins: [
+    { name: 'throughline', source: './', description: 'build a design system' },
+  ],
+};
+
+test('valid manifests produce no problems', () => {
+  const problems = validatePlugin({ plugin: validPlugin, marketplace: validMarketplace });
+  assert.deepEqual(problems, []);
+});
+
+test('flags a missing plugin name', () => {
+  const problems = validatePlugin({ plugin: { ...validPlugin, name: '' }, marketplace: validMarketplace });
+  assert.ok(problems.some((p) => /plugin\.json.*name/.test(p)));
+});
+
+test('flags an invalid semver version', () => {
+  const problems = validatePlugin({ plugin: { ...validPlugin, version: 'v1' }, marketplace: validMarketplace });
+  assert.ok(problems.some((p) => /version.*semver/.test(p)));
+});
+
+test('flags keywords that are not an array of strings', () => {
+  const problems = validatePlugin({ plugin: { ...validPlugin, keywords: 'figma' }, marketplace: validMarketplace });
+  assert.ok(problems.some((p) => /keywords/.test(p)));
+});
+
+test('flags an empty plugins array in the marketplace', () => {
+  const problems = validatePlugin({ plugin: validPlugin, marketplace: { ...validMarketplace, plugins: [] } });
+  assert.ok(problems.some((p) => /plugins.*non-empty array/.test(p)));
+});
+
+test('flags a marketplace plugin entry missing a source', () => {
+  const bad = { ...validMarketplace, plugins: [{ name: 'throughline', description: 'x' }] };
+  const problems = validatePlugin({ plugin: validPlugin, marketplace: bad });
+  assert.ok(problems.some((p) => /plugins\[0\]\.source/.test(p)));
+});
+
+test('flags when no marketplace entry name matches plugin.json name', () => {
+  const bad = { ...validMarketplace, plugins: [{ name: 'other', source: './', description: 'x' }] };
+  const problems = validatePlugin({ plugin: validPlugin, marketplace: bad });
+  assert.ok(problems.some((p) => /must match plugin\.json/.test(p)));
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `node --test ci/validate-plugin.test.mjs`
+Expected: FAIL — cannot find module `./validate-plugin.mjs`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `ci/validate-plugin.mjs`:
+
+```js
+// Validates the plugin's two manifest files. Pure function + CLI.
+// Run from anywhere: paths resolve relative to this file (repo root is `..`).
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const SEMVER = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+
+export function validatePlugin({ plugin, marketplace }) {
+  const problems = [];
+
+  // plugin.json
+  if (!isNonEmptyString(plugin.name)) {
+    problems.push('plugin.json: "name" must be a non-empty string');
+  }
+  if (!isNonEmptyString(plugin.description)) {
+    problems.push('plugin.json: "description" must be a non-empty string');
+  }
+  if (!isNonEmptyString(plugin.version)) {
+    problems.push('plugin.json: "version" must be a non-empty string');
+  } else if (!SEMVER.test(plugin.version)) {
+    problems.push(`plugin.json: "version" is not valid semver: ${plugin.version}`);
+  }
+  if (plugin.author === undefined || plugin.author === null) {
+    problems.push('plugin.json: "author" is required');
+  }
+  if (plugin.keywords !== undefined) {
+    if (!Array.isArray(plugin.keywords) || !plugin.keywords.every(isNonEmptyString)) {
+      problems.push('plugin.json: "keywords" must be an array of non-empty strings');
+    }
+  }
+
+  // marketplace.json
+  if (!isNonEmptyString(marketplace.name)) {
+    problems.push('marketplace.json: "name" must be a non-empty string');
+  }
+  if (marketplace.owner === undefined || marketplace.owner === null) {
+    problems.push('marketplace.json: "owner" is required');
+  }
+  if (!Array.isArray(marketplace.plugins) || marketplace.plugins.length === 0) {
+    problems.push('marketplace.json: "plugins" must be a non-empty array');
+  } else {
+    marketplace.plugins.forEach((p, i) => {
+      if (!isNonEmptyString(p.name)) problems.push(`marketplace.json: plugins[${i}].name must be a non-empty string`);
+      if (!isNonEmptyString(p.source)) problems.push(`marketplace.json: plugins[${i}].source must be a non-empty string`);
+      if (!isNonEmptyString(p.description)) problems.push(`marketplace.json: plugins[${i}].description must be a non-empty string`);
+    });
+    if (isNonEmptyString(plugin.name) && !marketplace.plugins.some((p) => p.name === plugin.name)) {
+      problems.push(`marketplace.json: no plugin entry has name "${plugin.name}" (must match plugin.json)`);
+    }
+  }
+
+  return problems;
+}
+
+function isNonEmptyString(v) {
+  return typeof v === 'string' && v.trim().length > 0;
+}
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+function readJson(path) {
+  try {
+    return { value: JSON.parse(readFileSync(path, 'utf8')) };
+  } catch (err) {
+    return { error: `${path}: ${err.message}` };
+  }
+}
+
+function main() {
+  const p = readJson(join(REPO_ROOT, '.claude-plugin', 'plugin.json'));
+  const m = readJson(join(REPO_ROOT, '.claude-plugin', 'marketplace.json'));
+  const problems = [];
+  if (p.error) problems.push(p.error);
+  if (m.error) problems.push(m.error);
+  if (!p.error && !m.error) {
+    problems.push(...validatePlugin({ plugin: p.value, marketplace: m.value }));
+  }
+  if (problems.length === 0) {
+    console.log('✓ plugin.json + marketplace.json OK');
+    return;
+  }
+  console.error(`✗ ${problems.length} problem(s):`);
+  for (const pr of problems) console.error(`  ${pr}`);
+  process.exit(1);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `node --test ci/validate-plugin.test.mjs`
+Expected: PASS — 7 tests pass.
+
+- [ ] **Step 5: Run the CLI against the real repo**
+
+Run: `node ci/validate-plugin.mjs`
+Expected: prints `✓ plugin.json + marketplace.json OK` and exits 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ci/validate-plugin.mjs ci/validate-plugin.test.mjs
+git commit -m "feat(ci): validate plugin.json + marketplace.json structure"
+```
+
+---
+
+## Task 3: Skill / command / manifest-doc validator (`ci/validate-skills.mjs`)
+
+**Files:**
+- Create: `ci/validate-skills.mjs`
+- Test: `ci/validate-skills.test.mjs`
+
+Validates each `skills/*/SKILL.md` frontmatter, each `commands/*.md` frontmatter, and that the `references/manifest-schema.md` example JSON parses.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `ci/validate-skills.test.mjs`:
+
+```js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  validateSkill,
+  validateCommand,
+  validateManifestDoc,
+  MAX_DESCRIPTION,
+} from './validate-skills.mjs';
+
+function skillSource({ name = 'demo', description = 'a demo skill' } = {}) {
+  return `---\nname: ${name}\ndescription: ${description}\n---\n# Demo\n`;
+}
+
+test('a well-formed skill produces no problems', () => {
+  const problems = validateSkill({ dirName: 'demo', source: skillSource() });
+  assert.deepEqual(problems, []);
+});
+
+test('flags a name that does not match the directory', () => {
+  const problems = validateSkill({ dirName: 'demo', source: skillSource({ name: 'other' }) });
+  assert.ok(problems.some((p) => /must equal the directory name/.test(p)));
+});
+
+test('flags a missing description', () => {
+  const src = '---\nname: demo\n---\n# Demo\n';
+  const problems = validateSkill({ dirName: 'demo', source: src });
+  assert.ok(problems.some((p) => /"description" is required/.test(p)));
+});
+
+test('flags an over-length description', () => {
+  const long = 'x'.repeat(MAX_DESCRIPTION + 1);
+  const problems = validateSkill({ dirName: 'demo', source: skillSource({ description: long }) });
+  assert.ok(problems.some((p) => /max/.test(p)));
+});
+
+test('reports a parse error for missing frontmatter', () => {
+  const problems = validateSkill({ dirName: 'demo', source: '# no frontmatter\n' });
+  assert.equal(problems.length, 1);
+  assert.ok(/opening/.test(problems[0]));
+});
+
+test('a well-formed command produces no problems', () => {
+  const src = '---\ndescription: do a thing\n---\nbody\n';
+  const problems = validateCommand({ fileName: 'demo.md', source: src });
+  assert.deepEqual(problems, []);
+});
+
+test('flags a command missing a description', () => {
+  const src = '---\nother: x\n---\nbody\n';
+  const problems = validateCommand({ fileName: 'demo.md', source: src });
+  assert.ok(problems.some((p) => /"description" is required/.test(p)));
+});
+
+test('manifest doc with a valid integer schemaVersion passes', () => {
+  const src = 'text\n```json\n{ "schemaVersion": 4 }\n```\nmore\n';
+  assert.deepEqual(validateManifestDoc(src), []);
+});
+
+test('flags a manifest doc whose example JSON does not parse', () => {
+  const src = '```json\n{ not json }\n```\n';
+  const problems = validateManifestDoc(src);
+  assert.ok(problems.some((p) => /does not parse/.test(p)));
+});
+
+test('flags a manifest doc whose schemaVersion is not an integer', () => {
+  const src = '```json\n{ "schemaVersion": "4" }\n```\n';
+  const problems = validateManifestDoc(src);
+  assert.ok(problems.some((p) => /must be an integer/.test(p)));
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `node --test ci/validate-skills.test.mjs`
+Expected: FAIL — cannot find module `./validate-skills.mjs`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `ci/validate-skills.mjs`:
+
+```js
+// Validates skill frontmatter (skills/*/SKILL.md), command frontmatter
+// (commands/*.md), and the manifest doc's example JSON. Pure functions + CLI.
+import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { parseFrontmatter } from './lib/frontmatter.mjs';
+
+export const MAX_DESCRIPTION = 1024;
+
+export function validateSkill({ dirName, source }) {
+  let data;
+  try {
+    ({ data } = parseFrontmatter(source));
+  } catch (err) {
+    return [`skills/${dirName}/SKILL.md: ${err.message}`];
+  }
+  const problems = [];
+  if (!isNonEmptyString(data.name)) {
+    problems.push(`skills/${dirName}/SKILL.md: "name" is required`);
+  } else if (data.name !== dirName) {
+    problems.push(`skills/${dirName}/SKILL.md: "name" (${data.name}) must equal the directory name (${dirName})`);
+  }
+  if (!isNonEmptyString(data.description)) {
+    problems.push(`skills/${dirName}/SKILL.md: "description" is required`);
+  } else if (data.description.length > MAX_DESCRIPTION) {
+    problems.push(`skills/${dirName}/SKILL.md: "description" is ${data.description.length} chars (max ${MAX_DESCRIPTION})`);
+  }
+  return problems;
+}
+
+export function validateCommand({ fileName, source }) {
+  let data;
+  try {
+    ({ data } = parseFrontmatter(source));
+  } catch (err) {
+    return [`commands/${fileName}: ${err.message}`];
+  }
+  const problems = [];
+  if (!isNonEmptyString(data.description)) {
+    problems.push(`commands/${fileName}: "description" is required`);
+  }
+  return problems;
+}
+
+export function validateManifestDoc(source) {
+  const match = source.match(/```json\n([\s\S]*?)\n```/);
+  if (!match) {
+    return ['references/manifest-schema.md: no ```json example block found'];
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(match[1]);
+  } catch (err) {
+    return [`references/manifest-schema.md: example JSON does not parse: ${err.message}`];
+  }
+  if (!Number.isInteger(parsed.schemaVersion)) {
+    return ['references/manifest-schema.md: example "schemaVersion" must be an integer'];
+  }
+  return [];
+}
+
+function isNonEmptyString(v) {
+  return typeof v === 'string' && v.trim().length > 0;
+}
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+function main() {
+  const problems = [];
+
+  const skillsDir = join(REPO_ROOT, 'skills');
+  const skillDirs = readdirSync(skillsDir).filter((d) => statSync(join(skillsDir, d)).isDirectory());
+  for (const dirName of skillDirs) {
+    const skillPath = join(skillsDir, dirName, 'SKILL.md');
+    if (!existsSync(skillPath)) {
+      problems.push(`skills/${dirName}: missing SKILL.md`);
+      continue;
+    }
+    problems.push(...validateSkill({ dirName, source: readFileSync(skillPath, 'utf8') }));
+  }
+
+  const commandsDir = join(REPO_ROOT, 'commands');
+  const commandFiles = readdirSync(commandsDir).filter((f) => f.endsWith('.md'));
+  for (const fileName of commandFiles) {
+    problems.push(...validateCommand({ fileName, source: readFileSync(join(commandsDir, fileName), 'utf8') }));
+  }
+
+  problems.push(...validateManifestDoc(readFileSync(join(REPO_ROOT, 'references', 'manifest-schema.md'), 'utf8')));
+
+  if (problems.length === 0) {
+    console.log(`✓ ${skillDirs.length} skills, ${commandFiles.length} commands, manifest doc OK`);
+    return;
+  }
+  console.error(`✗ ${problems.length} problem(s):`);
+  for (const pr of problems) console.error(`  ${pr}`);
+  process.exit(1);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `node --test ci/validate-skills.test.mjs`
+Expected: PASS — 10 tests pass.
+
+- [ ] **Step 5: Run the CLI against the real repo**
+
+Run: `node ci/validate-skills.mjs`
+Expected: prints `✓ 12 skills, 4 commands, manifest doc OK` and exits 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ci/validate-skills.mjs ci/validate-skills.test.mjs
+git commit -m "feat(ci): validate SKILL.md/command frontmatter + manifest-doc example"
+```
+
+---
+
+## Task 4: Full-suite check + `ci/README.md`
+
+**Files:**
+- Create: `ci/README.md`
+
+- [ ] **Step 1: Run the full suite from the repo root**
+
+Run: `node --test`
+Expected: PASS — the existing 43 tests **plus** the 23 new tests (6 + 7 + 10) = **66 tests, 0 fail**. Confirm the summary line reads `tests 66 / pass 66 / fail 0`.
+
+- [ ] **Step 2: Run both CLIs from the repo root**
+
+Run:
+```bash
+node ci/validate-plugin.mjs && node ci/validate-skills.mjs
+```
+Expected: two `✓` lines, exit 0.
+
+- [ ] **Step 3: Write `ci/README.md`**
+
+Create `ci/README.md`:
+
+```markdown
+# `ci/` — plugin self-validation
+
+Plugin-internal validators run by GitHub Actions (`.github/workflows/ci.yml`).
+**Not** copied into user repos — unlike `scripts/`, these guard *this plugin's*
+own structure. Zero dependencies; stdlib only.
+
+## What runs in CI
+
+1. `node --test` — the full test suite (these validators' logic tests + the
+   `scripts/` suite). Run with **bare `node --test` from the repo root**, never
+   `node --test ci/` (pathed invocation errors on Node ≥21).
+2. `node ci/validate-plugin.mjs` — `.claude-plugin/plugin.json` and
+   `marketplace.json`: valid JSON, required fields, semver version, and that a
+   marketplace entry's `name` matches `plugin.json`.
+3. `node ci/validate-skills.mjs` — every `skills/*/SKILL.md` has `name`
+   (matching its directory) and a `description` (≤ 1024 chars); every
+   `commands/*.md` has a `description`; and the `references/manifest-schema.md`
+   example JSON parses with an integer `schemaVersion`.
+
+## Run locally
+
+```bash
+node --test                  # all tests
+node ci/validate-plugin.mjs  # guard plugin manifests
+node ci/validate-skills.mjs  # guard skill/command/manifest-doc structure
+```
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ci/README.md
+git commit -m "docs(ci): README for plugin self-validation validators"
+```
+
+---
+
+## Task 5: GitHub Actions workflow + CHANGELOG
+
+**Files:**
+- Create: `.github/workflows/ci.yml`
+- Modify: `CHANGELOG.md` (the `## [Unreleased]` section)
+
+- [ ] **Step 1: Write the workflow**
+
+Create `.github/workflows/ci.yml`:
+
+```yaml
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Run test suite
+        run: node --test
+      - name: Validate plugin manifests
+        run: node ci/validate-plugin.mjs
+      - name: Validate skill/command frontmatter
+        run: node ci/validate-skills.mjs
+```
+
+- [ ] **Step 2: Lint the workflow YAML locally**
+
+Run: `node -e "const fs=require('node:fs');const s=fs.readFileSync('.github/workflows/ci.yml','utf8');if(!/jobs:/.test(s)||!/node --test/.test(s))throw new Error('workflow missing expected keys');console.log('workflow shape OK')"`
+Expected: prints `workflow shape OK`. (There is no YAML parser in the zero-dep toolchain; this is a smoke check. Real validation happens when the workflow runs on GitHub.)
+
+- [ ] **Step 3: Add a CHANGELOG entry**
+
+In `CHANGELOG.md`, under `## [Unreleased]` → `### Added`, add this bullet (place it after the existing brownfield bullets):
+
+```markdown
+- **Plugin CI (first GitHub Actions workflow).** `.github/workflows/ci.yml` runs
+  on every pull request and on pushes to `main`: the full `node --test` suite
+  plus two zero-dependency structural validators in `ci/` — `validate-plugin.mjs`
+  (plugin.json / marketplace.json: valid JSON, required fields, semver, name
+  match) and `validate-skills.mjs` (every SKILL.md `name` matches its directory
+  and has a ≤1024-char description; every command has a description; the
+  manifest-doc example JSON parses with an integer `schemaVersion`). Closes the
+  "no plugin CI" carry-forward from the brownfield retrofit effort.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/ci.yml CHANGELOG.md
+git commit -m "feat(ci): GitHub Actions workflow running tests + structural validators"
+```
+
+- [ ] **Step 5: Final full verification**
+
+Run all three from the repo root one last time:
+```bash
+node --test && node ci/validate-plugin.mjs && node ci/validate-skills.mjs
+```
+Expected: `tests 66 / pass 66 / fail 0`, then two `✓` lines, overall exit 0.
+
+---
+
+## Notes for the executor
+
+- **Do not** add a `package.json`, install any dependency, or import anything
+  outside the Node stdlib. The entire `scripts/` + `ci/` toolchain is deliberately
+  zero-dependency.
+- The validators resolve paths relative to their own file location (repo root is
+  `..`), so they run correctly from any working directory; CI runs them from the
+  repo root regardless.
+- The 12 existing skills and 4 commands already satisfy these rules (verified
+  while authoring this plan: all `name` values match their directories; the
+  longest description is 856 chars), so the real-repo CLI runs in Tasks 2, 3, and
+  5 are expected to pass on first try. If one fails, that is a real pre-existing
+  inconsistency to fix, not a validator bug.
+- After all tasks: this is part of open PR #12. Per the project's integration
+  habit, push to `origin/claude/infallible-colden-cd4503` and fold a short
+  mention into the PR description (the carry-forward note can be updated to
+  "addressed").
+```

--- a/docs/superpowers/specs/2026-06-25-brownfield-retrofit-design.md
+++ b/docs/superpowers/specs/2026-06-25-brownfield-retrofit-design.md
@@ -1,0 +1,284 @@
+# Brownfield Design-System Retrofit — Design Spec
+
+> **Status:** Approved design, pre-implementation.
+> **Source:** `docs/brownfield-retrofit-learnings.md` (the Sweet app PR #443 case
+> study) plus bugs B1–B4 in `BACKLOG.md`.
+> **Goal:** Equip the ThroughLine plugin to handle large-scale retrofits — a mature
+> codebase **and** an already-populated Figma file reconciled onto a two-tier token
+> system — as elegantly as it handles greenfield builds today.
+
+---
+
+## 1. Problem
+
+Every current skill assumes **greenfield** (build from scratch):
+
+- `token-builder` — "starting the foundation of a design system"
+- `repository-builder` — "graduate the local folder into a real monorepo"
+- `design-system-status` / `figma-environment-setup` — read/scan local state, never
+  assess a mature *external* system
+- `component-builder`, `storybook-chromatic-builder` — build *new* artifacts
+
+Nothing handles **"both artifacts already exist and have drifted — reconcile and
+retrofit them onto tokens"** without breaking a live app or unbinding existing
+Figma components. A brownfield retrofit runs almost backwards from greenfield: it
+starts from two mature, drifted artifacts and converges them.
+
+Separately, four bugs surfaced in testing that share one root cause — **the plugin
+asserts state without performing a verified read**:
+
+- **B1** — existing-file variable read reported "0 variables" on first pass
+  (stale/cache/early read) until the user said it was wrong.
+- **B2** — assumed "no text styles" because it found no text *variables* — never
+  actually read the styles.
+- **B3** — can't reliably detect library publish state, so silently assumes "not
+  published."
+- **B4** — phantom stale bridge ports hard-block progress; the user never opened
+  extra instances.
+
+This spec addresses the brownfield gap **and** all four bugs, because the
+"never assert absence without a verified read" principle is the same fix surface
+the audit/detection work touches.
+
+---
+
+## 2. Approach (decided)
+
+- **Scope:** Full brownfield capability in one coordinated effort.
+- **Front door:** No new command. `/start` (via `figma-environment-setup`)
+  **auto-detects** a brownfield situation and routes into the audit.
+- **Scripts:** **Hybrid** — canonical vetted scripts in a new `scripts/` dir for the
+  generalizable tools; a skill-adapted scaffold for the inherently repo-shaped grep;
+  Figma-side snippets stay in `references/`.
+- **Decision journal:** `retrofit-planner` **offers, default-on** for retrofits.
+- **Bugs:** **Fold in all four (B1–B4)** under one unified principle.
+
+---
+
+## 3. Unified principle (fixes B1–B4)
+
+Add a hard rule, stated once in `references/brownfield-retrofit.md` and referenced
+wherever state is detected:
+
+> **Never assert that something is absent, empty, unpublished, or stale without an
+> explicit, completed read that returned that result.** "I didn't find X" must mean
+> "I queried for X and the result was empty (after the file/pages fully loaded),"
+> never "I assumed X from Y." When a result is genuinely undetectable, **ask the
+> user once and persist the answer in the manifest** — never guess.
+
+Concrete applications:
+
+- **B1:** Before counting variables, `await figma.loadAllPagesAsync()`. Treat a `0`
+  count on first read as suspect — retry / re-read before reporting. An
+  unexpectedly-empty result is a possible read error, not ground truth.
+- **B2:** Variables and styles are **different surfaces**. Query each independently:
+  variables (`figma_get_variables`), text styles (`figma_get_text_styles`),
+  effect/paint styles (`figma_get_styles`). Only report "none" for the specific
+  class whose read returned empty.
+- **B3:** Try to detect publish state first (`figma_get_library_components` /
+  `figma_get_library_variables`, library component keys). If detection is
+  unreliable, **ask once** ("Is this library published to a team library?") and
+  persist in the manifest. Frame the unpublished path as a graceful choice, not a
+  failure. (Ties to existing feature #6 — the publishing checkpoint.)
+- **B4:** Distinguish **live** concurrent bridge instances from **dead/stale**
+  entries. Only hard-block on genuinely live ones; auto-reap or offer one-click
+  cleanup for stale ones. If a real block is needed, name the exact ports and give a
+  concrete clear path (`figma_reconnect`, reload plugin) — never just "shut down the
+  others." Investigate the root cause (plugin reload / MCP reconnect spawning a port
+  without reaping the old one / same session double-counted).
+
+---
+
+## 4. New skills
+
+### 4.1 `design-system-audit` — the front door (PROCESS skill)
+
+Runs after `figma-environment-setup` detects brownfield, before any building.
+Mirrors what `design-system-status` would be if it assessed an *external* system
+instead of a local JSON.
+
+**Steps:**
+
+1. **Size the code surface** — run the color-usage grep scaffold (adapted to the
+   detected repo) to count: SCSS color vars, Tailwind color classes, JS `Colors.*`
+   usages, raw hex + `rgba()` literals, SVG hardcoded fills. Produce a worklist with
+   counts (the Sweet table shape).
+2. **Inventory the Figma file** — explicit per-class reads (honoring §3): variable
+   count, **binding count**, text styles, effect/paint styles, modes.
+3. **Compute "% semantic"** — report e.g. "you're ~90% semantic," which decides
+   whether this is a rename+cleanup or a rewrite. Surface early so the user
+   right-sizes effort.
+4. **Write `audit` manifest section** and recommend the next step (`retrofit-planner`
+   or `token-crosswalk-builder`).
+
+**Frontmatter:** `name: design-system-audit`; description marks it PROCESS, triggers
+on brownfield detection. Default model per house style.
+
+**Owns manifest:** `audit.*`, sets `tokens.intakeMode: "retrofit"`.
+
+### 4.2 `token-crosswalk-builder` — the backbone artifact
+
+Builds the persistent three-way map: **new token ↔ old Figma token ↔ code
+identifier**, as `tokens/crosswalk.json`.
+
+- **Columns:** `newToken`, `newValue`, `tier`, `figmaOld`, `codeTokens[]`,
+  `status`, `recommendedSemantic`.
+- **`status` enum:** `aligned | renamed | drift-fix | added | mapped-nearest`.
+- **Reverse index:** code symbol → new token, emitted to semi-automate SCSS/Tailwind
+  swaps.
+- **Validator gate:** `tokens:validate` must pass N/N (resolved value == new value).
+  Ships as a canonical script (see §6).
+
+**Owns manifest:** `tokenCrosswalk` (pointer to the file + status counts).
+
+### 4.3 `retrofit-planner` — the orchestrator
+
+Mirrors `component-pipeline`: invokes sub-skills via the **Skill tool**, with a
+**human confirmation gate between every stage**, and only updates the manifest
+fields it owns (`retrofit.phase`, `completedSkills`).
+
+**Encoded safe sequence (with gates):**
+
+1. **Audit** → `design-system-audit`
+2. **Refine in place** → `token-builder` (brownfield branch; never delete/recreate)
+3. **Rebind components** (preserve Figma IDs / bindings)
+4. **Sync layer** → `token-sync-layer` (brownfield transforms)
+5. **Capture Chromatic baseline** → `storybook-chromatic-builder` — *before* code
+   retrofit, so intended drift-fixes are distinguishable from regressions
+6. **Retrofit code** (dual-output: new + old tokens coexist)
+7. **Remove old outputs** — *only* after a zero-reference grep passes (the
+   token-removal guard, §6)
+
+**Non-obvious ordering rules baked in as gates:**
+- Refine-in-place, never delete-and-recreate variables (preserves IDs → bindings).
+- Chromatic baseline before the code retrofit.
+- Dual-output transition; delete old only after zero-reference grep.
+- Verify with the actual app, not just the build (verification triad, §7).
+
+**Decision-journal offer (default-on):** at the start of a retrofit, offer to
+scaffold `docs/design-system/` (`specs/ plans/ spikes/ findings/ decisions/
+handoffs/`). Recommend yes (retrofits are multi-session); allow decline. This is the
+human decision trail, complementary to the manifest's machine state.
+
+**Owns manifest:** `retrofit.*`, appends to `completedSkills`.
+
+---
+
+## 5. Brownfield branches in existing skills
+
+| Skill | Added branch |
+| --- | --- |
+| `figma-environment-setup` | **Detection + routing:** extend Step 0 scan to fingerprint existing code tokens and (once Figma is connected) the Figma variable structure; route a mature codebase and/or populated Figma file to `design-system-audit`. **Baseline before mutation:** capture a Figma version checkpoint / token export for rollback before any write. Apply §3 to all reads here (B1/B2). Harden the bridge-port preflight per B4. |
+| `token-builder` | **Refine-in-place path:** detect existing variables; rename **preserving IDs**; run a **binding-survival audit** (count bindings before/after a rename — see §6 / figma-scripting). Never delete-and-recreate. |
+| `token-sync-layer` | **Transforms learned the hard way:** emit alpha as `rgb(… / <alpha-value>)` **channels** (so Tailwind `/opacity` modifiers survive), normalize opacity **0–100 → 0–1**, round **float32 noise at the export boundary** (`Math.round(v*100)/100`). Also: convert `/opacity` on var-based tokens to `color-mix(in srgb, var(--…) NN%, transparent)` / channel alpha. |
+| `storybook-chromatic-builder` | **Baseline-before-retrofit** guidance + the **verification triad** (§7) + explicit warnings: `build-storybook` only compiles **story-reachable** SCSS; **Chromatic — not `tsc`/build — is the source of truth** for color-utility removal. |
+
+---
+
+## 6. Scripts (hybrid)
+
+New `scripts/` directory — the executable analog of `references/`.
+
+**Canonical, vetted, shipped as-is (generalizable / schema-driven):**
+
+- **Crosswalk validator** — resolved value == new value; the N/N CI gate.
+- **Reverse-index generator** — code symbol → new token, from `crosswalk.json`.
+- **Repo-wide token-removal guard** — grep all `.tsx/.ts` (minus generated + tests)
+  for references to about-to-be-deleted utilities; deleted Tailwind utilities become
+  silent no-ops, so `tsc`/build won't catch them.
+
+**Skill-adapted scaffold (inherently repo-shaped):**
+
+- **Color-usage grep** — ships the categories + structure; `design-system-audit`
+  tunes the patterns (`$primary-*`, `bg-primary-red`, `Colors.*`, hex/rgba, SVG
+  fills) to the detected codebase.
+
+**Stays in `references/` (runs in Figma, not the repo):**
+
+- **Binding-survival audit** — `figma_execute` snippet that counts bindings
+  before/after a rename. Documented in `references/figma-scripting.md` in the
+  existing gotcha/snippet format. Feeds `audit` manifest results.
+
+---
+
+## 7. References & guardrails
+
+**New `references/brownfield-retrofit.md`** — canonical home for:
+
+- The **unified principle** (§3).
+- The **7 DON'T guardrails** (each a hard rule):
+  1. Don't bind line-height/letter-spacing variables to text styles (Figma stores
+     PERCENT; a unitless `1.6` rebinds as `1.6px`). **Font-size binding only.**
+  2. Don't normalize float32 in Figma (no-op — it re-quantizes). Normalize at the
+     export boundary.
+  3. Don't delete-and-recreate variables to rename — it unbinds everything. Rename
+     in place to preserve IDs.
+  4. Don't trust `tsc`/build to catch Tailwind color-utility removal — guard
+     repo-wide; let Chromatic be the net.
+  5. Don't assume `build-storybook` exercises all SCSS — run the app, spot-check
+     5–7 routes before declaring an SCSS change done.
+  6. Don't carry `/opacity` modifiers onto var-based tokens — convert to
+     `color-mix` or channel-based alpha.
+  7. Don't hand-edit generated files — change the source, re-run `tokens:sync`.
+- The **safe sequence** (§4.3).
+- The **verification triad**: (1) `check-types` (TypeScript), (2) `build-storybook` +
+  Chromatic snapshots, (3) **run the actual app** + spot-check real routes. `tsc` is
+  blind to Tailwind silent no-ops; Storybook is blind to story-unreachable code;
+  neither catches the other's gaps — all three are necessary.
+
+The sync-specific guardrails (1, 2, 6) are **also** surfaced in
+`references/sync-adapters.md` / `token-sync-layer` where they're applied.
+
+---
+
+## 8. Manifest changes (`design-system.json`)
+
+Bump `schemaVersion` 3 → 4. **New sections only — no existing field changes.**
+
+```jsonc
+"audit": {
+  "codeSurface": { "scssColorVars": 692, "tailwindColorClasses": 230, "jsColorsUsages": 74, "rawHexRgba": 143, "svgFills": 430 },
+  "figmaInventory": { "variables": 0, "bindings": 0, "textStyles": 0, "effectStyles": 0, "modes": [] },
+  "percentSemantic": null,
+  "ranAt": "<ISO>"
+},
+"tokenCrosswalk": {
+  "path": "tokens/crosswalk.json",
+  "statusCounts": { "aligned": 0, "renamed": 0, "driftFix": 0, "added": 0, "mappedNearest": 0 },
+  "validatorPassing": null
+},
+"retrofit": {
+  "phase": "audit",            // audit | refine | rebind | sync | baseline | code | cleanup | done
+  "startedAt": "<ISO>",
+  "completedAt": null,
+  "journalScaffolded": false
+},
+"figma": {
+  "libraryPublished": null     // B3: null = unknown/ask; true/false once detected or answered
+}
+```
+
+Extend `tokens.intakeMode` enum with `"retrofit"`. Honor immutables: `workspace.origin`
+set once; `completedSkills` append-only; no skill writes another skill's fields.
+
+---
+
+## 9. Out of scope
+
+- Automating Figma library publishing (not exposed by the API; user-only, plan-gated
+  — see feature #6). We only *detect or ask*, never publish.
+- Non-color token retrofits beyond what the case study covered (type/spacing/radius
+  follow the same crosswalk pattern but aren't separately specced here).
+- Rewriting greenfield skills — brownfield is added as **branches**, greenfield paths
+  are untouched.
+
+---
+
+## 10. Bug → fix traceability
+
+| Bug | Fixed by |
+| --- | --- |
+| B1 (0-variables false read) | §3 + `design-system-audit` step 2 + `figma-environment-setup` reads |
+| B2 (assumed no text styles) | §3 (per-class independent reads) |
+| B3 (publish-state assumption) | §3 + `figma.libraryPublished` manifest field + detect-or-ask |
+| B4 (phantom bridge ports) | §3 + `figma-environment-setup` bridge-port preflight hardening |

--- a/docs/superpowers/specs/2026-06-25-brownfield-retrofit-design.md
+++ b/docs/superpowers/specs/2026-06-25-brownfield-retrofit-design.md
@@ -75,11 +75,14 @@ Concrete applications:
   variables (`figma_get_variables`), text styles (`figma_get_text_styles`),
   effect/paint styles (`figma_get_styles`). Only report "none" for the specific
   class whose read returned empty.
-- **B3:** Try to detect publish state first (`figma_get_library_components` /
-  `figma_get_library_variables`, library component keys). If detection is
-  unreliable, **ask once** ("Is this library published to a team library?") and
-  persist in the manifest. Frame the unpublished path as a graceful choice, not a
-  failure. (Ties to existing feature #6 — the publishing checkpoint.)
+- **B3:** Uses the **existing** manifest fields `figma.canPublish` (null until
+  asked), `figma.libraryPublished` (default `false`), and `figma.publishedAt` — no
+  new field. The fix is **behavioral**: treat a default/`false` `libraryPublished`
+  as *unverified*, not "definitely not published." Try to detect first
+  (`figma_get_library_components` / `figma_get_library_variables`, library component
+  keys). If detection is unreliable, **ask once** ("Is this library published to a
+  team library?") and persist. Frame the unpublished path as a graceful choice, not
+  a failure. (Ties to existing feature #6 — the publishing checkpoint.)
 - **B4:** Distinguish **live** concurrent bridge instances from **dead/stale**
   entries. Only hard-block on genuinely live ones; auto-reap or offer one-click
   cleanup for stale ones. If a real block is needed, name the exact ports and give a
@@ -252,13 +255,14 @@ Bump `schemaVersion` 3 → 4. **New sections only — no existing field changes.
   "startedAt": "<ISO>",
   "completedAt": null,
   "journalScaffolded": false
-},
-"figma": {
-  "libraryPublished": null     // B3: null = unknown/ask; true/false once detected or answered
 }
 ```
 
-Extend `tokens.intakeMode` enum with `"retrofit"`. Honor immutables: `workspace.origin`
+Extend `tokens.intakeMode` enum with `"retrofit"` (existing values:
+`generative | descriptive | import`). **B3 adds no field** — it reuses
+`figma.canPublish` / `figma.libraryPublished` / `figma.publishedAt`; the field-doc
+text is clarified so a default `false` reads as *unverified* (verify-or-ask before
+asserting), not "definitely not published." Honor immutables: `workspace.origin`
 set once; `completedSkills` append-only; no skill writes another skill's fields.
 
 ---
@@ -280,5 +284,5 @@ set once; `completedSkills` append-only; no skill writes another skill's fields.
 | --- | --- |
 | B1 (0-variables false read) | §3 + `design-system-audit` step 2 + `figma-environment-setup` reads |
 | B2 (assumed no text styles) | §3 (per-class independent reads) |
-| B3 (publish-state assumption) | §3 + `figma.libraryPublished` manifest field + detect-or-ask |
+| B3 (publish-state assumption) | §3 + behavioral detect-or-ask on existing `figma.canPublish`/`libraryPublished`/`publishedAt` (no new field) |
 | B4 (phantom bridge ports) | §3 + `figma-environment-setup` bridge-port preflight hardening |

--- a/docs/superpowers/specs/2026-06-25-brownfield-retrofit-design.md
+++ b/docs/superpowers/specs/2026-06-25-brownfield-retrofit-design.md
@@ -1,8 +1,8 @@
 # Brownfield Design-System Retrofit — Design Spec
 
 > **Status:** Approved design, pre-implementation.
-> **Source:** `docs/brownfield-retrofit-learnings.md` (the Sweet app PR #443 case
-> study) plus bugs B1–B4 in `BACKLOG.md`.
+> **Source:** `docs/brownfield-retrofit-learnings.md` (a production Next.js
+> retrofit case study) plus bugs B1–B4 in `BACKLOG.md`.
 > **Goal:** Equip the ThroughLine plugin to handle large-scale retrofits — a mature
 > codebase **and** an already-populated Figma file reconciled onto a two-tier token
 > system — as elegantly as it handles greenfield builds today.
@@ -105,7 +105,7 @@ instead of a local JSON.
 1. **Size the code surface** — run the color-usage grep scaffold (adapted to the
    detected repo) to count: SCSS color vars, Tailwind color classes, JS `Colors.*`
    usages, raw hex + `rgba()` literals, SVG hardcoded fills. Produce a worklist with
-   counts (the Sweet table shape).
+   counts (the case-study table shape).
 2. **Inventory the Figma file** — explicit per-class reads (honoring §3): variable
    count, **binding count**, text styles, effect/paint styles, modes.
 3. **Compute "% semantic"** — report e.g. "you're ~90% semantic," which decides
@@ -280,9 +280,53 @@ set once; `completedSkills` append-only; no skill writes another skill's fields.
 
 ## 10. Bug → fix traceability
 
-| Bug | Fixed by |
-| --- | --- |
-| B1 (0-variables false read) | §3 + `design-system-audit` step 2 + `figma-environment-setup` reads |
-| B2 (assumed no text styles) | §3 (per-class independent reads) |
-| B3 (publish-state assumption) | §3 + behavioral detect-or-ask on existing `figma.canPublish`/`libraryPublished`/`publishedAt` (no new field) |
-| B4 (phantom bridge ports) | §3 + `figma-environment-setup` bridge-port preflight hardening |
+| Bug | Fixed by | Status after Plan 1 |
+| --- | --- | --- |
+| B1 (0-variables false read) | §3 + `design-system-audit` step 2 + `figma-environment-setup` reads | **Mitigated** — liveness no longer reports a false count; full per-class inventory lands with `design-system-audit` (Plan 3). Root cause may be MCP-side (see §11). |
+| B2 (assumed no text styles) | §3 (per-class independent reads) | **Mitigated** — read discipline documented; enforced in the audit skill (Plan 3). |
+| B3 (publish-state assumption) | §3 + behavioral detect-or-ask on existing `figma.canPublish`/`libraryPublished`/`publishedAt` (no new field) | **Doc-only in Plan 1.** The behavioral detect-or-ask change must land in the consuming skills (`component-builder`, `figma-publishing.md`) in **Plan 3**. Not yet fixed in production. |
+| B4 (phantom bridge ports) | §3 + `figma-environment-setup` bridge-port preflight hardening | **Mitigated, pending verification** — guidance distinguishes live/stale, but real-world reaping depends on MCP behavior (see §11). |
+
+---
+
+## 11. Carry-forward risks (assigned to later plans)
+
+Surfaced during Plan 1 review; tracked here so plan authoring picks them up.
+
+**For Plan 2 (scripts + `token-crosswalk-builder`):**
+- **Finalize the `crosswalk.json` schema first.** The validator and reverse-index
+  generator depend on it; ship the schema before the scripts that consume it.
+- **"Ship vetted scripts" is only partly achievable.** The color-usage grep is
+  inherently repo-shaped — ship it as an adaptable scaffold, and `log()` plainly
+  what patterns were assumed vs. detected so coverage isn't silently partial.
+
+**For Plan 3 (`design-system-audit`, `retrofit-planner`, brownfield branches):**
+- **B3 behavioral fix** — detect-or-ask publish state in `component-builder` /
+  `figma-publishing.md` (see §10).
+- **Close the interim inventory gap.** Plan 1 removed the (buggy) inventory from
+  `figma-environment-setup` Step 6 and delegated it to `design-system-audit`. Until
+  that skill exists, connecting to a populated file gives *no* inventory feedback.
+  Build the audit skill promptly, or add a correct inline read sooner.
+- **Wire `brownfield-retrofit.md` into the skills that need it.** Today only Step 6
+  and `figma-scripting.md` link to it; the guardrails aren't actively loaded by any
+  skill a brownfield user runs until the new skills `Read` it at the right moments.
+- **Don't hardcode the case-study stack.** The verification triad and guardrails
+  assume Chromatic + `build-storybook` + `tokens:sync`/`tokens:validate`. Real
+  brownfield repos may use other test/CI/token tooling — detect and generalize, or
+  degrade gracefully, rather than asserting the stack.
+- **Surface the new manifest sections in `/design-system-status` and `/start`.**
+  They currently ignore `audit` / `retrofit`.
+
+**Cross-cutting (not plan-specific):**
+- **The B1/B2/B4 fixes are unverified against a real system.** They were authored
+  from a case study, not reproduced. Before trusting them, test against (a) a
+  known-populated Figma file and (b) a genuine multi-bridge-port scenario. If the
+  root cause is in the third-party `figma-console-mcp` (caching a `0`, not reaping
+  stale ports — see the upstream notes in `BACKLOG.md`), the skill-side guidance is
+  a *mitigation*, and the real fix is upstream.
+- **No plugin CI exists.** There is no automated validation of SKILL.md frontmatter,
+  `plugin.json`, or the manifest JSON schema. Markdown self-checks and review are the
+  only net. A lightweight validation workflow would catch future broken edits.
+- **`schemaVersion` migration only triggers in `figma-environment-setup` Step 0.**
+  Fine because it always runs first, but a stale v3 manifest read by a downstream
+  skill won't have the new fields — keep the migrate-forward rule honored everywhere.

--- a/docs/superpowers/specs/2026-06-27-plugin-ci-design.md
+++ b/docs/superpowers/specs/2026-06-27-plugin-ci-design.md
@@ -1,0 +1,198 @@
+# ThroughLine plugin CI — design
+
+**Date:** 2026-06-27
+**Status:** Approved (brainstorming) — ready for an implementation plan.
+**Context:** Closes the "no plugin CI" carry-forward from the brownfield retrofit
+effort (PR #12, spec §11). This is the repository's **first** GitHub Actions
+workflow.
+
+## Goal
+
+A GitHub Actions workflow that runs on every pull request (and pushes to `main`)
+and **fails the build** when the plugin's own structure is broken:
+
+- a typo or invalid JSON in `.claude-plugin/plugin.json` or `marketplace.json`,
+- a malformed, misnamed, or incomplete `SKILL.md` frontmatter,
+- a missing command `description`,
+- a regression in the existing `scripts/` test suite (43 tests that today run
+  only on a contributor's machine).
+
+It gives the existing tests teeth in CI and adds structural validators for the
+plugin metadata. **Zero runtime dependencies, no `npm install` step** — this
+matches the deliberate zero-dep ethos of the `scripts/` directory.
+
+## Non-goals (YAGNI)
+
+- A full machine-readable JSON Schema for `design-system.json` (explicitly
+  declined — the prose schema in `references/manifest-schema.md` stays the source
+  of truth).
+- Markdown prose linting / spell-check.
+- Validating that `${CLAUDE_PLUGIN_ROOT}/...` cross-references resolve, or that
+  skills referenced by other skills exist. (Good future additions; out of scope
+  for the first CI.)
+- Reproducing B1/B2/B4 against a real Figma file (a separate carry-forward,
+  unrelated to CI).
+
+## File layout
+
+A new top-level **`ci/`** directory, kept distinct from `scripts/`. This matters:
+`scripts/` is "executable code copied verbatim into the user's repo" by
+`token-crosswalk-builder` (it copies a specific named list, so nothing leaks, but
+`scripts/README.md` frames the whole dir as an *install contract*). The CI
+validators are **plugin-internal dev tooling** and never ship into a user's
+project — so they live in their own directory to keep that boundary obvious.
+
+```
+ci/
+  lib/
+    frontmatter.mjs        # zero-dep frontmatter parser (pure)
+  validate-plugin.mjs      # validates plugin.json + marketplace.json (lib + CLI)
+  validate-plugin.test.mjs
+  validate-skills.mjs      # validates skills/*/SKILL.md + commands/*.md (lib + CLI)
+  validate-skills.test.mjs
+.github/
+  workflows/
+    ci.yml
+```
+
+Each `.mjs` exports **pure functions** (input: strings / parsed objects; output:
+a list of human-readable problems) plus a thin CLI entry that reads the real repo
+files and calls those functions. This is the same lib / CLI / colocated-`.test.mjs`
+shape the crosswalk scripts already use.
+
+Bare `node --test` from the repo root discovers `*.test.mjs` recursively, so it
+picks up both `ci/` and `scripts/` with no change to the test command. (Note: the
+existing convention is bare `node --test` from root — **not** `node --test
+scripts/`, which errors on Node ≥ 21.)
+
+## Component: `ci/lib/frontmatter.mjs`
+
+A minimal, dependency-free parser for the simple YAML frontmatter these files use
+(single-line `key: value` pairs, values optionally wrapped in single or double
+quotes — which is all the current skills/commands use).
+
+- `parseFrontmatter(text)` → `{ data, body }`.
+  - Throws if the text does not begin with a `---` line and contain a closing
+    `---` line.
+  - Parses each line of the block as `key: value`, splitting on the **first**
+    colon; trims surrounding whitespace; strips a single matching pair of
+    wrapping quotes from the value.
+  - `data` is a plain object of string keys → string values; `body` is the
+    remaining markdown.
+- Explicitly does **not** attempt full YAML (no nested maps, lists, multi-line
+  scalars). The current corpus has none; if a future skill needs richer
+  frontmatter, the parser fails loudly rather than silently mis-parsing.
+
+## Component: `ci/validate-plugin.mjs`
+
+Pure function `validatePlugin({ pluginJson, marketplaceJson, parseError })` →
+`string[]` of problems. The CLI reads the two files, reports a JSON parse error as
+a single problem, and otherwise passes the parsed objects in.
+
+Checks:
+
+- `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` both exist
+  and are valid JSON. (A read/parse failure is itself a reported problem.)
+- `plugin.json`:
+  - has non-empty string `name`, `description`;
+  - has `version` matching a semver pattern (`MAJOR.MINOR.PATCH`, optional
+    pre-release / build metadata);
+  - has an `author` (object or string);
+  - if `keywords` is present, it is an array of strings.
+- `marketplace.json`:
+  - has non-empty string `name`;
+  - has an `owner`;
+  - has a non-empty `plugins` array, each entry having non-empty string `name`,
+    `source`, and `description`;
+  - at least one plugin entry's `name` equals `plugin.json`'s `name`.
+
+## Component: `ci/validate-skills.mjs`
+
+Two pure functions over already-read file contents:
+
+- `validateSkill({ dirName, source })` → `string[]`:
+  - frontmatter block present and parseable;
+  - `name` present and non-empty;
+  - **`name` exactly equals `dirName`** — the highest-value check, because a
+    mismatch silently breaks skill discovery in Claude Code;
+  - `description` present, non-empty, and within a generous length cap
+    (`MAX_DESCRIPTION = 1024` chars — comfortably above the current longest
+    description; a single named constant so the limit is easy to find/adjust);
+  - extra frontmatter keys are **allowed** (e.g. `model:`, `allowed-tools:`) — the
+    validator never fails on unknown keys.
+- `validateCommand({ fileName, source })` → `string[]`:
+  - frontmatter block present and parseable;
+  - `description` present and non-empty.
+  - No `name` requirement (a command's name derives from its filename).
+
+The CLI enumerates `skills/*/SKILL.md` and `commands/*.md`, runs the matching
+function on each, and aggregates problems. It also flags a `skills/<dir>` that has
+no `SKILL.md`.
+
+## Optional included check: manifest-doc parses
+
+A small extra that honors the "manifest schema" wording of the carry-forward
+without authoring a JSON Schema: extract the first fenced ```` ```json ```` block
+from `references/manifest-schema.md`, assert it parses, and assert its
+`schemaVersion` is an integer. Lives as a pure helper + a check in the skills/docs
+validator CLI (or its own tiny `validate-manifest-doc` function — implementation
+detail for the plan). ~5 lines of logic; catches a broken example in the de-facto
+schema doc.
+
+## Error handling & output
+
+Every validator:
+
+- collects **all** problems rather than stopping at the first,
+- prints them grouped by file with a clear `✗ <file>: <problem>` style,
+- exits `1` if there is at least one problem,
+- otherwise prints a one-line `✓` summary (e.g. `✓ 12 skills, 4 commands OK`) and
+  exits `0`.
+
+This mirrors the reporting style of the existing `scripts/` CLIs.
+
+## The workflow: `.github/workflows/ci.yml`
+
+```yaml
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: node --test
+      - run: node ci/validate-plugin.mjs
+      - run: node ci/validate-skills.mjs
+```
+
+- `pull_request` covers the team's branch-and-PR flow (PR #12 style); `push` to
+  `main` guards the trunk. This avoids double-runs on PR branches.
+- Node 20 (LTS) — bare `node --test` discovery is stable; no `node --test
+  scripts/` issue.
+- No `npm install` — everything is zero-dep stdlib (`node:test`, `node:fs`,
+  `node:path`, `node:assert`).
+- `node --test` runs the existing 43 tests **plus** the new validator logic tests;
+  the two `node ci/validate-*.mjs` steps guard the real repo files.
+
+## Testing strategy (TDD)
+
+For the parser and each validator, write `*.test.mjs` first using crafted inputs:
+one valid case and one case per failure mode (missing key, wrong type, bad semver,
+name/dir mismatch, over-length description, missing frontmatter, invalid JSON,
+etc.). Then implement until green. The CLIs reading real files are exercised in CI
+against the actual repo, which is the live guard.
+
+## Documentation
+
+Add a short `ci/README.md` (or a section) explaining: what each validator checks,
+how to run them locally (`node ci/validate-plugin.mjs`, `node ci/validate-skills.mjs`,
+`node --test`), and that these are plugin-internal — **not** copied into user
+repos. Update the top-level `CHANGELOG.md` `[Unreleased]` section.

--- a/references/brownfield-retrofit.md
+++ b/references/brownfield-retrofit.md
@@ -48,8 +48,8 @@ Each cost real debugging time on a live retrofit. Treat each as a hard rule.
 3. **Don't delete-and-recreate variables to rename** — it unbinds everything. Rename
    in place to preserve Figma IDs (and therefore every existing binding).
 4. **Don't trust `tsc` / build to catch Tailwind color-utility removal** — deleted
-   utilities become *silent no-ops*. Guard repo-wide (all `.tsx/.ts` minus generated
-   + tests), and let Chromatic be the net.
+   utilities become *silent no-ops*. Guard repo-wide across all `.tsx`/`.ts` files
+   except generated and test files, and let Chromatic be the net.
 5. **Don't assume `build-storybook` exercises all SCSS** — story-unreachable modules
    (and a dead `@import` of a deleted partial) only fail when the real app renders.
    Run the app and spot-check 5–7 routes before declaring an SCSS change done.
@@ -67,7 +67,8 @@ of damage.
    inventory the Figma file with verified per-class reads.
 2. **refine** — rename/realign variables **in place** (`token-builder` brownfield
    branch). Never delete-and-recreate (guardrail 3); run a binding-survival audit.
-3. **rebind** — reconcile components onto the refined variables, preserving IDs.
+3. **rebind** — reconcile components onto the refined variables, preserving IDs. No
+   dedicated tool — the `retrofit-planner` orchestrator drives this step directly.
 4. **sync** — run the sync layer with the brownfield transforms (alpha channels,
    opacity 0–100→0–1, float32 rounding at the export boundary).
 5. **baseline** — capture a Chromatic baseline **before** any code retrofit, so

--- a/references/brownfield-retrofit.md
+++ b/references/brownfield-retrofit.md
@@ -1,0 +1,89 @@
+# Brownfield retrofit — read discipline, guardrails, safe sequence
+
+Canonical reference for retrofitting a design system onto a **mature codebase and
+an already-populated Figma file** (the brownfield path), as opposed to building
+greenfield. Read this before running `design-system-audit`, `token-crosswalk-builder`,
+`retrofit-planner`, or any brownfield branch of `token-builder`, `token-sync-layer`,
+or `storybook-chromatic-builder`.
+
+## The read-discipline principle (fixes bugs B1–B4)
+
+**Never assert that something is absent, empty, unpublished, or stale without an
+explicit, completed read that returned that result.** "I didn't find X" must mean
+"I queried for X and the result was empty (after the file and all pages fully
+loaded)," never "I assumed X from Y." When a result is genuinely undetectable, ask
+the user once and persist the answer in the manifest — never guess.
+
+Concrete applications:
+
+- **Variables (B1).** Before counting variables, `await figma.loadAllPagesAsync()`.
+  Treat a `0` count on a first read as suspect — re-read before reporting. An
+  unexpectedly-empty result is a possible read/cache error, not ground truth. Prefer
+  the dedicated `figma_get_variables` tool over a hand-written probe.
+- **Styles vs. variables (B2).** Text styles, effect/paint styles, and variables are
+  **different surfaces**. Absence of variables says nothing about styles. Query each
+  independently — variables (`figma_get_variables`), text styles
+  (`figma_get_text_styles`), effect/paint styles (`figma_get_styles`) — and only
+  report "none" for the specific class whose own read returned empty.
+- **Publish state (B3).** Treat a default/`false` `figma.libraryPublished` as
+  _unverified_. Attempt detection first (`figma_get_library_components` /
+  `figma_get_library_variables`, library component keys). If inconclusive, ask once
+  ("Is this library published to a team library?") and persist to
+  `figma.libraryPublished` / `figma.canPublish`. Frame the unpublished path as a
+  graceful choice, not a failure.
+- **Bridge ports (B4).** Distinguish *live* concurrent bridge instances from
+  *dead/stale* entries. Only block on genuinely live ones; reap or offer one-click
+  cleanup for stale ones. See the bridge-instance preflight in
+  `${CLAUDE_PLUGIN_ROOT}/references/figma-scripting.md`.
+
+## The 7 guardrails (hard "DON'T" rules)
+
+Each cost real debugging time on a live retrofit. Treat each as a hard rule.
+
+1. **Don't bind line-height / letter-spacing variables to text styles.** Figma stores
+   them as PERCENT; a unitless ratio var (`1.6`) rebinds as `1.6px` — catastrophic.
+   **Font-size binding only** (px→px is safe).
+2. **Don't normalize float32 in Figma** — it is a no-op (Figma re-quantizes to float32
+   on store). Normalize at the export boundary instead (`Math.round(v*100)/100`).
+3. **Don't delete-and-recreate variables to rename** — it unbinds everything. Rename
+   in place to preserve Figma IDs (and therefore every existing binding).
+4. **Don't trust `tsc` / build to catch Tailwind color-utility removal** — deleted
+   utilities become *silent no-ops*. Guard repo-wide (all `.tsx/.ts` minus generated
+   + tests), and let Chromatic be the net.
+5. **Don't assume `build-storybook` exercises all SCSS** — story-unreachable modules
+   (and a dead `@import` of a deleted partial) only fail when the real app renders.
+   Run the app and spot-check 5–7 routes before declaring an SCSS change done.
+6. **Don't carry `/opacity` modifiers onto var-based tokens** — convert to
+   `color-mix(in srgb, var(--…) NN%, transparent)` or channel-based alpha.
+7. **Don't hand-edit generated files** — change the source and re-run `tokens:sync`.
+
+## The safe retrofit sequence
+
+Run these phases in order; `retrofit-planner` gates each one with a human
+confirmation. The ordering rules are not arbitrary — each prevents a specific class
+of damage.
+
+1. **audit** — measure both sides (`design-system-audit`). Size the code surface and
+   inventory the Figma file with verified per-class reads.
+2. **refine** — rename/realign variables **in place** (`token-builder` brownfield
+   branch). Never delete-and-recreate (guardrail 3); run a binding-survival audit.
+3. **rebind** — reconcile components onto the refined variables, preserving IDs.
+4. **sync** — run the sync layer with the brownfield transforms (alpha channels,
+   opacity 0–100→0–1, float32 rounding at the export boundary).
+5. **baseline** — capture a Chromatic baseline **before** any code retrofit, so
+   intended drift-fixes are distinguishable from regressions.
+6. **code** — retrofit the codebase with **dual output**: new and old tokens coexist
+   during the transition.
+7. **cleanup** — remove old outputs **only** after a zero-reference grep passes (the
+   repo-wide token-removal guard).
+
+## The verification triad
+
+No single check catches everything; all three are necessary on every retrofit:
+
+1. **`check-types`** (TypeScript) — blind to Tailwind silent no-ops.
+2. **`build-storybook` + Chromatic snapshots** — the visual-regression net; blind to
+   story-unreachable code. **Chromatic, not `tsc`/build, is the source of truth** for
+   color-utility removal.
+3. **Run the actual app** + spot-check real routes — the only thing that exercises
+   story-unreachable SCSS.

--- a/references/brownfield-retrofit.md
+++ b/references/brownfield-retrofit.md
@@ -64,7 +64,10 @@ confirmation. The ordering rules are not arbitrary — each prevents a specific 
 of damage.
 
 1. **audit** — measure both sides (`design-system-audit`). Size the code surface and
-   inventory the Figma file with verified per-class reads.
+   inventory the Figma file with verified per-class reads. Compute `percentSemantic`
+   (manifest `audit.percentSemantic`): a system that is already largely semantic is a
+   **rename-in-place + cleanup** job; a low-semantic one is closer to a **rewrite**.
+   The higher the percentage, the lighter the retrofit — let it right-size the effort.
 2. **refine** — rename/realign variables **in place** (`token-builder` brownfield
    branch). Never delete-and-recreate (guardrail 3); run a binding-survival audit.
 3. **rebind** — reconcile components onto the refined variables, preserving IDs. No

--- a/references/crosswalk-schema.md
+++ b/references/crosswalk-schema.md
@@ -1,0 +1,113 @@
+# Crosswalk schema — `crosswalk.json`
+
+The crosswalk is the backbone artifact of a brownfield retrofit: a persistent,
+machine-readable **three-way map** between the new token, the old Figma variable,
+and the old code identifier(s). It drives the code retrofit and the
+`tokens:validate` CI gate. Built by the `token-crosswalk-builder` skill; consumed
+by the validator and reverse-index scripts (`scripts/`). The machine contract is
+`${CLAUDE_PLUGIN_ROOT}/scripts/crosswalk.schema.json`; this doc is its prose home.
+
+## Where it lives
+
+`packages/tokens/crosswalk.json`, beside the DTCG intermediate
+`packages/tokens/dtcg/tokens.json` that `token-sync-layer` emits. The manifest's
+`tokenCrosswalk.path` records the actual path. (Spec §8 shows `tokens/crosswalk.json`
+illustratively; the standard monorepo path is `packages/tokens/crosswalk.json`.)
+
+## Top-level shape
+
+```jsonc
+{
+  "$schema": "./crosswalk.schema.json",
+  "version": 1,
+  "tokens": [ /* rows */ ]
+}
+```
+
+`$schema` is optional but recommended — editors use it to validate the file against `crosswalk.schema.json` inline.
+
+## Row columns
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `newToken` | string | DTCG dot-path, exactly as `token-sync-layer` emits it (`color.text.primary`). This is the key the validator resolves against the DTCG tokens. |
+| `newValue` | string | The **resolved leaf value** — aliases followed to a literal. For a semantic token whose `$value` is `{color.gray.900}`, this is the primitive literal (`#111827`), never the `{…}` reference. |
+| `tier` | `"primitive"` \| `"semantic"` | Which tier the new token belongs to. |
+| `figmaOld` | string \| null | The old Figma variable name/path being reconciled, or `null` for an `added` token with no prior Figma variable. |
+| `codeTokens` | string[] | Old code identifiers this token replaces (`$primary-red`, `bg-primary-red`, `Colors.primaryRed`, `--primary-red`). May be `[]`. Drives the reverse index. |
+| `status` | enum | The reconciliation status — see below. |
+| `recommendedSemantic` | string \| null | An optional suggested semantic token to migrate a raw/primitive usage toward. |
+
+## `status` enum
+
+Kebab-case, from the Sweet case study (151 renamed, 42 added, 12 aligned,
+3 mapped-nearest, 2 drift-fix):
+
+| `status` | Meaning |
+| --- | --- |
+| `aligned` | New token already matches the old one in name and value — no change needed. |
+| `renamed` | Same value, new name. The bulk of a ~90%-semantic retrofit. |
+| `drift-fix` | The old value was wrong/inconsistent; the new value intentionally differs (a deliberate fix, distinguishable from a regression via the Chromatic baseline). |
+| `added` | A new token with no prior Figma variable (`figmaOld: null`). |
+| `mapped-nearest` | No exact old equivalent; mapped to the nearest new token (a judgment call worth review). |
+
+## Status-count rollup (kebab → camelCase)
+
+The manifest's `tokenCrosswalk.statusCounts` uses camelCase keys. The validator
+emits the rollup in this shape so the skill can copy it straight into the manifest:
+
+| Row `status` | `statusCounts` key |
+| --- | --- |
+| `aligned` | `aligned` |
+| `renamed` | `renamed` |
+| `drift-fix` | `driftFix` |
+| `added` | `added` |
+| `mapped-nearest` | `mappedNearest` |
+
+## The validation gate
+
+`tokens:validate` resolves every `newToken` against `packages/tokens/dtcg/tokens.json`
+(following `{…}` alias chains to a leaf) and asserts the resolved value equals the
+row's `newValue`, for **every** row (the N/N gate — Sweet passed 210/210). Value
+comparison is case-insensitive and trimmed, so `#EF4444` and `#ef4444` are equal. A
+token present in the crosswalk but absent from the DTCG source is a failure
+(reported as *missing*), never silently skipped — this honors the read-discipline
+principle in `${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md`.
+
+## Worked example
+
+```jsonc
+{
+  "$schema": "./crosswalk.schema.json",
+  "version": 1,
+  "tokens": [
+    {
+      "newToken": "color.gray.900",
+      "newValue": "#111827",
+      "tier": "primitive",
+      "figmaOld": "grey/900",
+      "codeTokens": ["$grey-900"],
+      "status": "renamed",
+      "recommendedSemantic": "color.text.primary"
+    },
+    {
+      "newToken": "color.text.primary",
+      "newValue": "#111827",
+      "tier": "semantic",
+      "figmaOld": "Text/Default",
+      "codeTokens": ["$text-default", "text-grey-900"],
+      "status": "renamed",
+      "recommendedSemantic": null
+    },
+    {
+      "newToken": "color.surface.raised",
+      "newValue": "#ffffff",
+      "tier": "semantic",
+      "figmaOld": null,
+      "codeTokens": [],
+      "status": "added",
+      "recommendedSemantic": null
+    }
+  ]
+}
+```

--- a/references/figma-publishing.md
+++ b/references/figma-publishing.md
@@ -34,17 +34,31 @@ slot — not a broken state. The typed dropdown is a later *upgrade*.
    and the typed dropdown is simply unavailable. Frame this as a plan limitation,
    never as a failure or something they did wrong.
 
-## Capability check (ask once, record it)
+## Capability check (detect first, then ask once, record it)
 
-Before relying on publishing, establish whether the user *can* publish and
-whether they *have*:
+Before relying on publishing, establish whether the user *can* publish and whether
+they *have* — but **treat a default/`false` `figma.libraryPublished` as _unverified_,
+not "definitely not published" (bug B3).** Apply the read discipline in
+`${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md`: never assert "unpublished"
+without a verified read.
 
-- If `figma.canPublish` is `null`, ask once, plainly: "Are you on a paid Figma
-  plan (Professional or higher)? Publishing a shared library — which unlocks the
-  nicer typed icon dropdowns on components — needs one." Record `true`/`false`.
-- Record whether they've published in `figma.libraryPublished` (+ `publishedAt`).
+1. **Detect first.** Before asking anything, attempt to detect publish state by reading
+   for published library artifacts: `figma_get_library_components` /
+   `figma_get_library_variables` (and library component keys). If those resolve, the
+   file *is* published — record `figma.libraryPublished: true` (+ `publishedAt`) and skip
+   the question.
+2. **Ask once only if detection is inconclusive.** If the reads are empty or unreliable
+   (detection can't confirm either way), ask the user a single plain question — "Is this
+   file published to a team library?" — and, separately, if `figma.canPublish` is `null`:
+   "Are you on a paid Figma plan (Professional or higher)? Publishing a shared library —
+   which unlocks the nicer typed icon dropdowns — needs one." Record `true`/`false` for
+   each.
+3. **Persist.** Record `figma.libraryPublished` (+ `publishedAt`) and `figma.canPublish`.
+   Don't probe repeatedly; read the manifest and only re-detect/re-ask if state is
+   genuinely missing.
 
-Don't probe repeatedly; read the manifest and only re-ask if state is missing.
+Frame the unpublished path as a **graceful choice**, never a failure — the toggle +
+manual-swap slot is fully functional.
 
 ## Sequencing — one publish checkpoint, after icons
 
@@ -65,12 +79,16 @@ them that's expected, don't make it feel like churn.
 
 For each slot that would be a typed `INSTANCE_SWAP`:
 
-1. **Can the swap targets resolve** (library published, `canPublish` true,
-   `libraryPublished` true)? →
-2. **Yes:** add the typed `INSTANCE_SWAP` dropdown with preferred values.
-3. **No (free plan, or not yet published):** build the **toggle + manual-swap**
-   slot instead, tell the user *why* in plain terms, and add the component name to
-   `components.instanceSwapUpgradePending` in the manifest.
+1. **Resolve publish state via the capability check above** — detect first
+   (`figma_get_library_components` / `figma_get_library_variables`), ask once only if
+   inconclusive, then persist. A default/`false` `libraryPublished` is *unverified*
+   until this runs — never treat it as a final "no".
+2. **Confirmed published** (`libraryPublished` true after detect-or-ask, `canPublish`
+   true): add the typed `INSTANCE_SWAP` dropdown with preferred values.
+3. **Confirmed not published** (free plan, or the user said not yet): build the
+   **toggle + manual-swap** slot instead, tell the user *why* in plain terms, and add
+   the component name to `components.instanceSwapUpgradePending` in the manifest. This
+   is a graceful choice, not a failure.
 
 ## The upgrade pass
 

--- a/references/figma-scripting.md
+++ b/references/figma-scripting.md
@@ -15,16 +15,16 @@ Concurrent writes from two **live** Desktop Bridge instances connected to the sa
 fragments** at negative coordinates — damage a screenshot won't reveal. So a second
 *live* instance is a hard stop.
 
-**But do not hard-block on _stale_ entries (bug B4).** Users routinely hit a wall
+**But do not hard-block on *stale* entries (bug B4).** Users routinely hit a wall
 where `otherInstances` lists ports they never opened — phantom/stale connections
 left by a plugin reload, a file switch, or an MCP reconnect that spawned a new port
 without reaping the old one. Telling them to "close the other instance" is useless
 when they never opened one. Distinguish the two cases before blocking:
 
 1. **Verify liveness, don't assume it.** Treat an `otherInstances` entry as
-   *suspected stale* until confirmed live. If the MCP exposes a liveness/heartbeat
-   signal, use it; otherwise attempt a `figma_reconnect` (or re-read
-   `figma_get_status`) — stale ports typically drop out after a reconnect.
+   *suspected stale* until confirmed live. Attempt a `figma_reconnect` (or re-read
+   `figma_get_status`) — stale ports typically drop out after a reconnect — or use a
+   liveness/heartbeat signal if the MCP exposes one.
 2. **Only the genuinely-live count blocks.** If exactly one live instance remains
    after reaping stale entries, proceed. Only block when **two or more** instances
    are confirmed live.
@@ -34,8 +34,8 @@ when they never opened one. Distinguish the two cases before blocking:
    the others." If only stale entries remain and they won't clear, say so plainly
    and let the user proceed rather than dead-ending them.
 
-This is the bridge-side application of the read-discipline principle
-(`${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md`): don't assert "another
+This is the bridge-side application of the read-discipline principle (B4) in
+`${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md`: don't assert "another
 instance is active" without confirming it's actually live.
 
 ## Read discipline: never report "empty" without a verified read (B1/B2)

--- a/references/figma-scripting.md
+++ b/references/figma-scripting.md
@@ -123,3 +123,56 @@ large grids (e.g. a 30+ cell color or variant grid), build **manual rows** —
 nested horizontal auto-layout frames inside a vertical parent — instead of one
 WRAP frame, or split the build across **multiple `figma_execute` calls**. The
 identical content that times out as one WRAP frame builds fine as manual rows.
+
+## Binding-survival audit: count variable bindings before and after a rename
+
+A brownfield retrofit renames variables **in place** to preserve their Figma IDs
+(guardrail 3 in `${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md` — a
+delete-and-recreate unbinds every consumer). The only way to *prove* a rename kept
+its bindings is to count consuming bindings before and after. Run this read with
+the dedicated tooling where possible (`figma_get_variables`), or via `figma_execute`
+when you need the raw consumer count.
+
+A variable's bindings are not enumerable directly, so count **consumers**: nodes and
+styles whose bound properties reference each variable id. The robust, `dynamic-page`-safe
+approach is to snapshot the total consumer count across the file before the rename,
+rename in place, then re-snapshot and assert equality.
+
+```js
+// dynamic-page safe: load everything, then walk consumers counting variable refs.
+await figma.loadAllPagesAsync();
+
+function countBoundVariableRefs(node, tally) {
+  const bv = node.boundVariables;
+  if (bv) {
+    for (const key of Object.keys(bv)) {
+      const entry = bv[key];
+      const refs = Array.isArray(entry) ? entry : [entry];
+      for (const r of refs) {
+        if (r && r.id) tally[r.id] = (tally[r.id] || 0) + 1;
+      }
+    }
+  }
+  if ('children' in node) {
+    for (const child of node.children) countBoundVariableRefs(child, tally);
+  }
+  return tally;
+}
+
+const tally = {};
+for (const page of figma.root.children) countBoundVariableRefs(page, tally);
+const totalBindings = Object.values(tally).reduce((a, b) => a + b, 0);
+// Report totalBindings (and tally per id) BEFORE the rename; re-run AFTER and
+// assert the total is unchanged. A drop means a binding was severed — STOP and
+// investigate (almost always a delete-and-recreate slipped in).
+```
+
+- **Pass an explicit `timeout`** (this walks every node — size it per the batch-timeout
+  rule above; a large file needs tens of seconds).
+- **Style bindings count too.** Text/effect/paint styles can bind variables; include a
+  pass over `getLocalTextStylesAsync()` / `getLocalPaintStylesAsync()` /
+  `getLocalEffectStylesAsync()` and their `boundVariables` if the file uses style-level
+  bindings.
+- **This is the number `design-system-audit` records** as
+  `audit.figmaInventory.bindings`, and the before/after gate the `token-builder`
+  brownfield branch runs around every rename.

--- a/references/figma-scripting.md
+++ b/references/figma-scripting.md
@@ -7,15 +7,55 @@ and executes batched JS. Several behaviors below have caused silent, hard-to-
 screenshot corruption — read this before authoring `figma_execute` scripts, and
 keep the read-backs in your post-build audit.
 
-## Preflight: one bridge instance per file (concurrent-write corruption)
+## Preflight: one *live* bridge instance per file (concurrent-write corruption)
 
-Before any write, call **`figma_get_status`** and inspect `otherInstances`. If
-more than one Desktop Bridge plugin instance is connected to the same `fileKey`
-(e.g. ports 9223 **and** 9224), **stop and warn the user — do not write.**
-Concurrent writes from two instances collide and produce **truncated parent
-frames and orphaned node fragments** scattered at negative coordinates — damage a
-screenshot won't reveal. Ask the user to close the extra plugin instance, confirm
-a single connection via `figma_get_status`, then proceed.
+Before any write, call **`figma_get_status`** and inspect `otherInstances`.
+Concurrent writes from two **live** Desktop Bridge instances connected to the same
+`fileKey` collide and produce **truncated parent frames and orphaned node
+fragments** at negative coordinates — damage a screenshot won't reveal. So a second
+*live* instance is a hard stop.
+
+**But do not hard-block on _stale_ entries (bug B4).** Users routinely hit a wall
+where `otherInstances` lists ports they never opened — phantom/stale connections
+left by a plugin reload, a file switch, or an MCP reconnect that spawned a new port
+without reaping the old one. Telling them to "close the other instance" is useless
+when they never opened one. Distinguish the two cases before blocking:
+
+1. **Verify liveness, don't assume it.** Treat an `otherInstances` entry as
+   *suspected stale* until confirmed live. If the MCP exposes a liveness/heartbeat
+   signal, use it; otherwise attempt a `figma_reconnect` (or re-read
+   `figma_get_status`) — stale ports typically drop out after a reconnect.
+2. **Only the genuinely-live count blocks.** If exactly one live instance remains
+   after reaping stale entries, proceed. Only block when **two or more** instances
+   are confirmed live.
+3. **If you must block, be actionable.** Name the exact ports, state which are
+   suspected stale vs. live, and give a concrete clear path (run `figma_reconnect`,
+   reload the bridge plugin, or restart the MCP client) — never a bare "shut down
+   the others." If only stale entries remain and they won't clear, say so plainly
+   and let the user proceed rather than dead-ending them.
+
+This is the bridge-side application of the read-discipline principle
+(`${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md`): don't assert "another
+instance is active" without confirming it's actually live.
+
+## Read discipline: never report "empty" without a verified read (B1/B2)
+
+Before reporting that a file has no variables, no text styles, or no effect styles,
+you MUST have run an explicit read **for that specific class** that returned empty —
+after the file is fully loaded. Two real bugs came from violating this:
+
+- **B1** — a first read returned `0` variables on a fully-populated file (stale/early
+  read) and was reported as fact. **Fix:** `await figma.loadAllPagesAsync()` before
+  counting; treat a `0` on first read as suspect and re-read before reporting; prefer
+  the dedicated `figma_get_variables` tool (handles `dynamic-page`, resolves aliases).
+- **B2** — "no text styles" was asserted because no text *variables* were found —
+  styles were never read. **Fix:** variables and styles are different surfaces. Read
+  each independently: variables (`figma_get_variables`), text styles
+  (`figma_get_text_styles`), effect/paint styles (`figma_get_styles`). Report "none"
+  only for the class whose own read came back empty.
+
+An unexpectedly-empty result is a possible read error, not ground truth. See the
+full principle in `${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md`.
 
 ## `dynamic-page` mode: use the async APIs — reads **and** writes
 

--- a/references/manifest-schema.md
+++ b/references/manifest-schema.md
@@ -11,11 +11,11 @@ what changed. Gating decisions are made by reading this file: if a prerequisite
 field is unset, the skill **offers** to run the prerequisite skill rather than
 bailing or running silently.
 
-## Schema (schemaVersion 3)
+## Schema (schemaVersion 4)
 
 ```json
 {
-  "schemaVersion": 3,
+  "schemaVersion": 4,
   "user": {
     "codingLevel": "new"
   },
@@ -82,6 +82,23 @@ bailing or running silently.
     "initialized": false,
     "chromatic": false,
     "codeConnect": false
+  },
+  "audit": {
+    "ranAt": null,
+    "codeSurface": null,
+    "figmaInventory": null,
+    "percentSemantic": null
+  },
+  "tokenCrosswalk": {
+    "path": null,
+    "statusCounts": null,
+    "validatorPassing": null
+  },
+  "retrofit": {
+    "phase": null,
+    "startedAt": null,
+    "completedAt": null,
+    "journalScaffolded": false
   },
   "completedSkills": []
 }
@@ -163,14 +180,22 @@ bailing or running silently.
   See `${CLAUDE_PLUGIN_ROOT}/references/figma-publishing.md`.
 - `libraryPublished` — whether the user has published the file as a library at
   least once (so local component keys resolve for `INSTANCE_SWAP`). User-driven
-  and manual; the plugin verifies, never publishes.
+  and manual; the plugin verifies, never publishes. **Treat the default `false`
+  as _unverified_, not "definitely not published" (bug B3): before asserting a
+  library is unpublished, attempt detection (`figma_get_library_components` /
+  `figma_get_library_variables`); if detection is inconclusive, ask the user once
+  and record the answer here. Never silently assume unpublished — see the read
+  discipline in `${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md`.**
 - `publishedAt` — ISO timestamp the user last confirmed a publish, for "you may
   need to re-publish after adding components" messaging.
 
 ### `tokens`
 - `intakeMode` — how the user started: `"generative"` (seed expanded by AI),
-  `"descriptive"` (from aesthetic direction), or `"import"` (existing set
-  organized). Recorded so later runs know how the system was built.
+  `"descriptive"` (from aesthetic direction), `"import"` (existing set
+  organized), or `"retrofit"` (a mature codebase **and** a populated Figma file
+  reconciled onto tokens — the brownfield path; differs from `"import"` by having
+  existing code bindings to inspect and converge). Recorded so later runs know how
+  the system was built.
 - `tiers` — `2` (primitive + semantic, default) or `3` (adds a component tier,
   multi-brand opt-in only).
 - `primitivesBuilt` / `semanticBuilt` / `stylesBuilt` — phase completion flags.
@@ -248,6 +273,42 @@ bailing or running silently.
 - `initialized` / `chromatic` / `codeConnect` — setup flags. `codeConnect` stays
   `false` when the user's Figma plan doesn't support it (the storybook skill
   degrades gracefully).
+
+### `audit`
+Populated by the `design-system-audit` skill (brownfield front door). `null` in
+every field until that skill runs. Records the measured state of a pre-existing
+system so the retrofit can be right-sized.
+- `ranAt` — ISO timestamp the audit last ran.
+- `codeSurface` — object of counts sizing the code-side retrofit, e.g.
+  `{ "scssColorVars": 692, "tailwindColorClasses": 230, "jsColorsUsages": 74,
+  "rawHexRgba": 143, "svgFills": 430 }`. Keys vary by what the repo actually uses.
+- `figmaInventory` — object snapshot of the existing Figma file from explicit
+  per-class reads, e.g. `{ "variables": 0, "bindings": 0, "textStyles": 0,
+  "effectStyles": 0, "modes": [] }`. Each count comes from a verified read, never
+  an assumption (see `brownfield-retrofit.md`).
+- `percentSemantic` — integer 0–100: how much of the existing system is already
+  semantic. The single number that decides rename+cleanup vs. rewrite.
+
+### `tokenCrosswalk`
+Populated by the `token-crosswalk-builder` skill. Points at the backbone artifact
+that maps new token ↔ old Figma token ↔ code identifier.
+- `path` — repo-relative path to the crosswalk file (e.g. `"tokens/crosswalk.json"`),
+  or `null` if not yet built. The manifest stores the pointer, not the map.
+- `statusCounts` — object counting crosswalk rows by `status`, e.g.
+  `{ "aligned": 12, "renamed": 151, "driftFix": 2, "added": 42, "mappedNearest": 3 }`.
+- `validatorPassing` — `true`/`false`/`null`: whether the last crosswalk validator
+  run passed (resolved value == new value for every row).
+
+### `retrofit`
+Populated by the `retrofit-planner` orchestrator. Tracks where a multi-phase
+retrofit stands so a later session can resume.
+- `phase` — one of `"audit"`, `"refine"`, `"rebind"`, `"sync"`, `"baseline"`,
+  `"code"`, `"cleanup"`, `"done"`, or `null` (no retrofit in progress). Phases run
+  in that order; see the safe sequence in
+  `${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md`.
+- `startedAt` / `completedAt` — ISO timestamps bounding the retrofit.
+- `journalScaffolded` — whether the `docs/design-system/` decision journal has been
+  created for this retrofit (offered default-on by `retrofit-planner`).
 
 ### `completedSkills`
 - Append-only list of skill identifiers that have run to completion at least

--- a/references/manifest-schema.md
+++ b/references/manifest-schema.md
@@ -285,9 +285,10 @@ system so the retrofit can be right-sized.
 - `figmaInventory` — object snapshot of the existing Figma file from explicit
   per-class reads, e.g. `{ "variables": 0, "bindings": 0, "textStyles": 0,
   "effectStyles": 0, "modes": [] }`. Each count comes from a verified read, never
-  an assumption (see `brownfield-retrofit.md`).
+  an assumption (see `${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md`).
 - `percentSemantic` — integer 0–100: how much of the existing system is already
-  semantic. The single number that decides rename+cleanup vs. rewrite.
+  semantic. The single number that decides rename+cleanup vs. rewrite — see
+  `${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md` for the threshold.
 
 ### `tokenCrosswalk`
 Populated by the `token-crosswalk-builder` skill. Points at the backbone artifact
@@ -297,7 +298,7 @@ that maps new token ↔ old Figma token ↔ code identifier.
 - `statusCounts` — object counting crosswalk rows by `status`, e.g.
   `{ "aligned": 12, "renamed": 151, "driftFix": 2, "added": 42, "mappedNearest": 3 }`.
 - `validatorPassing` — `true`/`false`/`null`: whether the last crosswalk validator
-  run passed (resolved value == new value for every row).
+  run passed (`resolved value == new value` for every row).
 
 ### `retrofit`
 Populated by the `retrofit-planner` orchestrator. Tracks where a multi-phase

--- a/references/manifest-schema.md
+++ b/references/manifest-schema.md
@@ -288,7 +288,8 @@ system so the retrofit can be right-sized.
   an assumption (see `${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md`).
 - `percentSemantic` — integer 0–100: how much of the existing system is already
   semantic. The single number that decides rename+cleanup vs. rewrite — see
-  `${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md` for the threshold.
+  `${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md` (safe sequence, `audit`
+  phase) for how it's used.
 
 ### `tokenCrosswalk`
 Populated by the `token-crosswalk-builder` skill. Points at the backbone artifact

--- a/references/sync-adapters.md
+++ b/references/sync-adapters.md
@@ -102,6 +102,28 @@ emit as references to primitive vars rather than flattened literals.
   indirection. Modes map to the platform's native mechanism (asset catalog
   variants, resource qualifiers).
 
+## Brownfield value transforms
+
+On a retrofit, the values flowing into the adapters get three extra transforms (the
+opacity 0–100→0–1 normalization happens earlier, at extraction). These affect what the
+web adapters emit; native adapters resolve to literals so the channel/`color-mix` forms
+apply to web targets. Full rationale: the 7 guardrails in
+`${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md`.
+
+- **Channel alpha (web).** Color tokens emit as space-separated channels
+  (`--color-bg-default: 239 68 68;`) consumed via
+  `rgb(var(--color-bg-default) / <alpha-value>)`, so Tailwind's `/opacity` modifiers
+  keep working. A finished `rgba(...)` would break them.
+- **`/opacity` → `color-mix` (web).** A `/opacity` modifier on a var-based token can't
+  fold its alpha into the var; emit `color-mix(in srgb, var(--token) NN%, transparent)`
+  instead (or the channel-alpha form).
+- **Float32 rounding at the export boundary.** Round values as they leave the pipeline
+  (`Math.round(v*100)/100`) — normalizing inside Figma is a no-op because Figma
+  re-quantizes to float32 on store.
+
+These are applied in `token-sync-layer`'s extraction/transform step (its "Brownfield
+transforms" subsection), not in the adapter presets.
+
 ## Output location
 
 All adapter output lands in `packages/tokens/` in the monorepo, organized by

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,57 @@
+# ThroughLine scripts
+
+The executable analog of `references/`: canonical, vetted, **zero-dependency** Node
+(ESM) scripts that the brownfield skills install into a user's monorepo. Authored and
+tested here; copied verbatim by `token-crosswalk-builder` into the user's
+`packages/tokens/scripts/`.
+
+| Script | Purpose | Installed as |
+| --- | --- | --- |
+| `validate-crosswalk.mjs` | Resolve every `newToken` against the DTCG token source; assert resolved value == `newValue`, N/N. The CI gate. | `tokens:validate` |
+| `build-reverse-index.mjs` | Emit a `codeToken -> newToken` map from the crosswalk to semi-automate SCSS/Tailwind swaps. | `tokens:reverse-index` |
+| `guard-token-removal.mjs` | Grep `.ts/.tsx` (minus generated + tests) for about-to-be-deleted symbols; blocks cleanup until zero references remain. | run during the cleanup phase |
+| `lib/crosswalk.mjs` | Shared loader + structural validation for `crosswalk.json` (used by the validator and reverse-index). | copied alongside |
+| `crosswalk.schema.json` | The finalized JSON Schema for `crosswalk.json` (contract + editor support). | copied beside `crosswalk.json` |
+
+The crosswalk contract is documented in
+`${CLAUDE_PLUGIN_ROOT}/references/crosswalk-schema.md`.
+
+## Usage
+
+```bash
+node validate-crosswalk.mjs --crosswalk crosswalk.json --tokens dtcg/tokens.json
+node build-reverse-index.mjs --crosswalk crosswalk.json --out crosswalk.reverse.json
+node guard-token-removal.mjs --root . --symbols symbols-to-remove.txt
+```
+
+Exit codes: `0` success, `1` validation/guard failure (mismatch, missing token,
+conflict, or remaining reference), `2` bad CLI arguments.
+
+## How the skill installs these
+
+`token-crosswalk-builder` copies `lib/crosswalk.mjs`, `validate-crosswalk.mjs`,
+`build-reverse-index.mjs`, `guard-token-removal.mjs`, and `crosswalk.schema.json`
+into the user's `packages/tokens/scripts/` (schema beside `crosswalk.json`), then
+wires `packages/tokens/package.json`:
+
+```jsonc
+"scripts": {
+  "tokens:validate": "node scripts/validate-crosswalk.mjs --crosswalk crosswalk.json --tokens dtcg/tokens.json",
+  "tokens:reverse-index": "node scripts/build-reverse-index.mjs --crosswalk crosswalk.json --out crosswalk.reverse.json"
+}
+```
+
+The scripts version with the user's repo so their CI runs them locally — a path
+inside the plugin install would not be reachable from the user's CI.
+
+## Tests
+
+Run the suite from the repo root (no install step — uses only Node built-ins):
+
+```bash
+node --test
+```
+
+This auto-discovers every `**/*.test.mjs` recursively (31 tests). Don't use
+`node --test scripts/` — a directory positional is treated as a test name on
+Node >=21 and errors; a `scripts/*.test.mjs` glob silently skips `scripts/lib/`.

--- a/scripts/build-reverse-index.mjs
+++ b/scripts/build-reverse-index.mjs
@@ -1,0 +1,56 @@
+// Reverse-index generator: codeToken -> newToken, from crosswalk.json.
+// Semi-automates the SCSS/Tailwind swaps. Zero dependencies.
+//
+// Usage:
+//   node build-reverse-index.mjs --crosswalk crosswalk.json --out crosswalk.reverse.json
+import { writeFileSync } from 'node:fs';
+import { parseArgs } from 'node:util';
+import { pathToFileURL } from 'node:url';
+import { loadCrosswalk } from './lib/crosswalk.mjs';
+
+export function buildReverseIndex(crosswalk) {
+  const raw = {};
+  const conflicts = [];
+  for (const row of crosswalk.tokens) {
+    for (const code of row.codeTokens) {
+      if (code in raw && raw[code] !== row.newToken) {
+        conflicts.push({ codeToken: code, tokens: [raw[code], row.newToken] });
+      } else {
+        raw[code] = row.newToken;
+      }
+    }
+  }
+  // Sort keys longest-first so a literal find-and-replace can't clobber a longer
+  // symbol via a shorter substring (e.g. replace "$blue-100" before "$blue").
+  const index = {};
+  for (const key of Object.keys(raw).sort((a, b) => b.length - a.length || a.localeCompare(b))) {
+    index[key] = raw[key];
+  }
+  return { index, conflicts };
+}
+
+function main() {
+  const { values } = parseArgs({
+    options: {
+      crosswalk: { type: 'string' },
+      out: { type: 'string' },
+    },
+  });
+  if (!values.crosswalk || !values.out) {
+    console.error('usage: build-reverse-index.mjs --crosswalk <crosswalk.json> --out <reverse.json>');
+    process.exit(2);
+  }
+  const crosswalk = loadCrosswalk(values.crosswalk);
+  const { index, conflicts } = buildReverseIndex(crosswalk);
+  writeFileSync(values.out, JSON.stringify(index, null, 2) + '\n');
+  console.log(`reverse index: ${Object.keys(index).length} code symbol(s) -> ${values.out}`);
+  if (conflicts.length) {
+    console.error(`\n${conflicts.length} conflict(s) — one code symbol maps to multiple new tokens:`);
+    for (const c of conflicts) console.error(`  - ${c.codeToken}: ${c.tokens.join(' vs ')}`);
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/build-reverse-index.test.mjs
+++ b/scripts/build-reverse-index.test.mjs
@@ -1,0 +1,49 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildReverseIndex } from './build-reverse-index.mjs';
+
+test('maps each codeToken to its newToken', () => {
+  const cw = { version: 1, tokens: [
+    { newToken: 'color.text.primary', codeTokens: ['$text-default', 'text-grey-900'], newValue: '#111827', tier: 'semantic', figmaOld: null, status: 'renamed', recommendedSemantic: null },
+  ]};
+  const { index, conflicts } = buildReverseIndex(cw);
+  assert.equal(index['$text-default'], 'color.text.primary');
+  assert.equal(index['text-grey-900'], 'color.text.primary');
+  assert.equal(conflicts.length, 0);
+});
+
+test('two code symbols can map to the same new token without conflict', () => {
+  const cw = { version: 1, tokens: [
+    { newToken: 'color.gray.900', codeTokens: ['$grey-900', '$gray-900'], newValue: '#111827', tier: 'primitive', figmaOld: null, status: 'renamed', recommendedSemantic: null },
+  ]};
+  const { conflicts } = buildReverseIndex(cw);
+  assert.equal(conflicts.length, 0);
+});
+
+test('flags a code symbol mapping to two different new tokens', () => {
+  const cw = { version: 1, tokens: [
+    { newToken: 'color.gray.900', codeTokens: ['$x'], newValue: '#111827', tier: 'primitive', figmaOld: null, status: 'renamed', recommendedSemantic: null },
+    { newToken: 'color.gray.800', codeTokens: ['$x'], newValue: '#1f2937', tier: 'primitive', figmaOld: null, status: 'renamed', recommendedSemantic: null },
+  ]};
+  const { conflicts } = buildReverseIndex(cw);
+  assert.equal(conflicts.length, 1);
+  assert.equal(conflicts[0].codeToken, '$x');
+  assert.deepEqual(conflicts[0].tokens, ['color.gray.900', 'color.gray.800']);
+});
+
+test('emits keys sorted longest-first (safe find-and-replace ordering)', () => {
+  const cw = { version: 1, tokens: [
+    { newToken: 'color.a', codeTokens: ['$blue'], newValue: '#1', tier: 'primitive', figmaOld: null, status: 'renamed', recommendedSemantic: null },
+    { newToken: 'color.b', codeTokens: ['$blue-100'], newValue: '#2', tier: 'primitive', figmaOld: null, status: 'renamed', recommendedSemantic: null },
+  ]};
+  const { index } = buildReverseIndex(cw);
+  assert.deepEqual(Object.keys(index), ['$blue-100', '$blue']);
+});
+
+test('skips rows with no codeTokens', () => {
+  const cw = { version: 1, tokens: [
+    { newToken: 'color.surface.raised', codeTokens: [], newValue: '#fff', tier: 'semantic', figmaOld: null, status: 'added', recommendedSemantic: null },
+  ]};
+  const { index } = buildReverseIndex(cw);
+  assert.deepEqual(index, {});
+});

--- a/scripts/crosswalk.schema.json
+++ b/scripts/crosswalk.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://throughline.dev/schemas/crosswalk.schema.json",
+  "title": "ThroughLine token crosswalk",
+  "description": "Three-way map: new token <-> old Figma token <-> code identifier. Drives the brownfield code retrofit and the tokens:validate CI gate.",
+  "type": "object",
+  "required": ["version", "tokens"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+    "version": { "const": 1 },
+    "tokens": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/row" }
+    }
+  },
+  "$defs": {
+    "row": {
+      "type": "object",
+      "required": ["newToken", "newValue", "tier", "figmaOld", "codeTokens", "status"],
+      "additionalProperties": false,
+      "properties": {
+        "newToken": { "type": "string", "minLength": 1, "description": "DTCG dot-path, e.g. color.text.primary" },
+        "newValue": { "type": "string", "minLength": 1, "description": "Resolved leaf value (aliases followed)" },
+        "tier": { "type": "string", "enum": ["primitive", "semantic"] },
+        "figmaOld": { "type": ["string", "null"], "description": "Old Figma variable name/path, or null if newly added" },
+        "codeTokens": { "type": "array", "items": { "type": "string" }, "description": "Old code identifiers this token replaces" },
+        "status": { "type": "string", "enum": ["aligned", "renamed", "drift-fix", "added", "mapped-nearest"] },
+        "recommendedSemantic": { "type": ["string", "null"] }
+      }
+    }
+  }
+}

--- a/scripts/grep-color-usage.mjs
+++ b/scripts/grep-color-usage.mjs
@@ -1,0 +1,143 @@
+// Color-usage grep scaffold: size a codebase's color-decision surface by category.
+// Repo-shaped by nature — ships sensible DEFAULT_CATEGORIES and accepts a --config
+// override; logs which categories used the assumed default vs. a detected pattern so
+// coverage is never silently partial. Zero dependencies.
+//
+// Usage:
+//   node grep-color-usage.mjs --root <dir> [--config <patterns.json>] [--out <counts.json>]
+//     patterns.json: { "<category>": { "files": "<regex>", "pattern": "<regex with g flag>" }, ... }
+import { readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { parseArgs } from 'node:util';
+import { pathToFileURL } from 'node:url';
+
+// The five categories from the case study. Each: which files it applies to, and the
+// (global) match pattern. Tuned defaults — design-system-audit may override per repo.
+export const DEFAULT_CATEGORIES = {
+  scssColorVars: {
+    files: /\.(scss|sass|css)$/,
+    pattern: /\$[\w-]*(?:color|colour|primary|secondary|tertiary|grey|gray|red|blue|green|yellow|orange|purple|pink|teal|cyan|black|white|brand|accent|surface|ink)[\w-]*/gi,
+  },
+  tailwindColorClasses: {
+    files: /\.(tsx?|jsx?|html|vue|svelte)$/,
+    pattern: /\b(?:bg|text|border|ring|fill|stroke|from|via|to|outline|divide|placeholder|caret|accent|shadow)-(?:primary|secondary|tertiary|grey|gray|red|blue|green|yellow|orange|purple|pink|teal|cyan|brand|accent|surface|ink)[\w-]*/g,
+  },
+  jsColorsUsages: {
+    files: /\.(tsx?|jsx?|mjs|cjs)$/,
+    pattern: /\bColors\.[A-Za-z_$][\w$]*/g,
+  },
+  rawHexRgba: {
+    files: /\.(scss|sass|css|tsx?|jsx?|vue|svelte|html|svg)$/,
+    pattern: /#[0-9a-fA-F]{3,8}\b|rgba?\([^)]*\)/g,
+  },
+  svgFills: {
+    files: /\.svg$/,
+    pattern: /(?:fill|stroke)="(?!none|currentColor|url\()[^"]+"/g,
+  },
+};
+
+export const DEFAULT_EXCLUDES = [
+  /(^|\/)node_modules(\/|$)/,
+  /(^|\/)generated(\/|$)/,
+  /\.generated\./,
+  /\.test\./,
+  /\.spec\./,
+  /(^|\/)__tests__(\/|$)/,
+  /(^|\/)dist(\/|$)/,
+  /(^|\/)\.next(\/|$)/,
+];
+
+// Source extensions worth opening at all (union of every category's `files`).
+const SOURCE_EXT = /\.(scss|sass|css|tsx?|jsx?|mjs|cjs|vue|svelte|html|svg)$/;
+
+export function* walk(root, excludes = DEFAULT_EXCLUDES) {
+  for (const entry of readdirSync(root)) {
+    const full = join(root, entry);
+    if (excludes.some((re) => re.test(full))) continue;
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      yield* walk(full, excludes);
+    } else if (SOURCE_EXT.test(full)) {
+      yield full;
+    }
+  }
+}
+
+// Count matches per category in one file. A category contributes only if its `files`
+// regex matches this path. Returns { <category>: count } for every category key.
+export function scanFile(path, categories) {
+  const counts = {};
+  for (const key of Object.keys(categories)) counts[key] = 0;
+  const text = readFileSync(path, 'utf8');
+  for (const [key, { files, pattern }] of Object.entries(categories)) {
+    if (!files.test(path)) continue;
+    const re = new RegExp(pattern.source, pattern.flags.includes('g') ? pattern.flags : pattern.flags + 'g');
+    const m = text.match(re);
+    counts[key] = m ? m.length : 0;
+  }
+  return counts;
+}
+
+export function grepColorUsage(root, categories = DEFAULT_CATEGORIES, excludes = DEFAULT_EXCLUDES) {
+  const counts = {};
+  for (const key of Object.keys(categories)) counts[key] = 0;
+  const byFile = [];
+  for (const file of walk(root, excludes)) {
+    const fileCounts = scanFile(file, categories);
+    const total = Object.values(fileCounts).reduce((a, b) => a + b, 0);
+    if (total > 0) {
+      byFile.push({ file: relative(root, file), counts: fileCounts });
+      for (const key of Object.keys(fileCounts)) counts[key] += fileCounts[key];
+    }
+  }
+  return { counts, byFile };
+}
+
+// Parse a --config JSON of { category: { files, pattern } } string regexes into RegExp.
+function loadCategories(path) {
+  const raw = JSON.parse(readFileSync(path, 'utf8'));
+  const out = {};
+  for (const [key, { files, pattern }] of Object.entries(raw)) {
+    out[key] = { files: new RegExp(files), pattern: new RegExp(pattern, 'g') };
+  }
+  return out;
+}
+
+function main() {
+  const { values } = parseArgs({
+    options: {
+      root: { type: 'string' },
+      config: { type: 'string' },
+      out: { type: 'string' },
+    },
+  });
+  if (!values.root) {
+    console.error('usage: grep-color-usage.mjs --root <dir> [--config <patterns.json>] [--out <counts.json>]');
+    process.exit(2);
+  }
+  const categories = values.config ? loadCategories(values.config) : DEFAULT_CATEGORIES;
+  // §11: never let coverage be silently partial — say which patterns were assumed.
+  const source = values.config ? `detected (from ${values.config})` : 'ASSUMED defaults';
+  console.log(`color-usage grep — pattern source: ${source}`);
+  console.log(`categories: ${Object.keys(categories).join(', ')}`);
+
+  const { counts, byFile } = grepColorUsage(values.root, categories);
+  const total = Object.values(counts).reduce((a, b) => a + b, 0);
+  console.log('\ncolor-decision surface:');
+  for (const [key, n] of Object.entries(counts)) {
+    console.log(`  ${key.padEnd(24)} ${n}`);
+  }
+  console.log(`  ${'TOTAL'.padEnd(24)} ${total}  (across ${byFile.length} file(s))`);
+  if (!values.config) {
+    console.log('\nnote: patterns are the shipped defaults. Tune them to this repo and re-run with --config for accurate counts.');
+  }
+
+  if (values.out) {
+    writeFileSync(values.out, JSON.stringify({ counts, byFile }, null, 2) + '\n');
+    console.log(`\nwrote ${values.out}`);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/grep-color-usage.test.mjs
+++ b/scripts/grep-color-usage.test.mjs
@@ -1,0 +1,80 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { grepColorUsage, scanFile, DEFAULT_CATEGORIES } from './grep-color-usage.mjs';
+
+function fixtureTree() {
+  const root = mkdtempSync(join(tmpdir(), 'grep-color-'));
+  // SCSS color vars + a raw hex literal on the same file
+  writeFileSync(join(root, 'theme.scss'), '$primary-red: #ff0000;\n$grey-900: #111827;\n.x { color: $primary-red; }\n');
+  // Tailwind color classes + a Colors.* usage
+  writeFileSync(join(root, 'App.tsx'), 'const c = "bg-primary-red text-grey-900";\nconst d = Colors.primaryRed;\n');
+  // SVG hardcoded fill (and one that must be ignored)
+  writeFileSync(join(root, 'logo.svg'), '<path fill="#ff0000"/><path fill="none"/><path fill="currentColor"/>\n');
+  // excluded surfaces
+  mkdirSync(join(root, 'node_modules', 'pkg'), { recursive: true });
+  writeFileSync(join(root, 'node_modules', 'pkg', 'index.ts'), 'const m = "bg-primary-red";\n');
+  mkdirSync(join(root, 'generated'), { recursive: true });
+  writeFileSync(join(root, 'generated', 'tokens.scss'), '$primary-red: #ff0000;\n');
+  writeFileSync(join(root, 'App.test.tsx'), 'const t = "bg-primary-red";\n');
+  return root;
+}
+
+test('scanFile counts SCSS color vars in a .scss file', () => {
+  const root = fixtureTree();
+  const counts = scanFile(join(root, 'theme.scss'), DEFAULT_CATEGORIES);
+  // $primary-red (decl + usage) + $grey-900 = 3 occurrences
+  assert.equal(counts.scssColorVars, 3);
+});
+
+test('scanFile counts raw hex + rgba in any source file', () => {
+  const root = fixtureTree();
+  const counts = scanFile(join(root, 'theme.scss'), DEFAULT_CATEGORIES);
+  assert.equal(counts.rawHexRgba, 2); // #ff0000 and #111827
+});
+
+test('scanFile counts Tailwind color classes and Colors.* usages in .tsx', () => {
+  const root = fixtureTree();
+  const counts = scanFile(join(root, 'App.tsx'), DEFAULT_CATEGORIES);
+  assert.equal(counts.tailwindColorClasses, 2); // bg-primary-red, text-grey-900
+  assert.equal(counts.jsColorsUsages, 1);        // Colors.primaryRed
+});
+
+test('scanFile counts SVG fills but ignores none/currentColor', () => {
+  const root = fixtureTree();
+  const counts = scanFile(join(root, 'logo.svg'), DEFAULT_CATEGORIES);
+  assert.equal(counts.svgFills, 1); // only fill="#ff0000"
+});
+
+test('file-type gating: tailwind pattern does not apply to .scss', () => {
+  const root = fixtureTree();
+  const counts = scanFile(join(root, 'theme.scss'), DEFAULT_CATEGORIES);
+  assert.equal(counts.tailwindColorClasses, 0);
+});
+
+test('grepColorUsage aggregates counts and honors excludes', () => {
+  const root = fixtureTree();
+  const { counts } = grepColorUsage(root, DEFAULT_CATEGORIES);
+  assert.equal(counts.scssColorVars, 3);      // generated/tokens.scss excluded
+  assert.equal(counts.tailwindColorClasses, 2); // node_modules + .test.tsx excluded
+  assert.equal(counts.jsColorsUsages, 1);
+  assert.equal(counts.rawHexRgba, 3);          // 2 in theme.scss + 1 in logo.svg
+  assert.equal(counts.svgFills, 1);
+});
+
+test('grepColorUsage reports per-file hits only for files with matches', () => {
+  const root = fixtureTree();
+  const { byFile } = grepColorUsage(root, DEFAULT_CATEGORIES);
+  const files = byFile.map((f) => f.file).sort();
+  assert.deepEqual(files, ['App.tsx', 'logo.svg', 'theme.scss']);
+});
+
+test('a custom category config overrides the defaults', () => {
+  const root = fixtureTree();
+  const custom = { brandColors: { files: /\.scss$/, pattern: /\$primary-[\w-]+/g } };
+  const { counts } = grepColorUsage(root, custom);
+  assert.deepEqual(Object.keys(counts), ['brandColors']);
+  assert.equal(counts.brandColors, 2); // decl + usage of $primary-red
+});

--- a/scripts/guard-token-removal.mjs
+++ b/scripts/guard-token-removal.mjs
@@ -1,0 +1,95 @@
+// Repo-wide token-removal guard: grep .ts/.tsx (minus generated + tests) for
+// references to about-to-be-deleted symbols. Zero dependencies.
+//
+// Cleanup must not proceed until this returns zero references — deleted Tailwind
+// utilities become silent no-ops that tsc/build will not catch (guardrail 4).
+//
+// Usage:
+//   node guard-token-removal.mjs --root <dir> --symbols <symbols.txt>
+//     symbols file: one symbol per line (blank lines and # comments ignored)
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { parseArgs } from 'node:util';
+import { pathToFileURL } from 'node:url';
+
+export const DEFAULT_EXCLUDES = [
+  /(^|\/)node_modules(\/|$)/,
+  /(^|\/)generated(\/|$)/,
+  /\.generated\./,
+  /\.test\./,
+  /\.spec\./,
+  /(^|\/)__tests__(\/|$)/,
+  /(^|\/)dist(\/|$)/,
+  /(^|\/)\.next(\/|$)/,
+];
+
+export function* walk(root, excludes = DEFAULT_EXCLUDES) {
+  for (const entry of readdirSync(root)) {
+    const full = join(root, entry);
+    if (excludes.some((re) => re.test(full))) continue;
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      yield* walk(full, excludes);
+    } else if (/\.tsx?$/.test(full)) {
+      yield full;
+    }
+  }
+}
+
+export function scanFile(path, symbols) {
+  const lines = readFileSync(path, 'utf8').split('\n');
+  const hits = [];
+  lines.forEach((line, i) => {
+    for (const sym of symbols) {
+      if (line.includes(sym)) {
+        hits.push({ line: i + 1, symbol: sym, text: line.trim() });
+      }
+    }
+  });
+  return hits;
+}
+
+export function guard(root, symbols, excludes = DEFAULT_EXCLUDES) {
+  const findings = [];
+  for (const file of walk(root, excludes)) {
+    for (const hit of scanFile(file, symbols)) {
+      findings.push({ file: relative(root, file), ...hit });
+    }
+  }
+  return findings;
+}
+
+function readSymbols(path) {
+  return readFileSync(path, 'utf8')
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l && !l.startsWith('#'));
+}
+
+function main() {
+  const { values } = parseArgs({
+    options: {
+      root: { type: 'string' },
+      symbols: { type: 'string' },
+    },
+  });
+  if (!values.root || !values.symbols) {
+    console.error('usage: guard-token-removal.mjs --root <dir> --symbols <symbols.txt>');
+    process.exit(2);
+  }
+  const symbols = readSymbols(values.symbols);
+  const findings = guard(values.root, symbols);
+  if (findings.length === 0) {
+    console.log(`token-removal guard: 0 references to ${symbols.length} symbol(s) — safe to remove.`);
+    return;
+  }
+  console.error(`token-removal guard: ${findings.length} remaining reference(s) — do NOT remove yet:`);
+  for (const f of findings) {
+    console.error(`  ${f.file}:${f.line}  ${f.symbol}  | ${f.text}`);
+  }
+  process.exit(1);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/guard-token-removal.test.mjs
+++ b/scripts/guard-token-removal.test.mjs
@@ -1,0 +1,47 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { guard, scanFile } from './guard-token-removal.mjs';
+
+function fixtureTree() {
+  const root = mkdtempSync(join(tmpdir(), 'guard-'));
+  writeFileSync(join(root, 'app.tsx'), 'const x = "bg-primary-red";\nconst y = 1;\n');
+  writeFileSync(join(root, 'clean.ts'), 'const z = "bg-surface";\n');
+  mkdirSync(join(root, 'generated'), { recursive: true });
+  writeFileSync(join(root, 'generated', 'tokens.ts'), 'export const c = "bg-primary-red";\n');
+  writeFileSync(join(root, 'app.test.tsx'), 'expect("bg-primary-red").toBe(x);\n');
+  mkdirSync(join(root, 'node_modules', 'pkg'), { recursive: true });
+  writeFileSync(join(root, 'node_modules', 'pkg', 'index.ts'), 'const m = "bg-primary-red";\n');
+  return root;
+}
+
+test('scanFile reports each line containing a symbol', () => {
+  const root = fixtureTree();
+  const hits = scanFile(join(root, 'app.tsx'), ['bg-primary-red']);
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].line, 1);
+  assert.equal(hits[0].symbol, 'bg-primary-red');
+});
+
+test('guard finds references in source, ignoring generated/tests/node_modules', () => {
+  const root = fixtureTree();
+  const findings = guard(root, ['bg-primary-red']);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].file, 'app.tsx');
+  assert.equal(findings[0].symbol, 'bg-primary-red');
+});
+
+test('guard returns empty when no source references remain', () => {
+  const root = fixtureTree();
+  const findings = guard(root, ['bg-does-not-exist']);
+  assert.deepEqual(findings, []);
+});
+
+test('guard scans multiple symbols at once', () => {
+  const root = fixtureTree();
+  const findings = guard(root, ['bg-primary-red', 'bg-surface']);
+  const files = findings.map((f) => f.file).sort();
+  assert.deepEqual(files, ['app.tsx', 'clean.ts']);
+});

--- a/scripts/lib/crosswalk.mjs
+++ b/scripts/lib/crosswalk.mjs
@@ -31,6 +31,15 @@ export function loadCrosswalk(path) {
   if (!data || typeof data !== 'object' || !Array.isArray(data.tokens)) {
     throw new Error('crosswalk: expected an object with a "tokens" array');
   }
+  if (data.version !== 1) {
+    throw new Error(`crosswalk: version must be 1, got ${JSON.stringify(data.version)}`);
+  }
+  const ALLOWED_TOP_KEYS = new Set(['$schema', 'version', 'tokens']);
+  for (const key of Object.keys(data)) {
+    if (!ALLOWED_TOP_KEYS.has(key)) {
+      throw new Error(`crosswalk: unknown key at top level: "${key}"`);
+    }
+  }
   const seen = new Set();
   data.tokens.forEach((row, i) => validateRow(row, i, seen));
   return data;
@@ -60,6 +69,12 @@ function validateRow(row, i, seen) {
   }
   if (row.recommendedSemantic != null && typeof row.recommendedSemantic !== 'string') {
     throw new Error(`crosswalk: ${where}.recommendedSemantic must be a string or null`);
+  }
+  const ALLOWED_ROW_KEYS = new Set(['newToken', 'newValue', 'tier', 'figmaOld', 'codeTokens', 'status', 'recommendedSemantic']);
+  for (const key of Object.keys(row)) {
+    if (!ALLOWED_ROW_KEYS.has(key)) {
+      throw new Error(`crosswalk: ${where} has unknown key: "${key}"`);
+    }
   }
   if (seen.has(row.newToken)) {
     throw new Error(`crosswalk: duplicate newToken "${row.newToken}"`);

--- a/scripts/lib/crosswalk.mjs
+++ b/scripts/lib/crosswalk.mjs
@@ -1,0 +1,76 @@
+// Shared loader + structural validation for crosswalk.json.
+// Zero dependencies. Mirrors scripts/crosswalk.schema.json's required/enum rules.
+import { readFileSync } from 'node:fs';
+
+export const STATUS_VALUES = ['aligned', 'renamed', 'drift-fix', 'added', 'mapped-nearest'];
+
+// Row status (kebab) -> manifest tokenCrosswalk.statusCounts key (camelCase).
+export const STATUS_COUNT_KEY = {
+  'aligned': 'aligned',
+  'renamed': 'renamed',
+  'drift-fix': 'driftFix',
+  'added': 'added',
+  'mapped-nearest': 'mappedNearest',
+};
+
+const TIERS = ['primitive', 'semantic'];
+
+export function loadCrosswalk(path) {
+  let raw;
+  try {
+    raw = readFileSync(path, 'utf8');
+  } catch (e) {
+    throw new Error(`crosswalk: cannot read file at ${path}: ${e.message}`);
+  }
+  let data;
+  try {
+    data = JSON.parse(raw);
+  } catch (e) {
+    throw new Error(`crosswalk: invalid JSON in ${path}: ${e.message}`);
+  }
+  if (!data || typeof data !== 'object' || !Array.isArray(data.tokens)) {
+    throw new Error('crosswalk: expected an object with a "tokens" array');
+  }
+  const seen = new Set();
+  data.tokens.forEach((row, i) => validateRow(row, i, seen));
+  return data;
+}
+
+function validateRow(row, i, seen) {
+  const where = `tokens[${i}]`;
+  if (!row || typeof row !== 'object') {
+    throw new Error(`crosswalk: ${where} is not an object`);
+  }
+  for (const field of ['newToken', 'newValue', 'tier', 'status']) {
+    if (typeof row[field] !== 'string' || row[field] === '') {
+      throw new Error(`crosswalk: ${where}.${field} must be a non-empty string`);
+    }
+  }
+  if (!TIERS.includes(row.tier)) {
+    throw new Error(`crosswalk: ${where}.tier must be one of ${TIERS.join(', ')}, got "${row.tier}"`);
+  }
+  if (!STATUS_VALUES.includes(row.status)) {
+    throw new Error(`crosswalk: ${where}.status must be one of ${STATUS_VALUES.join(', ')}, got "${row.status}"`);
+  }
+  if (!Array.isArray(row.codeTokens) || row.codeTokens.some((t) => typeof t !== 'string')) {
+    throw new Error(`crosswalk: ${where}.codeTokens must be an array of strings`);
+  }
+  if (row.figmaOld === undefined || (row.figmaOld !== null && typeof row.figmaOld !== 'string')) {
+    throw new Error(`crosswalk: ${where}.figmaOld must be a string or null`);
+  }
+  if (row.recommendedSemantic != null && typeof row.recommendedSemantic !== 'string') {
+    throw new Error(`crosswalk: ${where}.recommendedSemantic must be a string or null`);
+  }
+  if (seen.has(row.newToken)) {
+    throw new Error(`crosswalk: duplicate newToken "${row.newToken}"`);
+  }
+  seen.add(row.newToken);
+}
+
+export function statusCounts(crosswalk) {
+  const counts = { aligned: 0, renamed: 0, driftFix: 0, added: 0, mappedNearest: 0 };
+  for (const row of crosswalk.tokens) {
+    counts[STATUS_COUNT_KEY[row.status]] += 1;
+  }
+  return counts;
+}

--- a/scripts/lib/crosswalk.test.mjs
+++ b/scripts/lib/crosswalk.test.mjs
@@ -1,0 +1,106 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadCrosswalk, statusCounts, STATUS_VALUES, STATUS_COUNT_KEY } from './crosswalk.mjs';
+
+function writeTemp(obj) {
+  const dir = mkdtempSync(join(tmpdir(), 'crosswalk-'));
+  const path = join(dir, 'crosswalk.json');
+  writeFileSync(path, typeof obj === 'string' ? obj : JSON.stringify(obj));
+  return path;
+}
+
+const validRow = {
+  newToken: 'color.gray.900',
+  newValue: '#111827',
+  tier: 'primitive',
+  figmaOld: 'grey/900',
+  codeTokens: ['$grey-900'],
+  status: 'renamed',
+  recommendedSemantic: null,
+};
+const validDoc = { version: 1, tokens: [validRow] };
+
+test('loads a valid crosswalk', () => {
+  const cw = loadCrosswalk(writeTemp(validDoc));
+  assert.equal(cw.tokens.length, 1);
+  assert.equal(cw.tokens[0].newToken, 'color.gray.900');
+});
+
+test('rejects a missing file', () => {
+  assert.throws(() => loadCrosswalk('/no/such/file.json'), /cannot read file/);
+});
+
+test('rejects invalid JSON', () => {
+  assert.throws(() => loadCrosswalk(writeTemp('{ not json')), /invalid JSON/);
+});
+
+test('rejects a doc without a tokens array', () => {
+  assert.throws(() => loadCrosswalk(writeTemp({ version: 1 })), /"tokens" array/);
+});
+
+test('rejects a bad status', () => {
+  const bad = { version: 1, tokens: [{ ...validRow, status: 'frobnicated' }] };
+  assert.throws(() => loadCrosswalk(writeTemp(bad)), /status must be one of/);
+});
+
+test('rejects a bad tier', () => {
+  const bad = { version: 1, tokens: [{ ...validRow, tier: 'tertiary' }] };
+  assert.throws(() => loadCrosswalk(writeTemp(bad)), /tier must be/);
+});
+
+test('rejects a missing required string field', () => {
+  const bad = { version: 1, tokens: [{ ...validRow, newValue: '' }] };
+  assert.throws(() => loadCrosswalk(writeTemp(bad)), /newValue must be a non-empty string/);
+});
+
+test('rejects codeTokens that is not a string array', () => {
+  const bad = { version: 1, tokens: [{ ...validRow, codeTokens: [1, 2] }] };
+  assert.throws(() => loadCrosswalk(writeTemp(bad)), /codeTokens must be an array of strings/);
+});
+
+test('allows figmaOld null for added tokens', () => {
+  const added = { version: 1, tokens: [{ ...validRow, status: 'added', figmaOld: null, codeTokens: [] }] };
+  assert.doesNotThrow(() => loadCrosswalk(writeTemp(added)));
+});
+
+test('rejects figmaOld that is not a string or null', () => {
+  const bad = { version: 1, tokens: [{ ...validRow, figmaOld: 42 }] };
+  assert.throws(() => loadCrosswalk(writeTemp(bad)), /figmaOld must be a string or null/);
+});
+
+test('rejects a row missing figmaOld entirely', () => {
+  const row = { ...validRow };
+  delete row.figmaOld;
+  const bad = { version: 1, tokens: [row] };
+  assert.throws(() => loadCrosswalk(writeTemp(bad)), /figmaOld must be a string or null/);
+});
+
+test('rejects duplicate newToken', () => {
+  const dup = { version: 1, tokens: [validRow, { ...validRow }] };
+  assert.throws(() => loadCrosswalk(writeTemp(dup)), /duplicate newToken/);
+});
+
+test('rolls up status counts in camelCase', () => {
+  const doc = {
+    version: 1,
+    tokens: [
+      { ...validRow, newToken: 'a', status: 'aligned' },
+      { ...validRow, newToken: 'b', status: 'renamed' },
+      { ...validRow, newToken: 'c', status: 'drift-fix' },
+      { ...validRow, newToken: 'd', status: 'added', figmaOld: null },
+      { ...validRow, newToken: 'e', status: 'mapped-nearest' },
+      { ...validRow, newToken: 'f', status: 'renamed' },
+    ],
+  };
+  const counts = statusCounts(loadCrosswalk(writeTemp(doc)));
+  assert.deepEqual(counts, { aligned: 1, renamed: 2, driftFix: 1, added: 1, mappedNearest: 1 });
+});
+
+test('exposes the enum and the kebab->camel map', () => {
+  assert.deepEqual(STATUS_VALUES, ['aligned', 'renamed', 'drift-fix', 'added', 'mapped-nearest']);
+  assert.equal(STATUS_COUNT_KEY['drift-fix'], 'driftFix');
+  assert.equal(STATUS_COUNT_KEY['mapped-nearest'], 'mappedNearest');
+});

--- a/scripts/lib/crosswalk.test.mjs
+++ b/scripts/lib/crosswalk.test.mjs
@@ -83,6 +83,25 @@ test('rejects duplicate newToken', () => {
   assert.throws(() => loadCrosswalk(writeTemp(dup)), /duplicate newToken/);
 });
 
+test('rejects a missing or wrong version', () => {
+  assert.throws(() => loadCrosswalk(writeTemp({ tokens: [validRow] })), /version/);
+  assert.throws(() => loadCrosswalk(writeTemp({ version: 99, tokens: [validRow] })), /version/);
+});
+
+test('rejects an unknown top-level key', () => {
+  const bad = { version: 1, tokens: [validRow], bogus: true };
+  assert.throws(() => loadCrosswalk(writeTemp(bad)), /unknown key|unexpected key/i);
+});
+
+test('rejects an unknown row key (typo guard)', () => {
+  const bad = { version: 1, tokens: [{ ...validRow, codeToken: ['oops'] }] };
+  assert.throws(() => loadCrosswalk(writeTemp(bad)), /unknown key|unexpected key/i);
+});
+
+test('accepts a row with all valid keys including optional recommendedSemantic', () => {
+  assert.doesNotThrow(() => loadCrosswalk(writeTemp({ version: 1, tokens: [validRow] })));
+});
+
 test('rolls up status counts in camelCase', () => {
   const doc = {
     version: 1,

--- a/scripts/validate-crosswalk.mjs
+++ b/scripts/validate-crosswalk.mjs
@@ -1,0 +1,96 @@
+// Crosswalk validator: resolved DTCG value == crosswalk newValue, for every row.
+// The tokens:validate CI gate. Zero dependencies.
+//
+// Usage:
+//   node validate-crosswalk.mjs --crosswalk crosswalk.json --tokens dtcg/tokens.json
+import { readFileSync } from 'node:fs';
+import { parseArgs } from 'node:util';
+import { pathToFileURL } from 'node:url';
+import { loadCrosswalk, statusCounts } from './lib/crosswalk.mjs';
+
+const REF = /^\{([^}]+)\}$/;
+
+// Flatten nested DTCG groups into { "dot.path": rawValue }. Skips $-prefixed meta keys.
+export function flattenDtcg(obj, prefix = [], out = {}) {
+  for (const [key, val] of Object.entries(obj)) {
+    if (key.startsWith('$')) continue;
+    if (val && typeof val === 'object' && '$value' in val) {
+      out[[...prefix, key].join('.')] = val.$value;
+    } else if (val && typeof val === 'object') {
+      flattenDtcg(val, [...prefix, key], out);
+    }
+  }
+  return out;
+}
+
+// Follow {alias} chains to a leaf literal. Throws on missing or circular refs.
+export function resolveValue(name, flat, seen = new Set()) {
+  if (!(name in flat)) throw new Error(`token "${name}" not found in DTCG source`);
+  const val = flat[name];
+  if (typeof val === 'string') {
+    const m = val.match(REF);
+    if (m) {
+      if (seen.has(name)) throw new Error(`circular reference at "${name}"`);
+      seen.add(name);
+      return resolveValue(m[1], flat, seen);
+    }
+  }
+  return val;
+}
+
+function norm(v) {
+  return String(v).trim().toLowerCase();
+}
+
+export function validate(crosswalk, dtcg) {
+  const flat = flattenDtcg(dtcg);
+  const results = { total: crosswalk.tokens.length, passed: 0, mismatches: [], missing: [] };
+  for (const row of crosswalk.tokens) {
+    let resolved;
+    try {
+      resolved = resolveValue(row.newToken, flat);
+    } catch {
+      results.missing.push(row.newToken);
+      continue;
+    }
+    if (norm(resolved) === norm(row.newValue)) {
+      results.passed += 1;
+    } else {
+      results.mismatches.push({ token: row.newToken, expected: row.newValue, actual: resolved });
+    }
+  }
+  return results;
+}
+
+function main() {
+  const { values } = parseArgs({
+    options: {
+      crosswalk: { type: 'string' },
+      tokens: { type: 'string' },
+    },
+  });
+  if (!values.crosswalk || !values.tokens) {
+    console.error('usage: validate-crosswalk.mjs --crosswalk <crosswalk.json> --tokens <dtcg/tokens.json>');
+    process.exit(2);
+  }
+  const crosswalk = loadCrosswalk(values.crosswalk);
+  const dtcg = JSON.parse(readFileSync(values.tokens, 'utf8'));
+  const r = validate(crosswalk, dtcg);
+
+  console.log(`tokens:validate — ${r.passed}/${r.total} resolved values match`);
+  console.log('status counts:', JSON.stringify(statusCounts(crosswalk)));
+  if (r.missing.length) {
+    console.error(`\n${r.missing.length} token(s) missing from the DTCG source:`);
+    for (const t of r.missing) console.error(`  - ${t}`);
+  }
+  if (r.mismatches.length) {
+    console.error(`\n${r.mismatches.length} mismatch(es):`);
+    for (const m of r.mismatches) console.error(`  - ${m.token}: crosswalk says ${m.expected}, source resolves to ${m.actual}`);
+  }
+  const ok = r.passed === r.total;
+  if (!ok) process.exit(1);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/validate-crosswalk.test.mjs
+++ b/scripts/validate-crosswalk.test.mjs
@@ -1,0 +1,84 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { flattenDtcg, resolveValue, validate } from './validate-crosswalk.mjs';
+
+const dtcg = {
+  color: {
+    gray: {
+      900: { $value: '#111827', $type: 'color' },
+    },
+    text: {
+      primary: { $value: '{color.gray.900}', $type: 'color' },
+    },
+  },
+};
+
+test('flattenDtcg produces dot-path keys with raw $value', () => {
+  const flat = flattenDtcg(dtcg);
+  assert.equal(flat['color.gray.900'], '#111827');
+  assert.equal(flat['color.text.primary'], '{color.gray.900}');
+});
+
+test('resolveValue follows alias chains to a leaf', () => {
+  const flat = flattenDtcg(dtcg);
+  assert.equal(resolveValue('color.text.primary', flat), '#111827');
+  assert.equal(resolveValue('color.gray.900', flat), '#111827');
+});
+
+test('resolveValue throws on a missing token', () => {
+  assert.throws(() => resolveValue('color.nope', {}), /not found/);
+});
+
+test('resolveValue throws on a circular reference', () => {
+  const flat = { 'a': '{b}', 'b': '{a}' };
+  assert.throws(() => resolveValue('a', flat), /circular/);
+});
+
+test('validate passes N/N when every resolved value matches', () => {
+  const crosswalk = {
+    version: 1,
+    tokens: [
+      { newToken: 'color.gray.900', newValue: '#111827', tier: 'primitive', figmaOld: 'grey/900', codeTokens: [], status: 'renamed', recommendedSemantic: null },
+      { newToken: 'color.text.primary', newValue: '#111827', tier: 'semantic', figmaOld: 'Text/Default', codeTokens: [], status: 'renamed', recommendedSemantic: null },
+    ],
+  };
+  const r = validate(crosswalk, dtcg);
+  assert.equal(r.total, 2);
+  assert.equal(r.passed, 2);
+  assert.equal(r.mismatches.length, 0);
+  assert.equal(r.missing.length, 0);
+});
+
+test('validate compares case-insensitively and trims', () => {
+  const crosswalk = { version: 1, tokens: [
+    { newToken: 'color.gray.900', newValue: '  #111827  ', tier: 'primitive', figmaOld: null, codeTokens: [], status: 'aligned', recommendedSemantic: null },
+  ]};
+  // newValue with surrounding whitespace must still match the trimmed source value
+  const r = validate(crosswalk, { color: { gray: { 900: { $value: '#111827' } } } });
+  assert.equal(r.passed, 1);
+  const rUpper = validate({ version: 1, tokens: [
+    { newToken: 'color.gray.900', newValue: '#EF4444', tier: 'primitive', figmaOld: null, codeTokens: [], status: 'aligned', recommendedSemantic: null },
+  ]}, { color: { gray: { 900: { $value: '#ef4444' } } } });
+  assert.equal(rUpper.passed, 1);
+});
+
+test('validate reports a mismatch', () => {
+  const crosswalk = { version: 1, tokens: [
+    { newToken: 'color.gray.900', newValue: '#000000', tier: 'primitive', figmaOld: null, codeTokens: [], status: 'drift-fix', recommendedSemantic: null },
+  ]};
+  const r = validate(crosswalk, dtcg);
+  assert.equal(r.passed, 0);
+  assert.equal(r.mismatches.length, 1);
+  assert.equal(r.mismatches[0].token, 'color.gray.900');
+  assert.equal(r.mismatches[0].expected, '#000000');
+  assert.equal(r.mismatches[0].actual, '#111827');
+});
+
+test('validate reports a token missing from the DTCG source', () => {
+  const crosswalk = { version: 1, tokens: [
+    { newToken: 'color.ghost', newValue: '#fff', tier: 'primitive', figmaOld: null, codeTokens: [], status: 'added', recommendedSemantic: null },
+  ]};
+  const r = validate(crosswalk, dtcg);
+  assert.deepEqual(r.missing, ['color.ghost']);
+  assert.equal(r.passed, 0);
+});

--- a/skills/component-builder/SKILL.md
+++ b/skills/component-builder/SKILL.md
@@ -178,8 +178,13 @@ dropdown requires its swap targets (icons, components) to be **published** —
 Figma rejects local unpublished keys for swap targets. Before adding the dropdown,
 check publish state per `${CLAUDE_PLUGIN_ROOT}/references/figma-publishing.md`:
 
-- **Published (`figma.libraryPublished` true):** add the typed `INSTANCE_SWAP`
-  dropdown with preferred values.
+- **Resolve publish state first (detect-or-ask, bug B3):** a default/`false`
+  `figma.libraryPublished` is *unverified* — attempt detection
+  (`figma_get_library_components` / `figma_get_library_variables`) and ask once only if
+  inconclusive, per `${CLAUDE_PLUGIN_ROOT}/references/figma-publishing.md`. Never treat
+  a `false` as a final "not published" without that check.
+- **Confirmed published (`figma.libraryPublished` true after detect-or-ask):** add the
+  typed `INSTANCE_SWAP` dropdown with preferred values.
 - **Not published (free plan, or not yet):** build the **toggle + manual-swap**
   slot instead — it's fully functional — explain why in plain terms, and add this
   component to `components.instanceSwapUpgradePending` so a later run (after the
@@ -215,9 +220,11 @@ any component built with the toggle + manual-swap fallback is listed in
 `components.instanceSwapUpgradePending`. Append `component-builder` to
 `completedSkills`.
 
-**Upgrade pass:** if `components.instanceSwapUpgradePending` is non-empty and the
-library is now published (`figma.libraryPublished` true), offer to add the typed
-`INSTANCE_SWAP` dropdowns to those components and clear each from the list.
+**Upgrade pass:** if `components.instanceSwapUpgradePending` is non-empty, re-resolve
+publish state (detect-or-ask per `${CLAUDE_PLUGIN_ROOT}/references/figma-publishing.md`);
+only when it is **confirmed published** (`figma.libraryPublished` true via a verified
+detect-or-ask, not a stale default) offer to add the typed `INSTANCE_SWAP` dropdowns to
+those components and clear each from the list.
 
 Offer next steps: build the code counterparts and stories
 (storybook-chromatic-builder), or build a single new component end-to-end later

--- a/skills/design-system-audit/SKILL.md
+++ b/skills/design-system-audit/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: design-system-audit
+description: Measure a pre-existing design system before retrofitting it onto tokens — size the code-side color surface and inventory the existing Figma file with verified per-class reads, then compute how semantic the system already is so the retrofit is right-sized. This is a PROCESS skill and the brownfield front door. Use this when retrofitting a design system onto a mature codebase and an already-populated Figma file, when the user wants to audit an existing system, size a retrofit, count existing tokens/variables/bindings, or figure out how much work a migration is. Also trigger when figma-environment-setup detects a brownfield situation (existing repo or populated Figma file), before any building. Make sure to use this whenever someone is converging two mature, drifted artifacts rather than building greenfield.
+---
+
+# Design-system audit (brownfield front door)
+
+Measures **both sides** of a pre-existing system so a retrofit can be right-sized,
+before anything is built or changed. It is the brownfield analog of
+`/design-system-status`: where status reports a *local* manifest, this assesses an
+*external, mature* system — a real codebase and an already-populated Figma file.
+
+This is a brownfield skill. **Before doing anything, read**
+`${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md` — especially the
+read-discipline principle (never assert absence without a verified read) and the
+`audit` phase of the safe sequence. Greenfield builds skip this skill entirely.
+
+## Calibrate
+
+Read `user.codingLevel` (`${CLAUDE_PLUGIN_ROOT}/references/coding-level.md`) and scale
+explanation accordingly. The audit surfaces grep counts and a `percentSemantic`
+number — for `new` users explain what each means and why it matters (it decides
+rename-vs-rewrite); for `comfortable` users be terse. The measurements are identical
+across levels.
+
+## Prerequisites
+
+Read the manifest. This skill needs Figma connected (`figma.connected: true`) for the
+inventory step, and a repo path for the code-surface step (`workspace.localPath`). If
+Figma isn't connected, offer to run `figma-environment-setup` first. The code-surface
+step works on any repo regardless of `workspace.stage`.
+
+## Step 1 — Size the code surface
+
+Measure how many color decisions live in the codebase. Run the color-usage grep
+scaffold against the user's repo:
+
+```bash
+node ${CLAUDE_PLUGIN_ROOT}/scripts/grep-color-usage.mjs --root <workspace.localPath>
+```
+
+It counts five categories: SCSS color vars, Tailwind color classes, `Colors.*` JS
+usages, raw hex + `rgba()` literals, and SVG hardcoded fills — producing the
+case-study worklist shape.
+
+**Tune the patterns to the actual repo, and say what you assumed (read discipline +
+§11).** The shipped patterns are *defaults*, not ground truth. Before trusting the
+counts:
+1. Look at the repo's real conventions — open a few SCSS/TS files, check the actual
+   color-variable prefixes (`$primary-*`, `$grey-*`, a custom prefix), the Tailwind
+   color-class names, and whether colors come through a `Colors.*` object or some other
+   accessor.
+2. If the defaults don't fit, write a `--config <patterns.json>` of
+   `{ "<category>": { "files": "<regex>", "pattern": "<regex>" } }` tuned to this repo
+   and re-run with it.
+3. **Report which categories used the assumed defaults vs. a tuned pattern** — never
+   present default-pattern counts as if they were measured. The script prints this; pass
+   it through to the user so partial coverage is visible, not hidden.
+
+**Don't assume the stack.** The categories are color-specific but framework-agnostic; a
+repo with no Tailwind simply scores `0` there. Detect what the repo actually uses (is
+there a `tailwind.config`? SCSS? CSS-in-JS?) and explain the counts in those terms.
+
+## Step 2 — Inventory the Figma file (verified per-class reads)
+
+Variables, text styles, and effect/paint styles are **different surfaces** — read each
+independently and report "none" only for the class whose own read came back empty
+(read discipline, fixes B2). Before counting variables, ensure all pages are loaded
+(`await figma.loadAllPagesAsync()`); treat a `0` on first read as suspect and re-read
+before reporting (fixes B1).
+
+- **Variables** — `figma_get_variables` (handles `dynamic-page`, resolves aliases).
+  Record the count.
+- **Bindings** — run the binding-survival audit snippet in
+  `${CLAUDE_PLUGIN_ROOT}/references/figma-scripting.md` to count consuming bindings.
+  This is the load-bearing number: it's what a careless rename would destroy.
+- **Text styles** — `figma_get_text_styles`. Record the count.
+- **Effect/paint styles** — `figma_get_styles`. Record the count.
+- **Modes** — record the mode names per collection (e.g. `["Light", "Dark"]`).
+
+Never report a count you didn't read. If a read genuinely returns empty after a
+reliable load, that's a real `0`; if it's suspect, re-read or ask the user once and
+persist — never guess.
+
+## Step 3 — Compute "% semantic"
+
+From the inventory, estimate how much of the existing system is already **semantic**
+(named by role — `text/default`, `surface/raised`) vs. **raw/primitive** (named by
+value — `grey-900`, or bare hex). Report it as an integer 0–100 (`audit.percentSemantic`).
+
+This single number right-sizes the retrofit: a largely-semantic system (~90%) is a
+**rename-in-place + cleanup** job; a low-semantic one is closer to a **rewrite**.
+Surface it early and plainly — "you're ~90% semantic, so this is mostly renames and a
+cleanup, not a rebuild" — so the user calibrates effort before committing.
+
+## Step 4 — Write the manifest and recommend the next step
+
+Write the `audit` section (this skill owns it):
+
+- `codeSurface` — the per-category counts from Step 1 (keys vary by what the repo uses;
+  omit categories that don't apply rather than reporting a misleading `0`).
+- `figmaInventory` — `{ variables, bindings, textStyles, effectStyles, modes }` from
+  Step 2's verified reads.
+- `percentSemantic` — the integer from Step 3.
+- `ranAt` — the current ISO timestamp.
+
+Set `tokens.intakeMode: "retrofit"` (this skill establishes the brownfield path — it
+owns this transition). Append `design-system-audit` to `completedSkills`.
+
+Then recommend the next step:
+- If the user wants the guided, gated end-to-end retrofit → **`retrofit-planner`**
+  (the orchestrator; recommended for multi-session retrofits).
+- If they only want the crosswalk backbone next → **`token-crosswalk-builder`** (it
+  reads this `audit` section to seed its rows).
+
+## What this skill must NOT do
+
+- Never build, rename, or delete anything — this is a **measurement** skill. Changes
+  belong to `token-builder` (refine), the retrofit phases, and cleanup.
+- Never report a count without a verified read (read discipline). An unexpectedly-empty
+  read is a suspected error, not ground truth.
+- Never present default grep patterns as measured truth — say what was assumed.
+- Never assume the case-study stack (Tailwind/SCSS/Chromatic). Detect what the repo
+  actually uses and degrade gracefully.
+- Never write another skill's manifest fields (e.g. `tokenCrosswalk`, `retrofit.phase`).
+- Never overwrite `workspace.origin` — it is immutable after intake.

--- a/skills/figma-environment-setup/SKILL.md
+++ b/skills/figma-environment-setup/SKILL.md
@@ -325,7 +325,7 @@ Don't declare success on faith. Run one trivial **read** against Figma to prove
 the connection is live — for example, a low-cost call such as reading the file
 name or a single variable collection. This probe proves *connectivity only*.
 
-**Do not report an inventory from this probe (bugs B1/B2).** A cheap or early read
+**Do not report an inventory from this probe (the false-empty read bugs B1/B2).** A cheap or early read
 can come back empty on a fully-populated file (pages not yet loaded, cache/read
 error), and reporting "0 variables" or "no text styles" off the back of it is a
 confidence-destroying first impression. Proving the connection is live is a

--- a/skills/figma-environment-setup/SKILL.md
+++ b/skills/figma-environment-setup/SKILL.md
@@ -322,8 +322,21 @@ Figma files to work in, so I don't have to ask every time."
 ## Step 6 — Liveness check (prove it actually works)
 
 Don't declare success on faith. Run one trivial **read** against Figma to prove
-the connection is live — for example, fetch a quick summary of the file's
-existing variables/styles (a low-cost call). If it succeeds:
+the connection is live — for example, a low-cost call such as reading the file
+name or a single variable collection. This probe proves *connectivity only*.
+
+**Do not report an inventory from this probe (bugs B1/B2).** A cheap or early read
+can come back empty on a fully-populated file (pages not yet loaded, cache/read
+error), and reporting "0 variables" or "no text styles" off the back of it is a
+confidence-destroying first impression. Proving the connection is live is a
+separate concern from inventorying what's in the file — the full per-class
+inventory (with `loadAllPagesAsync` and independent reads for variables, text
+styles, and effect styles) belongs to the `design-system-audit` skill, which
+applies the read discipline in
+`${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md`. Here, only confirm the
+call succeeded — never announce counts.
+
+If the liveness probe succeeds:
 
 - Set `figma.connected` = `true` and `figma.lastVerified` to the current
   timestamp.

--- a/skills/figma-environment-setup/SKILL.md
+++ b/skills/figma-environment-setup/SKILL.md
@@ -147,6 +147,7 @@ heads-up, not a warning.
 > components, variables — works exactly the same. When we get to the code
 > phase, you'll need to convert this repo to a monorepo first. I'll walk you
 > through that step-by-step when we get there — it's a one-time setup.
+> Because you already have a system here, we'll start by **auditing** what exists — measuring your current colors in code and what's in your Figma file — so we right-size the work before changing anything. That's the `design-system-audit` step.
 > [one line per additional detected layer, e.g.: 'Storybook is already installed
 > — we'll build on top of what you have rather than starting fresh.']
 >
@@ -160,6 +161,7 @@ heads-up, not a warning.
 > Here's what that means for us: you're already in great shape for the code
 > phase. We'll build the Figma side first, then work inside your existing
 > monorepo structure when we get to code.
+> Because you already have a system here, we'll start by **auditing** what exists — measuring your current colors in code and what's in your Figma file — so we right-size the work before changing anything. That's the `design-system-audit` step.
 > [one line per additional detected layer]
 >
 > Ready to continue?"
@@ -408,6 +410,45 @@ step is building your color, spacing, and type tokens — just say something lik
 'let's build my tokens' and I'll take it from there. Or if you'd rather explore
 first, that's fine too." Update the manifest and stop. Don't auto-run the next
 skill.
+
+## Step 8 — Brownfield routing + rollback baseline (existing systems)
+
+After the liveness check passes, decide where to send the user. Most greenfield runs
+continue to token building. A **brownfield** run — a mature codebase and/or an
+already-populated Figma file — routes into the audit first, and an **in-progress
+retrofit** resumes where it left off. This is the front-door routing the spec calls
+for; apply the read discipline in
+`${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md` to every read here.
+
+**Read the manifest and route:**
+
+1. **Resume an in-progress retrofit.** If `retrofit.phase` is set and not `"done"`,
+   a retrofit is already underway — hand back to **`retrofit-planner`** to resume at
+   that phase, rather than starting anything new. Say plainly where it left off
+   (e.g. "Looks like we're mid-retrofit at the `sync` phase — want to pick up there?").
+2. **Route a mature system to the audit.** If `workspace.origin` is `"existing-repo"`
+   or `"existing-monorepo"` (a mature codebase), recommend **`design-system-audit`**
+   as the next step instead of `token-builder`: "You've got an existing system — let's
+   audit it first so we right-size the retrofit." The audit also covers a populated
+   Figma file via its verified per-class reads.
+3. **Greenfield stays greenfield.** If `workspace.origin` is `"greenfield"`, continue
+   the normal path (brainstorm → token-builder). Don't push greenfield users through
+   the audit.
+
+**Capture a rollback baseline before any mutation (brownfield only).** A retrofit
+changes a file that already has value in it, so before *any* write lands, capture a
+restore point:
+- **Figma version checkpoint** — note the current version (e.g. via
+  `figma_get_file_versions`) or have the user name a Figma version so there's a known-good
+  point to restore to. The plugin can read versions; it does not auto-create named
+  versions, so if none exists, ask the user to add one ("File → Save to version
+  history") and record that you did.
+- **Token export** — if the repo already emits tokens, snapshot the current generated
+  output (git is the natural baseline once `workspace.stage` is `local-git`+).
+
+Do this **before** routing into any skill that writes (the audit only reads, so the
+baseline must be in place before `token-builder`'s refine phase runs). Frame it as
+cheap insurance, not alarm.
 
 ## What this skill must NOT do
 

--- a/skills/retrofit-planner/SKILL.md
+++ b/skills/retrofit-planner/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: retrofit-planner
+description: Orchestrate a full brownfield design-system retrofit end to end — audit, refine variables in place, rebind components, sync, capture a Chromatic baseline, retrofit the code with dual output, then remove the old tokens only after a zero-reference grep — with a human confirmation gate between every phase. Use this when the user wants to run a complete retrofit, migrate a mature codebase and populated Figma file onto tokens, resume an in-progress retrofit, or be walked through the safe retrofit sequence. Also trigger after design-system-audit has sized the system, or when figma-environment-setup detects an in-progress retrofit. Make sure to use this whenever someone wants the guided, gated, multi-session brownfield retrofit rather than running the individual skills by hand.
+---
+
+# Retrofit planner (orchestrator)
+
+Sequences a brownfield retrofit through the safe 7-phase order, gating each phase on a
+human confirmation. Like `component-pipeline`, this skill holds **zero domain logic of
+its own** — it is a sequencer that invokes the real skills and the phase work, and only
+updates the manifest fields it owns (`retrofit.phase`, `completedSkills`). All the
+actual work lives in the skills it calls, so this orchestrator doesn't rot when they
+improve.
+
+**Before anything, read `${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md`** —
+the read discipline, the 7 guardrails, the safe sequence, and the verification triad
+are the rules this skill enforces as gates.
+
+## When to use vs. the individual skills
+
+Use this for a **complete retrofit**, especially across multiple sessions. For a single
+isolated step (just the audit, just the crosswalk), run that skill directly. This is the
+"converge my mature system onto tokens, end to end, without breaking the live app" flow.
+
+## Calibrate
+
+Read `user.codingLevel` (`${CLAUDE_PLUGIN_ROOT}/references/coding-level.md`). A retrofit
+touches Figma, tokens, code, CI, and a live app — for `new` users explain each phase and
+why its ordering matters the first time; for `comfortable` users be terse. The phases and
+gates are identical across levels.
+
+## Prerequisites
+
+Read the manifest. This orchestrator assumes a brownfield situation
+(`tokens.intakeMode: "retrofit"`, or `workspace.origin` is an existing repo/monorepo). If
+the audit hasn't run yet (`audit.ranAt` is `null`), start at the audit phase below. If
+none of the brownfield markers are set, this is probably greenfield — point the user to
+the normal build skills instead.
+
+## Decision-journal offer (default-on)
+
+At the start of a retrofit, offer to scaffold a decision journal at `docs/design-system/`
+with `specs/ plans/ spikes/ findings/ decisions/ handoffs/`. **Recommend yes** —
+retrofits are multi-session and the journal is the human decision trail (complementary to
+the manifest's machine state) — but allow the user to decline. Record the choice in
+`retrofit.journalScaffolded`. This is the only artifact this skill creates directly.
+
+## Detect the stack, don't assume it (§11)
+
+Before running phases that shell out (sync, baseline, code, cleanup), detect what the
+repo actually uses — read its `package.json` scripts for the real type-check, build,
+visual-test, and token commands. The case study used Chromatic + `build-storybook` +
+`tokens:sync`/`tokens:validate`; a real repo may differ. Map each phase onto the repo's
+actual commands, or degrade gracefully and say what's missing — never assert a command
+that doesn't exist.
+
+## The safe sequence (confirm between EVERY phase)
+
+Set `retrofit.phase` to the current phase as you enter it, so a later session can resume
+exactly here. Confirm the goal first, then walk the phases. **Each gate is a hard stop:
+do not advance without explicit confirmation** — the gates are what keep the live app
+intact and make the retrofit resumable.
+
+### Phase 1 — `audit` (invoke `design-system-audit`)
+
+Invoke `design-system-audit`: size the code surface, inventory the Figma file with
+verified per-class reads, compute `percentSemantic`. **Gate:** show the audit results and
+the right-sizing read ("~90% semantic → renames + cleanup, not a rewrite"). Confirm before
+continuing. Capture the rollback baseline (Figma version checkpoint / token export) now if
+`figma-environment-setup` didn't already.
+
+### Phase 2 — `refine` (invoke `token-builder` brownfield branch)
+
+Invoke `token-builder`'s refine-in-place branch: rename/realign variables **in place**,
+preserving IDs, with a binding-survival audit before and after each rename (guardrail 3).
+**Gate:** show the before/after binding counts are equal (no bindings severed) and the
+refined variable names. Confirm before continuing. **Never delete-and-recreate.**
+
+### Phase 3 — `rebind`
+
+Reconcile components onto the refined variables, preserving their Figma IDs. There is no
+dedicated skill for this — drive it directly here: verify components still reference the
+(renamed, same-id) variables, and fix any that drifted. **Gate:** confirm components still
+render bound. This is also the natural point to build the crosswalk if not yet done —
+offer `token-crosswalk-builder` (it reads the `audit` section to seed rows and wires
+`tokens:validate`).
+
+### Phase 4 — `sync` (invoke `token-sync-layer` brownfield branch)
+
+Invoke `token-sync-layer` with the brownfield transforms (channel alpha, opacity
+0–100→0–1, float32 rounding at the export boundary, `/opacity`→`color-mix`). It lands a
+reviewable PR per its own rules. **Gate:** confirm the sync PR before continuing.
+
+### Phase 5 — `baseline` (invoke `storybook-chromatic-builder`)
+
+Capture a Chromatic baseline **before** any code retrofit, so intended drift-fixes are
+distinguishable from regressions. **Gate:** confirm the baseline is green and captured.
+This ordering is not optional — baseline *after* the code change throws away the signal.
+
+### Phase 6 — `code` (dual output)
+
+Retrofit the codebase with **dual output**: new and old tokens coexist during the
+transition, so nothing breaks mid-migration. Use the crosswalk reverse index
+(`tokens:reverse-index`) to semi-automate the SCSS/Tailwind swaps. Run the verification
+triad as you go — `check-types`, `build-storybook` + Chromatic, **and run the actual app**
++ spot-check 5–7 routes (the build alone is blind to story-unreachable SCSS). **Gate:**
+confirm the triad passes before continuing.
+
+### Phase 7 — `cleanup`
+
+Remove the old token outputs **only after** the repo-wide token-removal guard returns
+**zero references** (`guard-token-removal.mjs`) — deleted Tailwind utilities are silent
+no-ops that `tsc`/build won't catch (guardrail 4). **Gate:** show the guard reporting zero
+references, then confirm removal. Re-run the verification triad after removal.
+
+When cleanup is verified, set `retrofit.phase: "done"` and `retrofit.completedAt`, and
+append `retrofit-planner` to `completedSkills`.
+
+## Resumability
+
+Because each phase is gated and `retrofit.phase` is written on entry, a stop at any point
+leaves a clean resume point. `figma-environment-setup` reads `retrofit.phase` on the next
+`/start` and routes back here at the right phase. Never silently restart from the top —
+resume where the manifest says.
+
+## What this skill must NOT do
+
+- Never reimplement what the sub-skills do — only sequence them and drive the
+  no-dedicated-skill phases (rebind, code, cleanup). If you're writing token/sync logic
+  here, stop and invoke the real skill.
+- Never skip a confirmation between phases — the gates keep the live app intact and make
+  the retrofit resumable.
+- Never delete-and-recreate variables (guardrail 3), baseline after the code retrofit
+  (phase 5 before 6), or remove old outputs before the zero-reference grep passes
+  (guardrail 4).
+- Never write another skill's manifest fields — own only `retrofit.*` and
+  `completedSkills`. The audit owns `audit.*`; the crosswalk owns `tokenCrosswalk`.
+- Never assert the case-study toolchain — detect the repo's real commands or degrade
+  gracefully.

--- a/skills/retrofit-planner/SKILL.md
+++ b/skills/retrofit-planner/SKILL.md
@@ -8,7 +8,7 @@ description: Orchestrate a full brownfield design-system retrofit end to end —
 Sequences a brownfield retrofit through the safe 7-phase order, gating each phase on a
 human confirmation. Like `component-pipeline`, this skill holds **zero domain logic of
 its own** — it is a sequencer that invokes the real skills and the phase work, and only
-updates the manifest fields it owns (`retrofit.phase`, `completedSkills`). All the
+updates the manifest fields it owns (`retrofit.*`, `completedSkills`). All the
 actual work lives in the skills it calls, so this orchestrator doesn't rot when they
 improve.
 
@@ -67,7 +67,8 @@ Invoke `design-system-audit`: size the code surface, inventory the Figma file wi
 verified per-class reads, compute `percentSemantic`. **Gate:** show the audit results and
 the right-sizing read ("~90% semantic → renames + cleanup, not a rewrite"). Confirm before
 continuing. Capture the rollback baseline (Figma version checkpoint / token export) now if
-`figma-environment-setup` didn't already.
+`figma-environment-setup` didn't already. On first entry, set `retrofit.startedAt` to the
+current ISO timestamp if it is unset.
 
 ### Phase 2 — `refine` (invoke `token-builder` brownfield branch)
 

--- a/skills/storybook-chromatic-builder/SKILL.md
+++ b/skills/storybook-chromatic-builder/SKILL.md
@@ -212,6 +212,38 @@ Set `storybook.initialized` = `true`, `storybook.chromatic` accordingly,
 Step 6.) Note the ongoing loop: new components flow through the
 component-pipeline orchestrator; token changes flow through `/sync-figma-tokens`.
 
+## Brownfield: baseline before retrofit + the verification triad
+
+On a **retrofit** (`tokens.intakeMode: "retrofit"`), the order of operations and the
+verification bar are stricter than greenfield. **Read
+`${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md`** — the safe sequence and the
+verification triad live there.
+
+**Capture the Chromatic baseline BEFORE the code retrofit.** Run `build-storybook` +
+Chromatic to establish a green baseline *before* any token/color code is changed. Then,
+when the retrofit lands, every diff is either an **intended drift-fix** (a color the
+audit flagged as wrong) or a **regression** — and the baseline is the only thing that
+tells them apart. Baseline *after* the retrofit and you've thrown away that signal.
+
+**The verification triad — all three are necessary; no single check catches everything:**
+1. **`check-types` (TypeScript)** — catches type errors, but is **blind to Tailwind
+   silent no-ops**: a deleted color utility just stops applying, with no type error
+   (guardrail 4).
+2. **`build-storybook` + Chromatic snapshots** — the visual-regression net, but **blind
+   to story-unreachable code**. `build-storybook` only compiles SCSS that some story
+   actually imports; a dead `@import` of a deleted partial, or a route's styles no story
+   renders, compiles "fine" here and breaks only in the app. **Chromatic — not
+   `tsc`/build — is the source of truth** for whether a color-utility removal was safe.
+3. **Run the actual app + spot-check 5–7 real routes** — the only thing that exercises
+   story-unreachable SCSS (guardrail 5). Don't declare an SCSS/color change done on the
+   strength of a green build alone.
+
+**Don't assume the stack (§11).** This triad names Chromatic + `build-storybook`
+because that's the case-study tooling. Detect what the repo actually uses — read its
+`package.json` scripts for the real type-check / build / visual-test commands — and map
+the triad onto them (or degrade gracefully and say so) rather than asserting commands
+that may not exist.
+
 ## What this skill must NOT do
 
 - Never finish a finalized component while leaving its Figma doc card on `draft`
@@ -225,3 +257,9 @@ component-pipeline orchestrator; token changes flow through `/sync-figma-tokens`
   — its incremental model keeps missing global token changes. Default to full
   snapshots (every story, every run); revisit only at large story counts.
 - Never use the sequential model for story-gen — parallelize via subagents.
+- Never capture the Chromatic baseline *after* a code retrofit — baseline before, so
+  intended drift-fixes are distinguishable from regressions.
+- Never trust `tsc`/build to catch Tailwind color-utility removal — it's a silent
+  no-op; Chromatic is the source of truth (guardrail 4).
+- Never declare an SCSS/color change done on a green build alone — run the app and
+  spot-check 5–7 real routes (guardrail 5).

--- a/skills/token-builder/SKILL.md
+++ b/skills/token-builder/SKILL.md
@@ -146,6 +146,41 @@ with a meaningful name is fine; a fake role nobody applies is not. If you can't
 name a genuine role for a category, give it semantic roles that map to actual
 usage rather than mirroring the primitive scale step-for-step.
 
+## Step 1.5 — Brownfield: refine existing variables in place (don't rebuild)
+
+If this is a **retrofit** (`tokens.intakeMode: "retrofit"`, or the file already has
+variables), do **not** create a fresh set on top of the old one. Refine what exists,
+in place. **Read `${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md` first** —
+guardrail 3 is the whole point of this branch.
+
+**The hard rule (guardrail 3):** rename and realign variables **in place** to preserve
+their Figma IDs. **Never delete-and-recreate** — every binding (a populated file can
+have thousands) references the variable *id*, so recreating under the same name still
+unbinds everything. A rename keeps the id; a delete+create does not.
+
+**The refine loop:**
+
+1. **Read what exists** (read discipline). Use `figma_get_variables` after
+   `await figma.loadAllPagesAsync()`. List the existing collections, variables, and
+   values. Treat a `0`/empty first read as suspect — re-read before concluding the file
+   is empty.
+2. **Snapshot bindings before.** Run the binding-survival audit in
+   `${CLAUDE_PLUGIN_ROOT}/references/figma-scripting.md` to record the total consuming
+   binding count *before* any change. This is your guardrail-3 tripwire.
+3. **Rename / realign in place.** Use the rename operation that keeps the id (e.g.
+   `figma_rename_variable` / setting `variable.name`), and update values in place. Map
+   old names to the new two-tier scheme; record each old→new mapping (the crosswalk
+   consumes it later via `token-crosswalk-builder`).
+4. **Snapshot bindings after, and assert equality.** Re-run the binding-survival audit.
+   The total **must be unchanged**. A drop means a binding was severed — STOP, find the
+   delete-and-recreate that slipped in, and restore from the baseline.
+5. **Add genuinely-new variables** (the `added` rows) as normal creates — only the
+   *existing* ones must be renamed rather than recreated.
+
+After the refine loop, continue with the normal tiers below for any net-new structure,
+but **skip recreating anything that already exists**. The primitive/semantic checkpoint
+(Step 2's PAUSE) still applies: lock names before building dependent semantics.
+
 ## Step 2 — Build the PRIMITIVE tier, then PAUSE
 
 Create the **per-category primitive collections** and their variables via a
@@ -322,3 +357,7 @@ comes later.
   types clean and consistent — it makes the downstream sync trivial.
 - **Token-efficiency:** scripted loops via `figma_execute`, batched per tier —
   not per-variable tool calls.
+- **Brownfield: never delete-and-recreate to rename (guardrail 3).** On a retrofit,
+  rename variables in place to preserve their Figma IDs and every binding. Snapshot the
+  binding count before and after each rename and assert it's unchanged — see Step 1.5
+  and `${CLAUDE_PLUGIN_ROOT}/references/figma-scripting.md`.

--- a/skills/token-crosswalk-builder/SKILL.md
+++ b/skills/token-crosswalk-builder/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: token-crosswalk-builder
+description: Build the brownfield token crosswalk — a persistent three-way map between each new token, the old Figma variable, and the old code identifier(s) — as crosswalk.json, then install the vetted validator/reverse-index scripts into the monorepo and wire the tokens:validate CI gate. Use this when retrofitting a design system onto a mature codebase, when the user wants to map old tokens to new ones, build a crosswalk, set up tokens:validate, or generate a reverse index for SCSS/Tailwind swaps. Also trigger when retrofit-planner reaches the crosswalk stage, or after design-system-audit has sized the retrofit. Make sure to use this whenever someone needs the machine-readable backbone that drives a brownfield code retrofit and its validation gate.
+---
+
+# Token crosswalk builder
+
+Builds the **backbone artifact** of a brownfield retrofit: `crosswalk.json`, a
+persistent three-way map of **new token ↔ old Figma variable ↔ old code identifier**.
+It drives the code retrofit and the `tokens:validate` CI gate. This skill also
+installs the canonical scripts into the user's repo and wires the gate.
+
+This is a brownfield skill. **Before doing anything, read**
+`${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md` (read discipline, the 7
+guardrails, the safe sequence) and
+`${CLAUDE_PLUGIN_ROOT}/references/crosswalk-schema.md` (the exact contract). Greenfield
+builds don't need this skill.
+
+## Calibrate
+
+Read `user.codingLevel` (`${CLAUDE_PLUGIN_ROOT}/references/coding-level.md`) and scale
+explanation accordingly. The crosswalk involves JSON, npm scripts, and a CI gate — for
+`new` users explain each plainly the first time; for `comfortable` users be terse.
+Actions are identical across levels.
+
+## Prerequisites (offer to run them, don't bail)
+
+Read the manifest. This skill needs:
+
+1. **A DTCG token source** at `packages/tokens/dtcg/tokens.json` — the validator
+   resolves against it. If it doesn't exist, offer to run `token-sync-layer` first
+   (it emits this file). Apply the read discipline: confirm the file exists by
+   reading it, never assume it's absent without looking.
+2. **The audit inputs** — ideally the `audit` manifest section (code surface,
+   Figma inventory, `percentSemantic`) populated by `design-system-audit`. If
+   `audit` is present, use it to seed the rows. If it is `null` (audit hasn't run —
+   it lands in Plan 3), don't block: ask the user for the old→new mapping inputs
+   directly (which old Figma variables and code symbols map to which new tokens),
+   and proceed. Note plainly that running `design-system-audit` first would
+   pre-fill this.
+3. **A repo at `local-git` or `github`** (`workspace.stage`) so the installed
+   scripts and `package.json` changes land as a reviewable diff/PR. If still
+   `folder`, offer `repository-builder`.
+
+## Step 1 — Build `crosswalk.json`
+
+Write `packages/tokens/crosswalk.json` per the contract in
+`${CLAUDE_PLUGIN_ROOT}/references/crosswalk-schema.md`. One row per new token:
+
+- `newToken` — the DTCG dot-path exactly as it appears in
+  `packages/tokens/dtcg/tokens.json` (e.g. `color.text.primary`).
+- `newValue` — the **resolved** leaf value (follow `{…}` aliases to the literal).
+- `tier` — `primitive` or `semantic`.
+- `figmaOld` — the old Figma variable name/path, or `null` if newly added.
+- `codeTokens[]` — the old code identifiers this token replaces (`$primary-red`,
+  `bg-primary-red`, `Colors.primaryRed`, `--primary-red`). May be `[]`.
+- `status` — `aligned | renamed | drift-fix | added | mapped-nearest`. Assign by:
+  same name & value → `aligned`; same value, new name → `renamed`; value
+  intentionally changed → `drift-fix`; brand-new token → `added`; no exact old
+  equivalent, mapped to nearest → `mapped-nearest`.
+- `recommendedSemantic` — optional semantic target for a raw/primitive usage, else
+  `null`.
+
+Do not guess values. Every `newValue` comes from a read of the DTCG source, not an
+assumption (read discipline).
+
+## Step 2 — Install the vetted scripts + wire `tokens:validate`
+
+Copy these from `${CLAUDE_PLUGIN_ROOT}/scripts/` into the user's repo **verbatim**
+(they are zero-dependency and version with the user's repo so their CI can run them):
+
+- `lib/crosswalk.mjs` → `packages/tokens/scripts/lib/crosswalk.mjs`
+- `validate-crosswalk.mjs` → `packages/tokens/scripts/validate-crosswalk.mjs`
+- `build-reverse-index.mjs` → `packages/tokens/scripts/build-reverse-index.mjs`
+- `guard-token-removal.mjs` → `packages/tokens/scripts/guard-token-removal.mjs`
+- `crosswalk.schema.json` → `packages/tokens/crosswalk.schema.json` (beside
+  `crosswalk.json`, so the `$schema` pointer resolves)
+
+Then add to `packages/tokens/package.json` `scripts` (don't clobber existing keys):
+
+```jsonc
+"tokens:validate": "node scripts/validate-crosswalk.mjs --crosswalk crosswalk.json --tokens dtcg/tokens.json",
+"tokens:reverse-index": "node scripts/build-reverse-index.mjs --crosswalk crosswalk.json --out crosswalk.reverse.json"
+```
+
+See `${CLAUDE_PLUGIN_ROOT}/scripts/README.md` for the full install contract.
+
+## Step 3 — Run the gate (must pass N/N)
+
+Run `npm run tokens:validate` (from `packages/tokens/`). It must report **N/N** —
+every row's resolved value matches its `newValue`. If it reports mismatches or
+missing tokens, fix the crosswalk (or the token source) and re-run. **Never proceed
+on a red validator and never edit a generated token file to make it pass** — change
+the source in Figma and re-sync (guardrail 7). The validator is the source of truth
+that the crosswalk and the real tokens agree.
+
+## Step 4 — Generate the reverse index
+
+Run `npm run tokens:reverse-index`. This writes `crosswalk.reverse.json`
+(`codeToken → newToken`), which the code-retrofit phase uses to semi-automate the
+SCSS/Tailwind swaps. If it reports conflicts (one old symbol mapping to two new
+tokens), resolve them in the crosswalk before relying on the index.
+
+## Step 5 — Update the manifest
+
+Write the `tokenCrosswalk` section **only** (this skill owns it; never write another
+skill's fields):
+
+- `path` — the actual path written (`"packages/tokens/crosswalk.json"`).
+- `statusCounts` — copy the camelCase object the validator printed
+  (`{ aligned, renamed, driftFix, added, mappedNearest }`).
+- `validatorPassing` — `true` once `tokens:validate` passes N/N.
+
+Append `token-crosswalk-builder` to `completedSkills`.
+
+## What this skill must NOT do
+
+- Never delete old tokens or outputs here — that's the cleanup phase, gated by the
+  token-removal guard returning zero references (safe sequence, guardrail 4).
+- Never edit generated token files to make the validator pass — fix the source.
+- Never write another skill's manifest fields (e.g. `tokens.intakeMode` is owned by
+  `design-system-audit`).
+- Never proceed past a red `tokens:validate`.
+- Never assert a prerequisite is absent without a verified read (read discipline).

--- a/skills/token-sync-layer/SKILL.md
+++ b/skills/token-sync-layer/SKILL.md
@@ -108,6 +108,33 @@ This DTCG JSON is the canonical intermediate. Write it to a known location in
 MCP's built-in CSS/Tailwind exporters for final output — route through Style
 Dictionary so the adapter system governs the result.
 
+### Brownfield transforms (learned the hard way)
+
+On a **retrofit** (`tokens.intakeMode: "retrofit"`), apply these transforms in
+addition to the opacity normalization above. Each cost real debugging time on a live
+retrofit — see the guardrails in
+`${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md`.
+
+- **Alpha as channels, not baked CSS vars (so Tailwind `/opacity` survives).** Emit
+  colors as space-separated channels with a slash-alpha slot —
+  `--color-x: 239 68 68;` consumed as `rgb(var(--color-x) / <alpha-value>)` — rather
+  than a finished `rgba(...)`. A baked `rgba()` can't accept Tailwind's `/opacity`
+  modifier; the channel form keeps `bg-x/50` working after the retrofit.
+- **`/opacity` on var-based tokens → `color-mix` or channel alpha (guardrail 6).**
+  Where existing code applies a `/opacity` modifier to a token that is now a CSS var,
+  you can't fold the alpha into the var. Convert to
+  `color-mix(in srgb, var(--color-x) NN%, transparent)` (or the channel-alpha form
+  above). Never carry a raw `/opacity` onto a var-based token.
+- **Round float32 noise at the export boundary (guardrail 2).** Figma stores values as
+  float32 and re-quantizes on write, so normalizing *inside* Figma is a no-op. Round at
+  the **export boundary** instead — `Math.round(v * 100) / 100` as values leave the
+  pipeline — so `0.30000001192092896` lands as `0.3` in the generated files. Do this in
+  the extraction/transform step, never by hand-editing the generated output (guardrail 7).
+
+These are transforms on the *values* the adapters emit; the adapter presets themselves
+are unchanged. See `${CLAUDE_PLUGIN_ROOT}/references/sync-adapters.md` for where they
+fit in the adapter output.
+
 ## Step 3 — Set up Style Dictionary + adapters
 
 Install and configure Style Dictionary v4 in `packages/tokens/`. For each chosen
@@ -201,3 +228,9 @@ source-of-truth model. Confirm the command works by describing how to invoke it.
 - Never write token files silently — always a reviewable PR/diff.
 - Never merge or push to a protected branch on the user's behalf without review.
 - Never skip rename detection — a silent rename is the worst failure mode.
+- Never bake alpha into finished `rgba(...)` on a retrofit — emit channels
+  (`rgb(var(--x) / <alpha-value>)`) so Tailwind `/opacity` modifiers survive.
+- Never carry a `/opacity` modifier onto a var-based token — convert to `color-mix`
+  or channel alpha (guardrail 6).
+- Never normalize float32 inside Figma (it re-quantizes) — round at the export
+  boundary (`Math.round(v*100)/100`, guardrail 2).


### PR DESCRIPTION
## Summary

The full **brownfield design-system retrofit** capability for the ThroughLine plugin — equipping it to retrofit a mature codebase *and* an already-populated Figma file onto a two-tier token system, as elegantly as it handles greenfield today. Drawn from a production Next.js retrofit case study (`docs/brownfield-retrofit-learnings.md`) and four bugs (B1–B4) that share one root cause: **the plugin asserted state without a verified read.**

This was a **3-plan effort, accumulated on this single PR** — each plan landed as a batch of commits and was added to this description as it merged in. **All three plans are now present; the effort is complete.** A **plugin-CI follow-on** (see below) closes the last cross-cutting carry-forward.

### Design docs
- `docs/superpowers/specs/2026-06-25-brownfield-retrofit-design.md` — approved design for the full effort (§10 bug status, §11 per-plan carry-forward risks).
- `docs/superpowers/plans/2026-06-25-brownfield-foundation.md` — Plan 1.
- `docs/superpowers/plans/2026-06-25-brownfield-crosswalk.md` — Plan 2.
- `docs/superpowers/plans/2026-06-26-brownfield-skills.md` — Plan 3.
- `docs/superpowers/specs/2026-06-27-plugin-ci-design.md` + `docs/superpowers/plans/2026-06-27-plugin-ci.md` — Plugin CI follow-on.

---

## Plan 1 — Foundation ✅

Cross-cutting groundwork + B1–B4 read-discipline hardening. Additive and scope-narrowing — no greenfield behavior changes.

- **Manifest → schemaVersion 4** (`references/manifest-schema.md`): new `audit`, `tokenCrosswalk`, `retrofit` sections; `"retrofit"` intake mode; clarified publish-state field docs. Migrate-forward rule already covers it.
- **New canonical reference** (`references/brownfield-retrofit.md`): read-discipline principle (B1–B4), 7 DON'T guardrails, safe retrofit sequence, verification triad.
- **Bridge-port + read discipline** (`references/figma-scripting.md`): block only on ≥2 *confirmed-live* bridge instances instead of hard-blocking on phantom/stale ports (B4); new "never report empty without a verified read" section (B1/B2).
- **Env-setup liveness** (`skills/figma-environment-setup/SKILL.md`): Step 6 probe proves *connectivity only* and never reports an inventory from a cheap/early read (B1/B2).

---

## Plan 2 — Crosswalk scripts + builder skill ✅

The crosswalk backbone, and the plugin's **first executable code**.

- **Crosswalk contract** (finalized first, per spec §11): `references/crosswalk-schema.md` (prose) + `scripts/crosswalk.schema.json` (JSON Schema).
- **Three canonical zero-dependency Node (ESM) scripts**, all TDD'd:
  - `scripts/lib/crosswalk.mjs` — shared loader + structural validation (enforces `version`, enums, rejects unknown keys).
  - `scripts/validate-crosswalk.mjs` — the `tokens:validate` N/N resolved-value gate (resolves DTCG alias chains, compares against `newValue`).
  - `scripts/build-reverse-index.mjs` — code symbol → new token map for semi-automated SCSS/Tailwind swaps.
  - `scripts/guard-token-removal.mjs` — repo-wide zero-reference grep that blocks cleanup while any reference to an about-to-be-deleted symbol remains (guardrail 4).
  - Plus `scripts/README.md` (install contract + test command).
- **`token-crosswalk-builder` skill** — builds `crosswalk.json`, installs the vetted scripts into the user's `packages/tokens/`, wires `tokens:validate`, and owns the `tokenCrosswalk` manifest section.

---

## Plan 3 — Audit + retrofit-planner skills, brownfield branches ✅

The brownfield path, wired end-to-end. Closes every Plan-3 carry-forward risk in spec §11. Additive — greenfield paths in the four modified skills are untouched (0 deletions each; the only replacements are the B3 fix in `component-builder`).

- **`design-system-audit` skill** (`skills/design-system-audit/SKILL.md`) — the brownfield front door: sizes the code-side color surface (via the new grep), inventories the Figma file with verified per-class reads, computes `percentSemantic`, owns the `audit` section and sets `tokens.intakeMode: "retrofit"`.
- **`retrofit-planner` skill** (`skills/retrofit-planner/SKILL.md`) — the orchestrator (mirrors `component-pipeline`): sequences the safe 7-phase retrofit (audit → refine → rebind → sync → baseline → code → cleanup → done) with a human gate per phase, offers a decision journal default-on, owns the `retrofit` section.
- **Color-usage grep scaffold** (`scripts/grep-color-usage.mjs` + test, TDD) — the deferred-from-Plan-2 surface sizer; ships default patterns and logs assumed-vs-detected coverage.
- **Binding-survival audit snippet** (`references/figma-scripting.md`) — counts variable bindings before/after a rename (the deferred-from-Plan-2 Figma-side snippet).
- **Brownfield branches in existing skills:**
  - `figma-environment-setup` — brownfield detection + routing to the audit, retrofit resume on `retrofit.phase`, pre-mutation rollback baseline.
  - `token-builder` — refine-in-place (rename preserving IDs, binding-survival audit; never delete-and-recreate, guardrail 3).
  - `token-sync-layer` + `references/sync-adapters.md` — brownfield transforms (channel alpha, float32 rounding at the export boundary, `/opacity`→`color-mix`).
  - `storybook-chromatic-builder` — baseline-before-retrofit + the verification triad.
- **Command surfacing** — `/design-system-status` reports `audit` / `tokenCrosswalk` / `retrofit`; `/start` routing note for brownfield/in-progress systems.

---

## Plugin CI — follow-on ✅

The repository's **first GitHub Actions workflow**, closing the "no plugin CI" carry-forward from spec §11. Zero runtime dependencies (Node stdlib only, no `package.json`, no install step).

- **`.github/workflows/ci.yml`** — runs on every pull request and on pushes to `main` (Node 20): the full `node --test` suite plus two structural validators.
- **`ci/lib/frontmatter.mjs`** — a minimal, fail-loud frontmatter parser (only strips fully-wrapped quotes; throws on a malformed fence rather than silently mis-parsing).
- **`ci/validate-plugin.mjs`** — `.claude-plugin/plugin.json` + `marketplace.json`: valid JSON, required fields, semver version, and that a marketplace entry's `name` matches `plugin.json` (guards non-object plugin entries).
- **`ci/validate-skills.mjs`** — every `skills/*/SKILL.md` has a `name` matching its directory and a ≤1024-char `description`; every `commands/*.md` has a `description`; the `references/manifest-schema.md` example JSON parses with an integer `schemaVersion`.
- **`ci/README.md`** — documents the validators and notes these are plugin-internal (NOT copied into user repos, unlike `scripts/`).
- All TDD'd: **+27 tests** (27 new in `ci/` on top of the 43 in `scripts/`) → **70 tests, 70 pass** via bare `node --test`.

---

## Bug status (B1–B4)
- **B1** (false "0 variables") — **mitigated + enforced**: liveness reports connectivity only; full per-class inventory now enforced in `design-system-audit` (Plan 3). Root cause may still be MCP-side (unverified against a real file).
- **B2** (assumed "no text styles") — **mitigated + enforced**: per-class independent reads enforced in `design-system-audit` (Plan 3).
- **B3** (silently "not published") — **✅ fixed**: the behavioral detect-or-ask change landed in `component-builder` + `references/figma-publishing.md` (Plan 3) — detect via `figma_get_library_components`/`figma_get_library_variables`, ask once if inconclusive, persist, frame the unpublished path gracefully. No new manifest field.
- **B4** (phantom stale bridge ports) — **mitigated, pending verification**: distinguishes live vs. stale; real-world reaping depends on MCP behavior.

## Carry-forward (tracked)
Per spec §11 cross-cutting notes: the B1/B2/B4 fixes remain **unverified against a real system** (case-study-authored, not reproduced) — this is the one remaining carry-forward.

The **plugin CI** carry-forward is now **✅ addressed** (see the Plugin CI section above): SKILL.md frontmatter, `plugin.json`/`marketplace.json`, and the manifest-doc example are validated on every PR.

## Test Plan
- [x] **Full suite:** `node --test` (from repo root) → **70 tests, 70 pass, 0 fail** (43 in `scripts/` + 27 in `ci/`; zero deps, no install step). Run as bare `node --test`; `node --test <dir>/` errors on Node ≥21.
- [x] **Plugin CI validators** pass against the real repo: `node ci/validate-plugin.mjs` → `✓ plugin.json + marketplace.json OK`; `node ci/validate-skills.mjs` → `✓ 12 skills, 4 commands, manifest doc OK`.
- [x] `scripts/crosswalk.schema.json` parses as valid JSON; manifest JSON block parses and reports `schemaVersion = 4`.
- [x] New SKILL.md frontmatter `name:` matches its directory (`design-system-audit`, `retrofit-planner`) — now enforced by CI for all skills.
- [x] **Cross-file consistency (whole-effort review):** manifest field names (`audit.*` / `tokenCrosswalk.*` / `retrofit.*` / `tokens.intakeMode` / `figma.*`), skill identifiers, the `retrofit.phase` enum, and guardrail numbers are identical everywhere and match `references/manifest-schema.md`. All `${CLAUDE_PLUGIN_ROOT}/...` cross-references resolve. Ownership boundaries honored (no skill writes another's fields).
- [x] Greenfield paths untouched in the four branched skills (additions only; the only replacements are the B3 fix).
- [x] Per-task spec + quality reviews and a holistic cross-file final review passed for all three plans and the CI follow-on.
- [ ] **Not yet:** reproduce B1/B2/B4 against a real populated Figma file + multi-port scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
