### PR TITLE
release: v0.10.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "throughline",
   "description": "ThroughLine — build a complete design system end to end. Author tokens, styles, icons, and components in Figma, then stand up a monorepo, sync tokens to framework-specific code via Style Dictionary, and generate Storybook stories with Chromatic. One unbroken line from design to code. Built for designers becoming developers; explanation scales to your comfort level.",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "author": {
     "name": "Jordan Pease"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-06-28
+
 ### Added
 - **Brownfield retrofit foundation (Plan 1 of 3).** Groundwork for retrofitting a
   design system onto a mature codebase *and* an already-populated Figma file,
@@ -455,7 +457,8 @@ components → Storybook on a pnpm + Turborepo + Next.js 16 + Tailwind v4 monore
 - Reference docs for coding level, manifest schema, sync adapters, Figma
   component standards, and brainstorm-before-build.
 
-[Unreleased]: https://github.com/jrpease/throughline/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/jrpease/throughline/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/jrpease/throughline/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/jrpease/throughline/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/jrpease/throughline/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/jrpease/throughline/compare/v0.6.0...v0.7.0

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **A Claude Code plugin packed with every skill you need to launch and manage a production-grade design system in hours — not months.**
 
-[![Version](https://img.shields.io/badge/version-0.9.0-6366f1)](.claude-plugin/plugin.json)
+[![Version](https://img.shields.io/badge/version-0.10.0-6366f1)](.claude-plugin/plugin.json)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Built for Claude Code](https://img.shields.io/badge/built%20for-Claude%20Code-d97757)](https://docs.claude.com/en/docs/claude-code)
 [![See it live — Storybook](https://img.shields.io/badge/See%20it%20live-Storybook-FF4785?logo=storybook&logoColor=white)](https://main--6a1ee089ae3a37b70a6e4559.chromatic.com)


### PR DESCRIPTION
Cuts **v0.10.0** now that the brownfield retrofit effort + plugin CI are on `main`.

## Changes
- Bump `.claude-plugin/plugin.json` `0.9.0` → `0.10.0`
- Roll `CHANGELOG.md` `[Unreleased]` into `## [0.10.0] - 2026-06-28` (+ compare links)
- README version badge `0.9.0` → `0.10.0`

## What's in this version (additive, no breaking changes)
- **Brownfield retrofit (Plans 1–3):** `design-system-audit`, `retrofit-planner`, `token-crosswalk-builder` skills; brownfield branches in token/sync/storybook skills; the B3 detect-or-ask publish fix.
- **Plugin CI:** the repo's first GitHub Actions workflow + zero-dep validators (`ci/`).
- **README:** surfaces the retrofit path; counts updated to 12 skills / 10 reference docs.

## Test Plan
- [x] `node --test` → 70 tests, 70 pass
- [x] `node ci/validate-plugin.mjs` + `node ci/validate-skills.mjs` → both green
- [x] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)