### PR TITLE
fix(figma): library-derived focus states + build-hardening from session report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Added
+- **Library-derived focus states.** Focus is now built to match `project.uiFramework`'s
+  real `:focus-visible` idiom (shadcn/default `0 0 0 3px` spread-shadow ring, `vanilla-css`
+  outline stroke, MUI per-component, ios-swift skip, tier-2 researched) instead of one
+  house-style stroke — see the per-library recipe in `figma-component-standards.md`
+  "State handling". The ring's *mechanism* is chosen by control fill: a drop-shadow effect
+  for filled controls, an absolutely-positioned ring **child** for transparent ones
+  (a Figma drop-shadow only casts from opaque pixels).
+- **Tabler and Phosphor promoted to first-class icon libraries** in `icon-system-builder`,
+  built by the same official-SVG-fetch mechanism as Lucide; `icons.library` enum extended
+  (`manifest-schema.md`).
+
+### Changed
+- **Focus rings no longer use a padded wrapper or a house-style offset stroke by default.**
+  Wrapping the control to make room for the ring is now forbidden (it inflated component
+  bounds); `offset/focus` is used only by the outline-style (`vanilla-css`) recipe.
+- **Large variant matrices use deterministic grid coordinates**, not `minWidth`/fixed
+  widths (which leak to instances) or `layoutMode="GRID"` (unreliable through the bridge);
+  the auto-layout audit item exempts coordinate-laid component sets.
+- **Self-publish detection reframed** (`figma-publishing.md`): neither REST nor bridge
+  reads can confirm a file's own publish, so the flow trusts the user's confirmation and
+  treats an `INSTANCE_SWAP` key rejection as the authoritative "not published" signal.
+
+### Fixed
+- **Figma scripting gotchas documented** in `references/figma-scripting.md`:
+  `setBoundVariableForEffect` silently resets `spread`/`radius`/`offset` (re-assert after
+  binding); drop-shadows cast only from opaque pixels; text style must be applied before
+  `.characters` (Inter font-load order); `resize()` axis mapping is inverted on VERTICAL
+  frames; `refreshCache: true` is required on read-after-write; seed bound paints with a
+  sensible placeholder and read the bind back; `figma_execute` is capped ~30s regardless
+  of the `timeout` arg, so large builds must be chunked.
+- **Doc-card component area must contrast every variant fill** (a shared surface token hid
+  same-fill variants); container/component-set fills get a bind read-back in the audit.
+- **Architectural rebuilds of a published/consumed component set** now warn that
+  delete-and-recreate detaches downstream instances, requiring re-instancing.
+
 ## [0.10.0] - 2026-06-28
 
 ### Added

--- a/docs/superpowers/specs/2026-07-02-figma-build-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-02-figma-build-hardening-design.md
@@ -1,0 +1,99 @@
+# Figma Build Hardening + Library-Derived Focus States — Design
+
+**Date:** 2026-07-02
+**Status:** Approved design → ready for implementation
+**Scope:** Documentation/instruction changes only (reference docs + skills). No token-builder, code-gen, or runtime code changes.
+
+## Context
+
+A greenfield run of `figma-environment-setup → token-builder → token-sheet-builder → icon-system-builder → component-builder` shipped a working system but exposed skill/reference gaps that forced rework or produced user-visible wrongness. Those gaps are catalogued in `~/Dev/throughline-brand/throughline-plugin-issues.md` (15 items, A1–A6 / B1–B5 / C1 / D1–D3).
+
+Separately, we reframed how focus states should be built: the plugin was prescribing one house-style focus stroke, ignoring that each component library (`project.uiFramework`) has its own real focus-visible idiom. The report's A2 and B1 are the concrete mechanics of that reframe, so the two efforts merge into one hardening pass.
+
+This spec supersedes the interim edits made earlier this session (which added a flat `strokeAlign="OUTSIDE"` focus-stroke rule + checklist item #9 to `figma-component-standards.md` and `component-builder/SKILL.md`). Those get rewritten by the focus-redesign section below.
+
+## Part 1 — Library-derived focus states (design decisions)
+
+**Decisions locked during brainstorming:**
+
+1. **Scope: Figma build only.** Focus tokens (`border/focus`, `width/focus`, `offset/focus`) and the code-gen side stay untouched. Only the component-*construction* rules change.
+2. **Derive the focus idiom from `project.uiFramework`** (already read in `component-builder` for variant vocab, so recipe selection is free).
+3. **Default (null / multi-framework / unknown): the shadcn-style ring** — a `0 0 0 3px` spread ring at ~50% opacity, border recolored to the ring color. This is the dominant modern pattern (shadcn and MUI both implement focus as a box-shadow spread ring).
+
+**Two independent axes determine how the ring is built in Figma:**
+
+- **Idiom (by `uiFramework`)** — the *look*: spread/opacity/border-recolor values and per-component behavior.
+- **Shape (by control fill, per report A2)** — the *mechanism*: a Figma `DROP_SHADOW` only casts from opaque pixels, so:
+  - **Filled control** → drop-shadow effect (no extra node).
+  - **Transparent control** (ghost/outline/link, unfilled input) → an **absolutely-positioned ring child** (`RECTANGLE`, `layoutPositioning='ABSOLUTE'`, `strokeAlign='OUTSIDE'`, stroke weight = ring width, size = parent, constraints `STRETCH`), never a wrapper.
+
+Both mechanisms map to the same `box-shadow: 0 0 0 3px var(--ring)` in code.
+
+**Per-library recipe table** (new, in `figma-component-standards.md`, parallel to the existing variant-vocab table):
+
+| Library | Focus idiom |
+|---|---|
+| shadcn / tailwind / default / null / multi | Border → `border/focus` + `0 0 0 3px` ring @ ~50% (`width/focus` spread, `border/focus` color). Shape per fill (A2). |
+| mui | Per-component: inputs thicken+recolor border (`width/focus`/`border/focus`); buttons/clickables get a `0 0 0 N` ring. Ripple omitted. |
+| vanilla-css | Outside-aligned offset **stroke** via `offset/focus` + `strokeAlign="OUTSIDE"` (maps to real `outline`/`outline-offset`). |
+| ios-swift | No web focus ring — skip (native focus). |
+| tier-2 / other | Research that library's `:focus-visible` idiom; default to the shadcn ring if unknown. |
+
+**Wrapper is forbidden (report B1).** Never wrap the control in a padded frame to make room for the ring, and never reserve padding on non-focus states. The ring is an effect or a stroke-child *on the control*, so component bounds stay flush with the visual control.
+
+**clipsContent (reconciles with existing lines 47/403/411):**
+- Shadow branch: the **control frame carrying the drop-shadow effect** must have `clipsContent = true` (clean silhouette → crisp ring); a frame's own effect isn't clipped by its own clip.
+- All **ancestor** frames (doc card, variant row, component set) stay `clipsContent = false` so the ring isn't sliced.
+- Ring-child branch: parent `clipsContent = false` (the child stroke overflows).
+
+## Part 2 — Report items, mapped to target files
+
+Each item is documented exactly as the report specifies (symptom → root cause → fix). IDs match `throughline-plugin-issues.md`.
+
+### `references/figma-scripting.md`
+- **A1 🔴** `setBoundVariableForEffect` resets `spread`/`radius`/`offset` to 0 → re-assert geometry after binding, then assign. Include the canonical snippet.
+- **A2 🔴** (rendering rule) drop-shadow casts only from opaque alpha; transparent frames need the ring-child; `clipsContent` doesn't change casting. (The *pattern* also lands in component-standards — see Part 1.)
+- **A3 🟠** `createText()` starts as Inter Regular; call `setTextStyleIdAsync` **before** writing `.characters`. Canonical helper order.
+- **A4 🟠** `resize()` axis mapping: for VERTICAL auto-layout, `primaryAxisSizingMode`=height, `counterAxisSizingMode`=width (inverted vs HORIZONTAL). Prefer `layoutSizingHorizontal/Vertical`; add worked example.
+- **A5 🟡** read-after-write: pass `refreshCache: true` on the verifying read after any variable/style write in-session. Add to read-discipline.
+- **A6 🟡** use a sensible placeholder color (approx token value, not pure black) so a late/failed paint bind degrades gracefully; read back `fills[0].boundVariables.color` for container fills in the audit.
+- **D1 🟡** `figma_execute` is effectively capped ~30s regardless of `timeout` arg → design large builds to chunk (e.g. 108 variants in 3×36).
+
+### `references/figma-component-standards.md`
+- **B1 🔴** rewrite the "Focus rings need an offset gap" bullet: forbid the padded wrapper; use the A2 hybrid + the Part 1 recipe table. Fold in / scope down the interim `strokeAlign` edit and rewrite checklist item #9 to "Focus state matches library idiom" (shadow branch: effect present + control frame clipped; ring-child branch: absolute stroke child; vanilla-css: outside stroke).
+- **B2 🔴** never use `minWidth`/fixed width on variants for showcase alignment (it's an intrinsic prop that ships to instances). Use deterministic grid coordinates (`layoutMode='NONE'` on the set, position each variant in a uniform cell centered on its hugged size). ("Component set arrangement.")
+- **B3 🟠** `layoutMode='GRID'` is unreliable through the bridge → deterministic coordinates for matrices > ~1 row. Note `figma_arrange_component_set` recreates the set in its own container — don't use it when the set already lives in a hand-built doc card.
+- **B4 🟠** doc-card component area must use a surface that contrasts with **all** variant fills (default `bg/default`); never the same token as any variant's resting fill. ("Documentation artboards & canvas layout.")
+- **B5 🟠** reconcile audit item #2: exempt a component **set** laid out with deterministic coordinates from the auto-layout requirement (variants themselves still must be auto-layout).
+- **A6 audit hook** — add the container-fill read-back to the post-build audit (shared with the scripting note).
+
+### `references/figma-publishing.md`
+- **C1 🟠** self-publish is not verifiable via `figma_get_library_components` (REST, needs `FIGMA_ACCESS_TOKEN` + `file_content:read`) or `figma_get_library_variables` (bridge, lists only subscribed external libs). Document: attempt detection (expect inconclusive) → trust user confirmation → proceed; treat a later `INSTANCE_SWAP` key rejection as the real re-check signal. Mirror a one-liner in the `component-builder` "Resolve publish state first" note.
+
+### `skills/icon-system-builder/SKILL.md`
+- **D2 🟡** promote **Tabler** (and **Phosphor**) to first-class libraries alongside Lucide/Material/custom. The Tabler path (deterministic SVG fetch + `createNodeFromSvg` + `createComponentFromNode`, vector strokes bound to `text/primary`) is proven; brand systems frequently specify Tabler/Phosphor.
+
+### `skills/component-builder/SKILL.md`
+- Focus build-step + never-list point at the per-library recipe keyed off `uiFramework`, the A2 hybrid, forbid-wrapper (B1), and the clip-on-control-frame note.
+- **D3 🟡** warn that architectural rebuilds of a published/consumed set **detach** downstream instances; require re-instancing and recording which components consume which.
+- Mirror the C1 publish note.
+
+## Files touched (summary)
+
+1. `references/figma-scripting.md` — A1, A2 (rule), A3, A4, A5, A6, D1
+2. `references/figma-component-standards.md` — focus recipe (Part 1), B1, B2, B3, B4, B5, A6 audit
+3. `references/figma-publishing.md` — C1
+4. `skills/icon-system-builder/SKILL.md` — D2
+5. `skills/component-builder/SKILL.md` — focus recipe pointers, D3, C1 mirror
+
+## Out of scope
+
+- `token-builder` and the focus token trio (unchanged).
+- Any code-generation / sync-adapter focus emission.
+- The transient A6 root cause itself (only its graceful-degradation + audit guidance is documented).
+
+## Verification
+
+- Each edited reference reads cleanly and its internal cross-references (checklist counts, section names) stay consistent.
+- The focus section, B1, and the clipsContent rules (lines 47/403/411) no longer contradict each other.
+- A structural pass (existing CI validators) still passes.

--- a/references/figma-component-standards.md
+++ b/references/figma-component-standards.md
@@ -29,10 +29,13 @@ a component read as polished:
 - **Outer strokes / borders.** A child with `strokeAlign = "OUTSIDE"` (or a flush-to-
   edge border) gets the outer half of its stroke sliced away — borders look thin,
   uneven, or missing on one side.
-- **Focus rings.** The focus indicator deliberately sits **2px clear of the control's
-  edge** (see *State handling* — the `offset/focus` rule), so it extends *beyond* the
-  control frame by design. A clipping parent eats it, defeating the focus-visibility
-  requirement.
+- **Focus rings.** A focus ring extends *beyond* the control's edge by design (see
+  *State handling*), so a clipping **ancestor** eats it — keep the doc card, variant
+  rows, and component set unclipped. One deliberate exception: a *filled* control that
+  casts its focus ring as a **drop-shadow effect** must have `clipsContent = true` on
+  that control frame itself — a frame's own effect isn't clipped by its own clip, and
+  clipping gives it a clean ring silhouette. The no-clip rule is about *ancestors*, not
+  that control frame.
 - **Shadows / elevation.** Drop shadows on a child near the edge get cut at the frame
   boundary instead of feathering out.
 
@@ -43,8 +46,11 @@ set it, and read it back.
 **Turn clipping ON only for a deliberate cutoff** — a frame whose *job* is to crop its
 contents to a fixed window: a scroll container, an image/media crop frame, an
 avatar/thumbnail masked to its bounds, or anything emulating CSS `overflow: hidden`.
-These are the viewport-level cases; everywhere else, leave content unclipped so strokes,
-focus rings, and shadows render in full.
+The one other legitimate ON case is a **filled control frame that casts its focus ring
+as a drop-shadow effect** — clip ON gives that ring a clean silhouette (see *State
+handling*), and clipping the frame's *children* doesn't clip the frame's own effect.
+Everywhere else, leave content unclipped so strokes, focus rings, and shadows render in
+full.
 
 ## Variants vs. component properties — use the right tool
 
@@ -90,12 +96,25 @@ as a readable grid so it's scannable in Figma and predictable run-to-run:
   with only `default`. Every component renders its complete, applicable state set
   across the columns (see "State handling" for the per-component checklist), so the
   set documents the real interaction surface, not a single resting state.
-- **Build it with auto layout, bound to spacing tokens.** Set the component set's
-  `layoutMode` (a vertical outer auto layout of horizontal rows, or a wrapped
-  layout) with `itemSpacing`/padding bound to `Spacing/*` tokens — never a flat
-  `layoutMode = "NONE"` with absolute positions. The `figma_arrange_component_set`
-  helper can do the row/column placement; verify the result is genuinely
-  auto-layout (read back `layoutMode`), not just visually tidy coordinates.
+- **Small sets — build with auto layout, bound to spacing tokens.** For a handful of
+  variants, set the component set's `layoutMode` (a vertical outer auto layout of
+  horizontal rows) with `itemSpacing`/padding bound to `Spacing/*` tokens. Verify the
+  result is genuinely auto-layout (read back `layoutMode`), not just tidy coordinates.
+- **Large matrices — use deterministic grid coordinates, not layout hacks.** For big
+  sets (many variants, more than ~1 row), lay the showcase out by positioning each
+  variant into a uniform grid cell **centered on its hugged size**, with
+  `layoutMode = "NONE"` on the set. This keeps every variant hugging/flush while the
+  grid stays aligned. Specifically:
+  - **Never set `minWidth` or a fixed width on variants to line up columns.** Width is
+    an **intrinsic component property** — it ships to every instance, so the visual
+    control ends up floating inside a wider component (and stretches any focus ring).
+    Alignment is a *display* concern; solve it with cell coordinates, not variant width.
+  - **Don't rely on `layoutMode = "GRID"`.** CSS-grid auto layout does not lay out
+    reliably through the plugin bridge today — it reads back correct but renders as a
+    single squished row. Use explicit coordinates for matrices larger than ~1 row.
+  - **Don't use `figma_arrange_component_set` on a set already inside a doc card** — it
+    **recreates the set inside its own labeled white container**, detaching it from a
+    hand-built card. Use it only for a standalone set you haven't yet placed.
 
 This ordering is deterministic: given the same matrix, the set looks the same every
 run, and it mirrors how the states/types map to code props.
@@ -124,15 +143,55 @@ run, and it mirrors how the states/types map to code props.
   reach; only omit a state when the component genuinely cannot enter it.
 - Keep state styling bound to tokens (a disabled state uses
   `color.text.disabled`, not a hardcoded gray) so it themes correctly.
-- **Focus rings need an offset gap.** The focus indicator (the focus ring/outline)
-  must sit **2px clear of the control's edge**, not flush against it — the code
-  equivalent of `outline-offset`. A ring drawn flush blends into the control's own
-  border and reads as a thicker border rather than a distinct focus state, hurting
-  the focus visibility WCAG asks for (2.4.11 / 2.4.13). Implement the offset with
-  the **`Border/Semantic` `offset/focus`** token (bound, never a hardcoded `2px`) —
-  e.g. an outer focus-ring layer inset by that token, or auto-layout padding of
-  `offset/focus` between the control and its ring. Keep the ring color bound to
-  `border/focus` and its width to `width/focus`.
+- **Focus states are derived from the target library, not a house style.** Do not
+  invent a custom focus ring. Build the focus state to match `project.uiFramework`'s
+  real `:focus-visible` idiom (the same value `component-builder` already reads for
+  variant vocabulary), keeping the ring color bound to `border/focus` and its width to
+  `width/focus`:
+  - **shadcn / tailwind / default / null / multi-framework** — the modern ring:
+    recolor the control's border to `border/focus` **plus** a `0 0 0 3px`-equivalent
+    ring at ~50% opacity (spread bound to `width/focus`). This is the default whenever
+    no single library is set.
+  - **mui** — per component: inputs thicken + recolor their border to `width/focus` /
+    `border/focus`; buttons and other clickables get a `0 0 0 N` ring. (The ripple
+    isn't represented in Figma.)
+  - **vanilla-css** — an offset **outline stroke**: a ring layer with
+    `strokeAlign = "OUTSIDE"` sitting `offset/focus` clear of the edge (maps to real
+    `outline` / `outline-offset`, satisfying WCAG 2.4.11 / 2.4.13). This is the **only**
+    recipe that uses `offset/focus`; `strokeAlign = "INSIDE"` here grows the stroke
+    inward, eats the gap, and is a fail.
+  - **ios-swift** — no web focus ring; skip (native focus handling).
+  - **tier-2 / other framework** — research that library's focus-visible idiom and
+    replicate it (shadow vs. outline vs. border); fall back to the shadcn ring if
+    unknown.
+- **How you build the ring depends on the control's fill, because a Figma
+  `DROP_SHADOW` only casts from opaque pixels** (unlike CSS `box-shadow`, which draws
+  from the border-box). For the shadow-based recipes:
+  - **Filled control** (has an opaque fill) → a **drop-shadow effect** on the control
+    (offset 0, blur 0, spread = ring width, color = `border/focus`). No extra node. The
+    control frame carrying the effect must have **`clipsContent = true`** so it casts a
+    clean rectangular ring (a frame's own effect isn't clipped by its own clip); its
+    **ancestor** frames stay `clipsContent = false` so the ring isn't sliced.
+  - **Transparent control** (outline / ghost / link, unfilled input — no opaque fill to
+    cast from) → an **absolutely-positioned ring child**: a `RECTANGLE` with
+    `layoutPositioning = "ABSOLUTE"`, `strokeAlign = "OUTSIDE"`, stroke weight = ring
+    width, sized to the parent with `STRETCH` constraints, parent `clipsContent =
+    false`. A **child, never a wrapper** — so it doesn't inflate layout and coexists
+    with any existing border. `clipsContent` does **not** make a transparent frame cast
+    a drop-shadow; use the ring-child instead.
+  Both mechanisms map to the same `box-shadow: 0 0 0 3px var(--ring)` in code.
+- **Never wrap the control to make room for the ring.** Do not add a parent frame with
+  `offset/focus` padding around the control, and do not reserve ring padding on
+  non-focus states — a wrapper makes the component bounds larger than the visual
+  control on every variant (the control floats inside an oversized frame). The ring is
+  an effect or a stroke **child** on the control itself; component bounds stay flush.
+- **Retrofitting a previously-built focus state.** Earlier builds used a house-style
+  **inside/outside offset stroke** or a **padded wrapper** for focus. Whenever you
+  rebuild or touch an existing component, migrate it to the recipe above: replace a
+  padded focus wrapper with an effect or ring-child on the control, replace an
+  inside-aligned stroke, and add the missing ring to any **transparent** variant that
+  has none (the shadow-based recipe silently skips transparent controls — see the
+  fill-based mechanism above). The old pattern is a fail in the post-build audit.
 
 ## Slots and nesting
 
@@ -230,6 +289,14 @@ Pick whichever reads better for the card's styling, but **one of them is require
 a doc card with no header/component division is a fail in the post-build audit.
 Whichever you choose, bind it to variables (border or surface tokens), never a
 hardcoded hex.
+
+**The component area's surface must contrast with every variant's fill.** Choose a
+doc-card component-area background that differs from **all** of the component's resting
+variant fills — default to `bg/default` — and never reuse a token that any variant
+fills with. If the area used `bg/subtle` while a `secondary` variant also fills
+`bg/subtle`, that variant renders invisible against the panel. This is a token-choice
+check, not a visual one: verify the area's token against the variant fills, since a
+low-contrast overlap can still look fine at a glance in the screenshot.
 
 ### Promoting a component's status (write-back on finalize)
 
@@ -388,10 +455,17 @@ For each generated artboard / doc card / icon grid, read the nodes back (via
    back `primaryAxisSizingMode`/`counterAxisSizingMode`** (or `layoutSizing*`): a
    `resize()` call silently flips the opposite axis to `FIXED`, collapsing a frame
    to ~10px — invisible in a screenshot. See the `resize()` trap in
-   `${CLAUDE_PLUGIN_ROOT}/references/figma-scripting.md`.
+   `${CLAUDE_PLUGIN_ROOT}/references/figma-scripting.md`. **Exception:** a component
+   **set** laid out with deterministic grid coordinates (the large-matrix case in
+   "Component set arrangement") legitimately uses `layoutMode = "NONE"`; the variants
+   *inside* it must still be auto-layout.
 3. **Variables bound** — every fill, stroke, text color, corner radius,
    `itemSpacing`, and padding resolves to a **bound variable** (`boundVariables`
    present), not a raw hex/px. No hardcoded values anywhere in the doc-card chrome.
+   **Check container and component-set background fills specifically** — a paint bind
+   that didn't stick renders the placeholder color instead (a pure-black placeholder
+   reads as accidental dark mode), so read back `fills[0].boundVariables.color` on
+   those container fills and re-bind any that resolve to a raw value.
 4. **Names deterministic** — components match their code counterpart names; the
    `Status` chip, `Status Label`, and `Last Updated` nodes are named exactly so
    finalize write-back can find them; no `Frame 47`-style auto names on meaningful
@@ -411,11 +485,22 @@ For each generated artboard / doc card / icon grid, read the nodes back (via
    state for that component (default/hover/focus/active/disabled plus the applicable
    conditional states — loading/selected/success/error), with variants (incl. each
    size) as rows and states as columns. A set shipping only `default` is a fail.
-9. **Visual** — the screenshot (from the validation loop) shows no overlaps,
+9. **Focus state matches the library idiom** — the focus state is built as
+   `project.uiFramework`'s real pattern (see "State handling"), not a house-style
+   stroke, and with no padded wrapper inflating the component. Shadow-based recipes: a
+   filled control carries a **drop-shadow** ring (effect present; that control frame
+   `clipsContent = true`), a transparent control carries an **absolutely-positioned
+   ring child** (not a wrapper). `vanilla-css`: an **outside-aligned** offset stroke
+   (`strokeAlign = "OUTSIDE"`; `"INSIDE"` is a fail). A wrapper frame that makes the
+   component bounds larger than the visual control is a fail. **This applies to
+   previously-built components too** — when you touch an existing one, a legacy padded
+   wrapper, an inside-aligned stroke, or a transparent variant with no ring at all must
+   be retrofitted to the current recipe (see "State handling").
+10. **Visual** — the screenshot (from the validation loop) shows no overlaps,
    misalignment, lopsided hug/fill sizing, or clipped strokes/focus rings.
 
 If any item fails, **fix and re-audit** — don't hand off a partial pass. Iterate
-with the same ~3-pass budget as the visual loop. Only when all nine pass is the
+with the same ~3-pass budget as the visual loop. Only when all ten pass is the
 build done.
 
 ## Naming

--- a/references/figma-publishing.md
+++ b/references/figma-publishing.md
@@ -42,20 +42,36 @@ not "definitely not published" (bug B3).** Apply the read discipline in
 `${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md`: never assert "unpublished"
 without a verified read.
 
-1. **Detect first.** Before asking anything, attempt to detect publish state by reading
-   for published library artifacts: `figma_get_library_components` /
-   `figma_get_library_variables` (and library component keys). If those resolve, the
-   file *is* published — record `figma.libraryPublished: true` (+ `publishedAt`) and skip
-   the question.
-2. **Ask once only if detection is inconclusive.** If the reads are empty or unreliable
-   (detection can't confirm either way), ask the user a single plain question — "Is this
-   file published to a team library?" — and, separately, if `figma.canPublish` is `null`:
-   "Are you on a paid Figma plan (Professional or higher)? Publishing a shared library —
-   which unlocks the nicer typed icon dropdowns — needs one." Record `true`/`false` for
-   each.
+1. **Attempt detection — but expect it to be inconclusive for a self-publish.** Try
+   reading for published library artifacts, but know that **neither available tool can
+   actually confirm the file published *itself*:**
+   - `figma_get_library_components` (REST) returns **`401/403 Invalid token`** unless a
+     `FIGMA_ACCESS_TOKEN` with `file_content:read` scope is configured for the REST path
+     — which it usually isn't in this setup.
+   - `figma_get_library_variables` (bridge) lists only libraries the file has
+     **subscribed to** (external), never the file's *own* publish — so it returns empty
+     for a self-publish even when the file is published.
+
+   So this step is real but usually **inconclusive**; only record
+   `figma.libraryPublished: true` if a read genuinely resolves the file's own published
+   artifacts. Do **not** treat the expected empty/error as "not published."
+2. **Trust the user's confirmation.** Because detection can't confirm a self-publish,
+   the flow falls through to asking — this is the *normal* path, not a failure of
+   detection. Ask a single plain question — "Is this file published to a team library?"
+   — and, separately, if `figma.canPublish` is `null`: "Are you on a paid Figma plan
+   (Professional or higher)? Publishing a shared library — which unlocks the nicer typed
+   icon dropdowns — needs one." Record `true`/`false` for each, and **proceed on the
+   user's answer**.
 3. **Persist.** Record `figma.libraryPublished` (+ `publishedAt`) and `figma.canPublish`.
-   Don't probe repeatedly; read the manifest and only re-detect/re-ask if state is
-   genuinely missing.
+   Don't probe repeatedly; read the manifest and only re-ask if state is genuinely
+   missing.
+
+**The real signal is a later `INSTANCE_SWAP` key rejection.** Since you can't verify a
+self-publish up front, treat the user's "yes, published" as good enough to proceed, and
+let the *bridge* be the ground truth: if adding a typed `INSTANCE_SWAP` with published
+keys is then **rejected** (local/unpublished key error), that's the authoritative
+"not actually published yet" — re-check with the user and fall back to the toggle +
+manual-swap slot. Don't block the build waiting for a confirmation the tools can't give.
 
 Frame the unpublished path as a **graceful choice**, never a failure — the toggle +
 manual-swap slot is fully functional.
@@ -79,10 +95,11 @@ them that's expected, don't make it feel like churn.
 
 For each slot that would be a typed `INSTANCE_SWAP`:
 
-1. **Resolve publish state via the capability check above** — detect first
-   (`figma_get_library_components` / `figma_get_library_variables`), ask once only if
-   inconclusive, then persist. A default/`false` `libraryPublished` is *unverified*
-   until this runs — never treat it as a final "no".
+1. **Resolve publish state via the capability check above** — attempt detection
+   (expect it to be inconclusive for a self-publish), trust the user's confirmation,
+   then persist. A default/`false` `libraryPublished` is *unverified* — never treat it
+   as a final "no". Don't wait on a confirmation the tools can't give; the real signal
+   is a typed-`INSTANCE_SWAP` key rejection at build time (below).
 2. **Confirmed published** (`libraryPublished` true after detect-or-ask, `canPublish`
    true): add the typed `INSTANCE_SWAP` dropdown with preferred values.
 3. **Confirmed not published** (free plan, or the user said not yet): build the

--- a/references/figma-scripting.md
+++ b/references/figma-scripting.md
@@ -57,6 +57,13 @@ after the file is fully loaded. Two real bugs came from violating this:
 An unexpectedly-empty result is a possible read error, not ground truth. See the
 full principle in `${CLAUDE_PLUGIN_ROOT}/references/brownfield-retrofit.md`.
 
+- **Read-after-write: pass `refreshCache: true` on the verifying read.** A specific
+  trigger of the false-empty class — immediately after a write in the same session,
+  `figma_get_variables` (and similar reads) can return a **stale cached empty** with an
+  old timestamp. Creating 25 semantic variables and reading them straight back returned
+  `variables: []`; the same read with `refreshCache: true` returned all 25. After **any**
+  variable/style write, pass `refreshCache: true` on the read that confirms it.
+
 ## `dynamic-page` mode: use the async APIs — reads **and** writes
 
 Synchronous document-wide getters *and several setters* throw under
@@ -77,6 +84,71 @@ setter throws mid-build is how partial writes happen. For a simple verification
 read, prefer the dedicated `figma_get_variables` tool (it handles `dynamic-page`
 correctly and resolves aliases with `resolveAliases: true`) over a hand-written
 script.
+
+## Set the text style *before* writing `.characters` (font-load order)
+
+`figma.createText()` starts every node as **Inter Regular** — so writing
+`.characters` first throws `Cannot write to node with unloaded font "Inter Regular"`
+even when you only loaded your brand fonts (e.g. Bricolage Grotesque + DM Mono).
+Applying the text style switches the node to a loaded family, so it must come **first**.
+This is the same call surface as the `setTextStyleIdAsync` (dynamic-page) note above —
+both bite in the same place.
+
+```js
+const t = figma.createText();
+await t.setTextStyleIdAsync(style.id);  // switches font to the loaded family FIRST
+t.characters = str;                     // now safe — no Inter load needed
+```
+
+## Binding an effect resets its geometry — re-assert `spread`/`radius`/`offset` after
+
+`figma.variables.setBoundVariableForEffect(effect, 'color', v)` returns a **new**
+effect object that drops every non-color field back to defaults — `spread → 0`,
+`radius → 0`, `offset → {0,0}`. A focus ring built as a drop-shadow (offset 0, blur 0,
+**spread 3**) therefore renders **invisible** after you bind its color: a read-back
+shows `spread: 0` even though the literal set `spread: 3`. Re-assert the geometry
+fields **after** binding, then assign:
+
+```js
+let eff = {type:'DROP_SHADOW', color:{r:0,g:0,b:0,a:1}, offset:{x:0,y:0}, radius:0, spread:3, visible:true, blendMode:'NORMAL'};
+eff = figma.variables.setBoundVariableForEffect(eff, 'color', ringVar);
+eff = {...eff, spread:3, radius:0, offset:{x:0,y:0}}; // REQUIRED — bind wiped these
+node.effects = [eff];
+```
+
+## A drop-shadow casts only from **opaque pixels** — transparent frames get no ring
+
+Unlike CSS `box-shadow` (which draws from the border-box), a Figma `DROP_SHADOW` is
+computed from the node's rendered **alpha**. A no-fill frame has nothing to cast, so a
+shadow-based focus ring (`0 0 0 3px`) shows on filled controls but is **completely
+absent** on transparent variants (outline / ghost / link). **`clipsContent` does NOT
+fix this** — it changes child clipping, not casting geometry (the commonly-cited
+"clip to make the shadow follow the radius" trick does nothing here). Verify by
+temporarily setting the ring to solid red: only filled frames will show it.
+
+**Pattern for a universal ring:**
+- **Filled control** → a drop-shadow effect (clean, no extra node).
+- **Transparent control** → an **absolutely-positioned ring child**: a `RECTANGLE`
+  with `layoutPositioning = "ABSOLUTE"`, `strokeAlign = "OUTSIDE"`, stroke weight = ring
+  width, sized to the parent with `STRETCH` constraints, parent `clipsContent = false`.
+  A **child, not a wrapper** — it doesn't inflate layout and coexists with an existing
+  border.
+
+Both map to the same `box-shadow: 0 0 0 3px var(--ring)` in code. See the build-side
+rules in `${CLAUDE_PLUGIN_ROOT}/references/figma-component-standards.md` ("State
+handling").
+
+## Give a bound paint a sensible placeholder color, and read the bind back
+
+A paint whose color you intend to bind can briefly render its **literal** color if the
+bind is late or doesn't stick — and a pure-black `{0,0,0}` placeholder then reads as an
+accidental **dark-mode** panel (seen once on a component-set background bound to
+`bg/default`; re-running the identical bind fixed it). Two safeguards:
+
+- Seed the paint with the token's **approximate value**, not pure black, so a
+  failed/late bind degrades gracefully.
+- **Read back `fills[0].boundVariables.color`** on container / component-set fills in
+  the post-build audit — a screenshot can't tell a stuck bind from a placeholder.
 
 ## `resize()` locks the *opposite* auto-layout axis to FIXED
 
@@ -104,6 +176,27 @@ Read back `primaryAxisSizingMode` / `counterAxisSizingMode` (or
 `layoutSizing*`) in the post-build audit — a collapsed axis is otherwise invisible
 until handoff.
 
+**The axis mapping is inverted for VERTICAL frames — this is the part that bites.**
+For a **VERTICAL** auto-layout frame, `primaryAxisSizingMode` controls **height** and
+`counterAxisSizingMode` controls **width** (the *opposite* of a HORIZONTAL frame, where
+primary = width). It's very easy to think "fixed width, hug height" and set the axes
+backwards, after which `resize()` pins the wrong dimension — the real symptoms were an
+Input variant collapsing to 10px tall (placeholders overlapping), a Card's *height*
+locking to 10px, and a parent layout frame's height pinned to a stale value.
+
+This is exactly why the **`layoutSizingHorizontal` / `layoutSizingVertical`** setters
+are safer: they name the dimension directly, so there's no primary/counter axis to get
+backwards.
+
+```js
+// VERTICAL frame, want fixed width + hug height:
+frame.layoutMode = "VERTICAL";
+frame.layoutSizingHorizontal = "FIXED";  // width  — unambiguous
+frame.layoutSizingVertical   = "HUG";    // height — unambiguous
+// Equivalent via axis modes (easy to invert): counter = width, primary = height
+// frame.counterAxisSizingMode = "FIXED"; frame.primaryAxisSizingMode = "AUTO";
+```
+
 ## Pass an explicit `timeout` for batch / multi-node writes
 
 `figma_execute`'s default timeout (~5000ms) is too low for scripts that touch
@@ -113,6 +206,13 @@ with no partial-success signal**, leaving a half-applied write. For any batch
 operation, pass an explicit `timeout` sized to the work — a good rule is
 **`node_count * 3000` ms** (e.g. a 9-card status write-back → `timeout: 30000`).
 Load fonts once and reuse where possible rather than re-loading per node.
+
+**But `figma_execute` is effectively capped at ~30s regardless of the `timeout` you
+pass** — a bigger number is not honored past that ceiling. So `node_count * 3000` is
+only a guide *up to* the cap; a build that genuinely needs more than ~30s must be
+**chunked into multiple `figma_execute` calls**, not handed a larger timeout. Design
+large builds for the cap from the start — the 108-variant Button was built as **3× 36-
+variant passes**. (This is the same ceiling behind the WRAP-chunking rule below.)
 
 ## Large wrapped auto-layout (`layoutWrap = "WRAP"`) is expensive — chunk it
 

--- a/references/manifest-schema.md
+++ b/references/manifest-schema.md
@@ -217,13 +217,15 @@ bailing or running silently.
   re-running the token-sheet-builder.
 
 ### `icons`
-- `library` — `"lucide"`, `"material"`, or `"custom"`.
+- `library` — `"lucide"`, `"tabler"`, `"phosphor"`, `"material"`, or `"custom"`.
+  (`lucide`/`tabler`/`phosphor` share the official-SVG-fetch mechanism.)
 - `version` — the library version the Figma mirror was built from (e.g. Lucide
   `"0.424.0"`). The drift check compares this against the installed npm package
   so the Figma icons and code icons stay the same generation. `null` for custom.
 - `built` — whether the Figma Icons page has been populated.
 - `packageInstalled` — whether the code-side npm package (`lucide-react`,
-  `@mui/icons-material`) has been installed. Library icons reach code via install
+  `@tabler/icons-react`, `@phosphor-icons/react`, `@mui/icons-material`) has been
+  installed. Library icons reach code via install
   + name mapping, never by generating component code; custom icons reach code via
   the sync layer's SVGR pipeline instead.
 - `subset` — the curated list of icon names imported (most projects need a

--- a/skills/component-builder/SKILL.md
+++ b/skills/component-builder/SKILL.md
@@ -50,9 +50,10 @@ relevant moment — ask which UI framework the components target (shadcn, MUI,
 vanilla, etc.; reuse the same value the sync adapter will use) and record it.
 If sync already set it, reuse it — don't re-ask. The framework does **not**
 change component structure/anatomy; it informs **variant vocabulary and naming**
-so the Figma component API lines up with the code API (see
-`${CLAUDE_PLUGIN_ROOT}/references/figma-component-standards.md`). For multi-framework targets, use a
-neutral vocabulary.
+so the Figma component API lines up with the code API, **and it drives the focus-state
+idiom** (shadcn ring vs. MUI per-component vs. vanilla-css outline — see "State
+handling" in `${CLAUDE_PLUGIN_ROOT}/references/figma-component-standards.md`). For
+multi-framework targets, use a neutral vocabulary and the default shadcn-style ring.
 
 **Recommended core set (editable).** Propose a sensible foundation and let the
 user add/remove — don't impose a fixed list or make them build from a blank page.
@@ -109,9 +110,16 @@ deterministic naming):
   component's **full relevant state set** across the columns, size groups stacked
   vertically. Per "Component set arrangement" and "State handling" in the standards
   doc.
-- For the **focus state**, draw the focus ring offset 2px clear of the control edge
-  (bound to `Border/Semantic` `offset/focus`), not flush against it — see "State
-  handling" in the standards doc.
+- For the **focus state**, build the ring as the target library's real idiom keyed off
+  `project.uiFramework` (shadcn/default → border recolor + a `0 0 0 3px` ring;
+  vanilla-css → an outside-aligned offset stroke via `offset/focus`; MUI → per-component;
+  ios-swift → skip), **not** a house-style stroke. Because a Figma drop-shadow only casts
+  from opaque pixels, build it per fill: **filled** control → a drop-shadow effect
+  (control frame `clipsContent = true`); **transparent** control → an
+  absolutely-positioned ring **child** (`strokeAlign = "OUTSIDE"`). **Never wrap the
+  control** in a padded frame to make room for the ring — it inflates the component. See
+  the per-library recipe in "State handling" of the standards doc, and the drop-shadow /
+  effect-binding gotchas in `${CLAUDE_PLUGIN_ROOT}/references/figma-scripting.md`.
 - **Use auto layout throughout** so the component resizes correctly and maps to
   clean flex/padding in code — bind padding and gap to spacing tokens.
 - **Bind every visual property to the system's tokens/styles** — fills to
@@ -179,10 +187,15 @@ Figma rejects local unpublished keys for swap targets. Before adding the dropdow
 check publish state per `${CLAUDE_PLUGIN_ROOT}/references/figma-publishing.md`:
 
 - **Resolve publish state first (detect-or-ask, bug B3):** a default/`false`
-  `figma.libraryPublished` is *unverified* — attempt detection
-  (`figma_get_library_components` / `figma_get_library_variables`) and ask once only if
-  inconclusive, per `${CLAUDE_PLUGIN_ROOT}/references/figma-publishing.md`. Never treat
-  a `false` as a final "not published" without that check.
+  `figma.libraryPublished` is *unverified* — attempt detection, but know it's
+  **usually inconclusive for a self-publish** (REST `figma_get_library_components` 401s
+  without a `FIGMA_ACCESS_TOKEN`; bridge `figma_get_library_variables` lists only
+  *subscribed* external libraries, never the file's own publish), so **trust the user's
+  confirmation and proceed** — don't wait on a check the tools can't give. Never treat a
+  `false` as a final "not published". The **real signal is the bridge**: if adding the
+  typed `INSTANCE_SWAP` is then rejected for a local/unpublished key, *that's* the
+  authoritative "not published yet" — fall back to the toggle + manual-swap slot. See
+  `${CLAUDE_PLUGIN_ROOT}/references/figma-publishing.md`.
 - **Confirmed published (`figma.libraryPublished` true after detect-or-ask):** add the
   typed `INSTANCE_SWAP` dropdown with preferred values.
 - **Not published (free plan, or not yet):** build the **toggle + manual-swap**
@@ -252,5 +265,12 @@ Offer next steps: build the code counterparts and stories
 - Never run the component header and the component area together with no division —
   every doc card segments the header from the component area with a divider line or
   a distinct header surface.
-- Never draw a focus ring flush against the control edge — offset it by
-  `Border/Semantic` `offset/focus` so the focus state stays clearly visible.
+- Never invent a house-style focus ring or wrap the control in a padded frame to make
+  room for one — derive the focus state from `project.uiFramework`'s real idiom, built
+  as a drop-shadow effect (filled controls) or an absolutely-positioned ring **child**
+  (transparent controls), per "State handling" in the standards doc.
+- Never rebuild a published/consumed component set with a delete-and-recreate without
+  re-instancing downstream — deleting and recreating a set (e.g. to change the Button's
+  internal architecture) **detaches every instance** that referenced its variants (the
+  Card's footer buttons, etc.). Record which components consume which, warn before an
+  architectural rebuild, and re-instance the affected consumers afterward.

--- a/skills/icon-system-builder/SKILL.md
+++ b/skills/icon-system-builder/SKILL.md
@@ -52,6 +52,31 @@ GitHub is unreachable, the user is on a restricted network, or they explicitly
 want the community file. Name the specific resource and surface its license first
 (see below).
 
+### Tabler & Phosphor → fetch the official SVGs directly (same as Lucide)
+
+**Tabler and Phosphor are first-class libraries built by the exact Lucide
+mechanism** — uniform per-icon SVGs published at a deterministic repo path where the
+filename *is* the canonical name, so they get the same fully-automated,
+official-source-of-truth, hands-off treatment (batch-fetch → `createNodeFromSvg` →
+`createComponentFromNode`), not a community-file copy. This path is **proven**: a
+greenfield run imported the Tabler subset by deterministic path with zero 404s and
+bound the vector strokes to `text/primary` for theming. Prefer it whenever the user's
+brand specifies Tabler or Phosphor (both are common picks).
+
+- **Tabler** (MIT, 24px stroke): `github.com/tabler/tabler-icons`, per-icon at
+  `icons/outline/<name>.svg` (and `icons/filled/<name>.svg` for the filled set). Pin a
+  release tag matching the installed `@tabler/icons-react` generation. A 404 is the
+  name-validation gate, same as Lucide.
+- **Phosphor** (MIT, 256px): `github.com/phosphor-icons/core`, per-icon at
+  `assets/<weight>/<name>.svg` where weight ∈ `thin|light|regular|bold|fill|duotone`
+  (regular has no suffix; others are `<name>-<weight>.svg`). Pick one weight as the
+  base to match the code package, pin the tag, and fetch that weight's files.
+
+After fetch, **bind the vector strokes/fills to `text/primary`** (or the icon color
+token) so the icons theme with the system, and name per the Step 3 contract. Fallbacks
+(only if the fetch is blocked) mirror Lucide's: the library's official Figma community
+file or importer plugin, license surfaced first.
+
 ### Material → official community file / importer (default)
 
 Material has **variant axes** (outlined / rounded / sharp × fill / weight / grade /
@@ -124,14 +149,15 @@ ask the user** which resource to use — never invent a source.
 
 ## Step 1 — Choose library + mechanism
 
-- Ask which library: **Lucide** (the shadcn default; outline only),
-  **Material**, or **custom** (user brings SVGs). Record in `icons.library`.
+- Ask which library: **Lucide** (the shadcn default; outline only), **Tabler**,
+  **Phosphor**, **Material**, or **custom** (user brings SVGs). Record in
+  `icons.library`.
 - Determine the subset (brainstorm, above).
-- The library fixes the mechanism (Core principle): **Lucide → fetch official
-  SVGs from the repo; Material → official community file / importer; custom →
-  batched SVG import.** Pin the version tag for Lucide. Only name + confirm a
-  specific community-file/importer resource for the paths that use one (Material,
-  or a Lucide fallback).
+- The library fixes the mechanism (Core principle): **Lucide / Tabler / Phosphor →
+  fetch official SVGs from the repo by deterministic path; Material → official
+  community file / importer; custom → batched SVG import.** Pin the version tag for
+  the fetch libraries. Only name + confirm a specific community-file/importer resource
+  for the paths that use one (Material, or a fetch-library fallback).
 
 ## Step 2 — Bring icons in
 

--- a/skills/token-builder/SKILL.md
+++ b/skills/token-builder/SKILL.md
@@ -256,8 +256,10 @@ its primitive so the alias is live. Default set and modes:
 - `Border/Semantic` — single mode. Roles: `width/{default,focus,emphasis}`
   aliasing `_Border/Primitive` widths, plus **`offset/focus`** (the gap between a
   control's edge and its focus ring, the `outline-offset` equivalent) aliasing the
-  `2` width primitive. Components apply `offset/focus` so focus rings stay clear of
-  the edge for accessibility — see "State handling" in the component standards.
+  `2` width primitive. It's used by the **outline-style** focus recipe (e.g.
+  `vanilla-css`) to keep the ring clear of the edge for accessibility; library idioms
+  that render focus as a spread-shadow ring don't need it — see "State handling" in the
+  component standards for the per-library recipes.
 - `Opacity/Semantic` (when the system needs disabled/overlay states) — single
   mode. Roles: `disabled`, `muted`, `overlay/scrim`, `hover`, aliasing
   `_Opacity/Primitive`. See the **opacity scale rule** below — this is the one


### PR DESCRIPTION
## Summary

Reframes focus construction and closes the skill/reference gaps surfaced by a greenfield build run (`throughline-brand/throughline-plugin-issues.md`, items A1–A6 / B1–B5 / C1 / D1–D3). Documentation/instruction only — tokens and code-gen untouched (Figma-build-only scope). Design spec: `docs/superpowers/specs/2026-07-02-figma-build-hardening-design.md`.

## Focus states (the headline)
- Derive the focus idiom from `project.uiFramework` instead of one house style: shadcn/default `0 0 0 3px` spread-shadow ring, `vanilla-css` outline stroke, MUI per-component, ios-swift skip, tier-2 researched.
- Choose the ring **mechanism by control fill** — drop-shadow effect for filled controls, absolutely-positioned ring **child** for transparent ones (a Figma drop-shadow only casts from opaque pixels). Padded wrapper forbidden.
- `clipsContent=true` on the shadow-casting control frame, `false` on ancestors.
- Retrofit clause + audit item so legacy wrapper / inside-stroke / missing-transparent-ring components get fixed when touched.

## Report items
- **`figma-scripting.md`** — A1 effect-geometry reset after bind, A2 drop-shadow opacity, A3 text-style-before-`.characters`, A4 VERTICAL `resize()` axis mapping, A5 read-after-write `refreshCache`, A6 placeholder paint + bind read-back, D1 ~30s execute cap → chunk.
- **`figma-component-standards.md`** — B2/B3 deterministic grid coords over `minWidth`/`GRID`, B4 component-area contrast, B5 audit exemption.
- **`figma-publishing.md`** — C1 self-publish not tool-verifiable; trust the user, treat an `INSTANCE_SWAP` key rejection as the real signal.
- **`icon-system-builder`** + schema — D2 Tabler + Phosphor first-class.
- **`component-builder`** — D3 warn on published-set rebuild detaching instances.

## Verification
70/70 `node --test`, plus `validate-plugin` and `validate-skills` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)