### PR TITLE
fix: scope is @radicoolstudio (radicool org name unavailable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ to [Semantic Versioning](https://semver.org).
 ## [0.12.0] - 2026-07-03
 
 ### Added
-- **Published to npm as [`@radicool/throughline`](https://www.npmjs.com/package/@radicool/throughline).**
-  The multi-agent installer is now installable everywhere: `npx @radicool/throughline init`.
+- **Published to npm as [`@radicoolstudio/throughline`](https://www.npmjs.com/package/@radicoolstudio/throughline).**
+  The multi-agent installer is now installable everywhere: `npx @radicoolstudio/throughline init`.
   (The unscoped `throughline` npm name belongs to an unrelated package.)
 - **Tag-driven release automation.** Pushing a `vX.Y.Z` tag now runs the full CI
   validation, publishes to npm with provenance via trusted publishing, and creates
@@ -18,7 +18,7 @@ to [Semantic Versioning](https://semver.org).
   (`.github/workflows/release.yml` + `ci/extract-changelog.mjs`).
 
 ### Changed
-- **Install command for Cursor/Codex/AGENTS.md targets is now `npx @radicool/throughline init`**
+- **Install command for Cursor/Codex/AGENTS.md targets is now `npx @radicoolstudio/throughline init`**
   (previously documented as `npx throughline init`, which was never published).
 - README version badge now reads live from the npm registry.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Every skill you need to launch and manage a production-grade design system in hours — not months. Built for Claude Code, and installable into Cursor, Codex, or any AGENTS.md agent.**
 
-[![npm](https://img.shields.io/npm/v/%40radicool%2Fthroughline?color=6366f1&label=npm)](https://www.npmjs.com/package/@radicool/throughline)
+[![npm](https://img.shields.io/npm/v/%40radicoolstudio%2Fthroughline?color=6366f1&label=npm)](https://www.npmjs.com/package/@radicoolstudio/throughline)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Built for Claude Code](https://img.shields.io/badge/built%20for-Claude%20Code-d97757)](https://docs.claude.com/en/docs/claude-code)
 [![Also on Cursor · Codex · AGENTS.md](https://img.shields.io/badge/also%20on-Cursor%20·%20Codex%20·%20AGENTS.md-22c55e)](#install)
@@ -73,7 +73,7 @@ Everything above was created during a single working session and synced directly
 
 | | |
 |---|---|
-| **A supported agent** | Required — [Claude Code](https://docs.claude.com/en/docs/claude-code) (native plugin), or **Cursor**, **Codex**, or any **AGENTS.md**-aware agent via `npx @radicool/throughline init`. |
+| **A supported agent** | Required — [Claude Code](https://docs.claude.com/en/docs/claude-code) (native plugin), or **Cursor**, **Codex**, or any **AGENTS.md**-aware agent via `npx @radicoolstudio/throughline init`. |
 | **Figma** | Required, **desktop app** (the browser version causes connection errors). **Professional plan or higher recommended** — multi-mode variables (Light/Dark, brand themes) need it. |
 | **Figma access token** | Required — read/write your file. The setup skill walks you through it; your token stays yours and is never shared in chat. |
 | **GitHub** (or similar) | Optional — only when you're ready to graduate to a real remote repo with PRs and CI. |
@@ -106,9 +106,9 @@ Update anytime with `/plugin marketplace update throughline-marketplace`.
 Run the installer in your project — it stamps in the skills, the reference docs, the scripts, and the Figma MCP config for your tool:
 
 ```
-npx @radicool/throughline init --target=cursor    # → .cursor/rules + .cursor/mcp.json
-npx @radicool/throughline init --target=codex      # → prompts/ + AGENTS.md index + codex-mcp.toml
-npx @radicool/throughline init --target=generic    # → skills/ + AGENTS.md index
+npx @radicoolstudio/throughline init --target=cursor    # → .cursor/rules + .cursor/mcp.json
+npx @radicoolstudio/throughline init --target=codex      # → prompts/ + AGENTS.md index + codex-mcp.toml
+npx @radicoolstudio/throughline init --target=generic    # → skills/ + AGENTS.md index
 ```
 
 It's safe to re-run (it merges `AGENTS.md` and `.cursor/mcp.json` non-destructively) and stages everything the skills read into `.throughline/`. Then open the `figma-environment-setup` skill/rule/prompt for your tool to begin. For Codex, add the printed `codex-mcp.toml` block to your Codex config to enable Figma access.

--- a/docs/superpowers/specs/2026-07-03-publishing-design.md
+++ b/docs/superpowers/specs/2026-07-03-publishing-design.md
@@ -36,7 +36,7 @@ plugin-marketplace submission, and the launch polish around them.
 
 ## Decisions (made during brainstorming)
 
-1. **npm name:** `@radicool/throughline` — published under the studio brand
+1. **npm name:** `@radicoolstudio/throughline` — published under the studio brand
    (radicool.studio) via an npm org. Bin name stays `throughline`. Fallback
    scope if `radicool` is claimed: `@radicoolstudio`.
 2. **Scope:** all four surfaces (npm, release automation, marketplace, polish).
@@ -49,12 +49,12 @@ plugin-marketplace submission, and the launch polish around them.
 
 `package.json` changes:
 
-- `name`: `throughline` → `@radicool/throughline`
+- `name`: `throughline` → `@radicoolstudio/throughline`
 - `version`: `0.11.0` → `0.12.0`
 - add `"publishConfig": { "access": "public" }` — scoped packages default to
   restricted and the publish would otherwise fail.
 - `bin` stays `{ "throughline": "scripts/install.mjs" }`. `npx
-  @radicool/throughline init` works because npx runs a package's single bin
+  @radicoolstudio/throughline init` works because npx runs a package's single bin
   regardless of its name, and global installs still expose a `throughline`
   command.
 
@@ -65,7 +65,7 @@ file carrying a version; `marketplace.json` has none), keeping
 The Claude plugin name stays plain `throughline` — plugin marketplaces
 namespace independently of npm.
 
-Command references: update `npx throughline init` → `npx @radicool/throughline
+Command references: update `npx throughline init` → `npx @radicoolstudio/throughline
 init` in **README.md** and **scripts/README.md** (the latter ships in the npm
 payload). Historical specs and plans under `docs/superpowers/` are records of
 past work and are left unchanged. Re-run the adapter generator if any generated
@@ -110,7 +110,7 @@ release step) since the tag may predate the workflow landing on main.
 - Fix the CHANGELOG link footer: add `[0.11.0]` and `[0.12.0]` compare links and
   point `[Unreleased]` at `v0.12.0...HEAD`.
 - Add a `0.12.0` CHANGELOG entry covering: published to npm as
-  `@radicool/throughline`, install command change, release automation.
+  `@radicoolstudio/throughline`, install command change, release automation.
 
 ## 4. Plugin marketplace submission
 
@@ -130,7 +130,7 @@ release step) since the tag may predate the workflow landing on main.
 
 - **README:** scoped npm command everywhere; replace the hand-maintained version
   badge with the npm registry badge
-  (`https://img.shields.io/npm/v/%40radicool%2Fthroughline`), which auto-updates;
+  (`https://img.shields.io/npm/v/%40radicoolstudio%2Fthroughline`), which auto-updates;
   once a marketplace accepts the plugin, add its `/plugin install` one-liner
   (deferred until acceptance — not part of this release).
 - **GitHub Release** for v0.12.0 with the CHANGELOG notes.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@radicool/throughline",
+  "name": "@radicoolstudio/throughline",
   "version": "0.12.0",
   "description": "Build a complete design system end to end — author in Figma, sync tokens to code, generate Storybook. Usable from Claude Code, Cursor, Codex, or any AGENTS.md agent.",
   "type": "module",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -73,6 +73,6 @@ the committed `adapters/<target>/` tree plus the runtime payload
 (`references/` + `scripts/`, minus `scripts/adapters/`) into `.throughline/`,
 rewriting `${CLAUDE_PLUGIN_ROOT}` → `.throughline`:
 
-    npx @radicool/throughline init --target=cursor|codex|generic
+    npx @radicoolstudio/throughline init --target=cursor|codex|generic
 
 See `scripts/install.mjs` (pure core + CLI + `install.test.mjs`).


### PR DESCRIPTION
The `radicool` npm org name was taken at creation time; per the plan's Task 7 fallback, the scope is now `@radicoolstudio` everywhere: package.json name, README badge/commands, scripts/README, CHANGELOG 0.12.0 entry, and the design spec. All 111 tests + validators green; `npm pack --dry-run` confirms `@radicoolstudio/throughline` with test files still excluded.

After merge: v0.12.0 is re-tagged onto main (nothing consumed the old tag — npm publish never happened) and the GitHub Release notes are regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UURePtW9chuNbuEA4mGKU4