### PR TITLE
fix(installer): npx bin symlink defeated the CLI guard (v0.12.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "throughline",
   "description": "ThroughLine — build a complete design system end to end. Author tokens, styles, icons, and components in Figma, then stand up a monorepo, sync tokens to framework-specific code via Style Dictionary, and generate Storybook stories with Chromatic. One unbroken line from design to code. Built for designers becoming developers; explanation scales to your comfort level.",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "author": {
     "name": "Jordan Pease"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-07-03
+
+### Fixed
+- **`npx @radicool/throughline init` silently did nothing.** npm invokes the bin
+  through a `node_modules/.bin` symlink, which defeated the CLI's
+  direct-invocation guard (`pathToFileURL(process.argv[1])` never matched the
+  real module path), so the installer exited 0 without installing. The guard
+  now realpath-resolves `argv[1]` first, with a symlink-invocation regression
+  test.
+
 ## [0.12.0] - 2026-07-03
 
 ### Added
@@ -511,7 +521,8 @@ components → Storybook on a pnpm + Turborepo + Next.js 16 + Tailwind v4 monore
 - Reference docs for coding level, manifest schema, sync adapters, Figma
   component standards, and brainstorm-before-build.
 
-[Unreleased]: https://github.com/jrpease/throughline/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/jrpease/throughline/compare/v0.12.1...HEAD
+[0.12.1]: https://github.com/jrpease/throughline/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/jrpease/throughline/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/jrpease/throughline/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/jrpease/throughline/compare/v0.9.0...v0.10.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@radicool/throughline",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Build a complete design system end to end — author in Figma, sync tokens to code, generate Storybook. Usable from Claude Code, Cursor, Codex, or any AGENTS.md agent.",
   "type": "module",
   "bin": {

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync, copyFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync, copyFileSync, realpathSync } from 'node:fs';
 import { join, dirname, relative, sep } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { rewritePluginRoot } from './adapters/translate.mjs';
@@ -129,7 +129,14 @@ export function install({ target, dir, pkgRoot = PKG_ROOT }) {
   return { target, dir, written, payload };
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+function isDirectInvocation() {
+  if (!process.argv[1]) return false;
+  let invoked = process.argv[1];
+  try { invoked = realpathSync(invoked); } catch { /* keep original */ }
+  return import.meta.url === pathToFileURL(invoked).href;
+}
+
+if (isDirectInvocation()) {
   const args = parseArgs(process.argv.slice(2));
   if (args.help) { console.log(USAGE); process.exit(0); }
   if (args.cmd !== 'init') { console.error(`✗ unknown command; expected "init"\n\n${USAGE}`); process.exit(1); }

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -152,3 +152,23 @@ test('CLI init installs into --dir and prints a summary', () => {
 test('CLI exits non-zero on a bad target', () => {
   assert.throws(() => execFileSync('node', [INSTALL, 'init', '--target=nope'], { stdio: 'pipe' }));
 });
+
+import { symlinkSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+
+test('npx-style invocation through a node_modules/.bin symlink actually installs', () => {
+  const binDir = freshDir('npx-bin');
+  const workDir = freshDir('npx-work');
+  const symlinkPath = join(binDir, 'throughline');
+  symlinkSync(INSTALL, symlinkPath);
+
+  const res = spawnSync('node', [symlinkPath, 'init', '--target=generic'], {
+    cwd: workDir,
+    encoding: 'utf8',
+  });
+
+  assert.equal(res.status, 0, `expected exit 0, got ${res.status}; stderr: ${res.stderr}`);
+  assert.ok(exists(join(workDir, 'AGENTS.md')), 'AGENTS.md scaffolded into cwd');
+  assert.ok(exists(join(workDir, 'skills')), 'skills/ scaffolded into cwd');
+  assert.match(res.stdout, /✓ throughline: installed/, 'prints success line');
+});


### PR DESCRIPTION
## Summary

`@radicool/throughline@0.12.0`'s published `npx @radicool/throughline init` exited 0 having done nothing. npm invokes the package's `bin` entry through a `node_modules/.bin/throughline` symlink; `scripts/install.mjs`'s direct-invocation guard compared `import.meta.url` (the real, resolved module path) against `pathToFileURL(process.argv[1]).href` (the symlink path, unresolved). Those never matched, so the CLI branch never ran and the process exited 0 silently — no scaffold, no error. Running `node scripts/install.mjs init ...` directly (as the previous test suite did) worked fine, which is why this shipped undetected.

## Fix

- `scripts/install.mjs`: extracted the guard into `isDirectInvocation()`, which now `realpathSync`s `process.argv[1]` before comparing to `import.meta.url` (falling back to the original value if the path doesn't exist). Symlink-safe, and still `false` when the module is `import`ed rather than executed, so existing consumers of the exported `install`/`parseArgs`/etc. are unaffected.
- Added a regression test in `scripts/install.test.mjs` that reproduces the exact npx invocation shape: creates a real filesystem symlink to `install.mjs`, spawns `node <symlink> init --target=generic` with `cwd` set to a separate temp dir (mirroring how npm's `.bin` shim invokes a package binary), and asserts exit 0 **and** that `AGENTS.md` / `skills/` actually landed in the working directory, **and** the `✓ throughline: installed ...` line printed. Confirmed this test fails against the pre-fix code (files absent despite exit 0), then passes after the fix.
- Bumped `package.json` and `.claude-plugin/plugin.json` to `0.12.1`, added a `CHANGELOG.md` entry under a new `[0.12.1]` heading.

## Verification

- `node --test`: 112/112 passing (repo-wide), including the new regression test.
- `node ci/validate-plugin.mjs && node ci/validate-skills.mjs && node scripts/adapters/generate.mjs --check`: all pass.
- End-to-end tarball simulation (closest reproduction of the real npm/npx bug): `npm pack` in the repo, then in a fresh temp project ran `npm install <tarball>` and `npx throughline init --target=generic` — this exercises the actual `node_modules/.bin` symlink npm creates. Confirmed the `✓ throughline: installed generic adapter (17 files) + 17-file runtime payload ...` line printed and `AGENTS.md` + `skills/` were scaffolded into the temp project. `.tgz` cleaned up afterward.

## Test plan

- [x] New regression test fails on pre-fix `install.mjs` (RED), passes after the fix (GREEN)
- [x] Full `node --test` suite green (112/112)
- [x] CI validation scripts pass
- [x] End-to-end `npm pack` + `npm install` + `npx throughline init` reproduces and confirms the fix on a real symlinked bin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UURePtW9chuNbuEA4mGKU4