### PR TITLE
feat: subagent-driven model-tier routing (Phase 1 — token-sync pilot)

### DIFF
--- a/adapters/codex/prompts/token-sync-layer.md
+++ b/adapters/codex/prompts/token-sync-layer.md
@@ -139,13 +139,18 @@ register the platform, transform group, format, and `outputReferences`
 flattens). Web adapters emit `:root`/`.dark` (or `[data-theme]`); the shadcn
 adapter also emits a Tailwind preset.
 
-**Execution model — subagent-driven for multiple platforms.** When more than one
-platform is targeted, generating each platform's output is independent and
-verifiable, so dispatch **one subagent per adapter**: each produces its
+**Execution model — subagent dispatch with model routing.** Generating each
+platform's output is independent and verifiable. If your host supports subagent
+dispatch, dispatch **one `code-executor` per adapter** — each produces its
 platform's files and verifies them (the config builds, the expected files
-appear, references resolve correctly for web / flatten for native). Review each
-before combining. For a single platform, run inline. (See the selective-
-subagent decision: code-gen skills parallelize; Figma-authoring skills don't.)
+appear, references resolve for web / flatten for native) — then a **`reviewer`**
+to check each before combining. Choose each subagent's model from its role tier
+per `.throughline/references/agent-routing.md` (`code-executor` → fast,
+`reviewer` → balanced), and only dispatch once each adapter's spec is complete
+enough to transcribe. If your host has no subagent dispatch, generate and verify
+each adapter inline instead. For a single platform, run inline either way. This
+is a code-gen stage, so these subagents may run in parallel — unlike Figma
+authoring, which is always sequential.
 
 ## Step 4 — Build and place outputs
 

--- a/adapters/cursor/.cursor/rules/token-sync-layer.mdc
+++ b/adapters/cursor/.cursor/rules/token-sync-layer.mdc
@@ -143,13 +143,18 @@ register the platform, transform group, format, and `outputReferences`
 flattens). Web adapters emit `:root`/`.dark` (or `[data-theme]`); the shadcn
 adapter also emits a Tailwind preset.
 
-**Execution model — subagent-driven for multiple platforms.** When more than one
-platform is targeted, generating each platform's output is independent and
-verifiable, so dispatch **one subagent per adapter**: each produces its
+**Execution model — subagent dispatch with model routing.** Generating each
+platform's output is independent and verifiable. If your host supports subagent
+dispatch, dispatch **one `code-executor` per adapter** — each produces its
 platform's files and verifies them (the config builds, the expected files
-appear, references resolve correctly for web / flatten for native). Review each
-before combining. For a single platform, run inline. (See the selective-
-subagent decision: code-gen skills parallelize; Figma-authoring skills don't.)
+appear, references resolve for web / flatten for native) — then a **`reviewer`**
+to check each before combining. Choose each subagent's model from its role tier
+per `.throughline/references/agent-routing.md` (`code-executor` → fast,
+`reviewer` → balanced), and only dispatch once each adapter's spec is complete
+enough to transcribe. If your host has no subagent dispatch, generate and verify
+each adapter inline instead. For a single platform, run inline either way. This
+is a code-gen stage, so these subagents may run in parallel — unlike Figma
+authoring, which is always sequential.
 
 ## Step 4 — Build and place outputs
 

--- a/adapters/generic/skills/token-sync-layer/SKILL.md
+++ b/adapters/generic/skills/token-sync-layer/SKILL.md
@@ -139,13 +139,18 @@ register the platform, transform group, format, and `outputReferences`
 flattens). Web adapters emit `:root`/`.dark` (or `[data-theme]`); the shadcn
 adapter also emits a Tailwind preset.
 
-**Execution model — subagent-driven for multiple platforms.** When more than one
-platform is targeted, generating each platform's output is independent and
-verifiable, so dispatch **one subagent per adapter**: each produces its
+**Execution model — subagent dispatch with model routing.** Generating each
+platform's output is independent and verifiable. If your host supports subagent
+dispatch, dispatch **one `code-executor` per adapter** — each produces its
 platform's files and verifies them (the config builds, the expected files
-appear, references resolve correctly for web / flatten for native). Review each
-before combining. For a single platform, run inline. (See the selective-
-subagent decision: code-gen skills parallelize; Figma-authoring skills don't.)
+appear, references resolve for web / flatten for native) — then a **`reviewer`**
+to check each before combining. Choose each subagent's model from its role tier
+per `.throughline/references/agent-routing.md` (`code-executor` → fast,
+`reviewer` → balanced), and only dispatch once each adapter's spec is complete
+enough to transcribe. If your host has no subagent dispatch, generate and verify
+each adapter inline instead. For a single platform, run inline either way. This
+is a code-gen stage, so these subagents may run in parallel — unlike Figma
+authoring, which is always sequential.
 
 ## Step 4 — Build and place outputs
 

--- a/agents/code-executor.md
+++ b/agents/code-executor.md
@@ -1,0 +1,28 @@
+---
+name: code-executor
+description: Transcribes code or generated output from a complete, transcription-grade spec and verifies its own build. Dispatched on the fast tier for mechanical, parallel-safe code-gen (per-adapter token output, per-component stories, SVGR transforms). Not for planning or design decisions — those belong to the dispatcher or the architect.
+model: inherit
+tools: Read, Write, Edit, Bash
+---
+
+# code-executor
+
+**Tier:** `fast` (see `${CLAUDE_PLUGIN_ROOT}/references/agent-routing.md`). **Concurrency:** parallel-safe.
+
+You receive a complete spec and produce exactly what it describes — no design
+decisions. If the spec is ambiguous or underspecified, do not guess: return
+`BLOCKED` naming the gap (the dispatcher will re-plan or escalate a tier up).
+
+## Contract
+
+1. Read the spec and the files it names.
+2. Produce the files the spec specifies, following existing repo patterns.
+3. **Verify your own work** — run the build/test the spec names and confirm the
+   expected artifacts appear (for token adapters: the config builds, expected
+   files exist, references resolve for web / flatten for native).
+4. Return a concise result: files written, verification command + outcome, and
+   one of `DONE` / `DONE_WITH_CONCERNS` / `BLOCKED`. Your final message IS the
+   return value — return data, not prose for a human.
+
+Never expand scope beyond the spec. Never mark `DONE` without running the
+verification step.

--- a/agents/code-executor.md
+++ b/agents/code-executor.md
@@ -18,8 +18,7 @@ decisions. If the spec is ambiguous or underspecified, do not guess: return
 1. Read the spec and the files it names.
 2. Produce the files the spec specifies, following existing repo patterns.
 3. **Verify your own work** — run the build/test the spec names and confirm the
-   expected artifacts appear (for token adapters: the config builds, expected
-   files exist, references resolve for web / flatten for native).
+   expected artifacts appear, exactly as the spec defines them.
 4. Return a concise result: files written, verification command + outcome, and
    one of `DONE` / `DONE_WITH_CONCERNS` / `BLOCKED`. Your final message IS the
    return value — return data, not prose for a human.

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -1,0 +1,29 @@
+---
+name: reviewer
+description: Reviews a completed unit of work for spec compliance and quality before it is combined or landed. Two modes — code-diff review (a git diff) and Figma-visual review (screenshot then analyze). Dispatched on the balanced tier, scaled to the diff's risk. Reports a verdict; does not fix.
+model: inherit
+tools: Read, Bash
+---
+
+# reviewer
+
+**Tier:** `balanced`, scaled to risk (see `${CLAUDE_PLUGIN_ROOT}/references/agent-routing.md`). **Concurrency:** parallel-safe.
+
+Review the unit you are given against its spec. Report; do not edit.
+
+## Mode: code-diff
+
+Given a spec and a diff:
+1. **Spec compliance** — does the diff do what the spec requires, and only that?
+2. **Quality** — correctness, DRY, repo conventions, dead code, tests that
+   assert something real.
+Return: `spec: ✅/❌ <reason>`, then quality findings ranked most-severe first,
+then an overall `approved` / `changes-requested`. Flag anything you cannot
+verify from the diff alone as `⚠️ cannot verify` — do not block on it; the
+dispatcher holds the cross-task context to resolve it.
+
+## Mode: Figma-visual *(exercised in Phase 2)*
+
+Figma work has no diff. Screenshot the result, then analyze alignment, spacing,
+proportions, and binding to tokens against the spec; report the same
+`approved` / `changes-requested` verdict. (Phase 2 wires the screenshot tools.)

--- a/ci/validate-skills.mjs
+++ b/ci/validate-skills.mjs
@@ -42,6 +42,29 @@ export function validateCommand({ fileName, source }) {
   return problems;
 }
 
+export function validateAgent({ fileName, source }) {
+  let data;
+  try {
+    ({ data } = parseFrontmatter(source));
+  } catch (err) {
+    return [`agents/${fileName}: ${err.message}`];
+  }
+  const problems = [];
+  const expectedName = fileName.replace(/\.md$/, '');
+  if (!isNonEmptyString(data.name)) {
+    problems.push(`agents/${fileName}: "name" is required`);
+  } else if (data.name !== expectedName) {
+    problems.push(`agents/${fileName}: "name" (${data.name}) must equal the file name (${expectedName})`);
+  }
+  if (!isNonEmptyString(data.description)) {
+    problems.push(`agents/${fileName}: "description" is required`);
+  }
+  if (data.model !== 'inherit') {
+    problems.push(`agents/${fileName}: "model" must be exactly "inherit" (agents never hardcode a concrete model)`);
+  }
+  return problems;
+}
+
 export function validateManifestDoc(source) {
   const match = source.match(/```json\n([\s\S]*?)\n```/);
   if (!match) {
@@ -85,10 +108,20 @@ function main() {
     problems.push(...validateCommand({ fileName, source: readFileSync(join(commandsDir, fileName), 'utf8') }));
   }
 
+  const agentsDir = join(REPO_ROOT, 'agents');
+  let agentCount = 0;
+  if (existsSync(agentsDir)) {
+    const agentFiles = readdirSync(agentsDir).filter((f) => f.endsWith('.md'));
+    agentCount = agentFiles.length;
+    for (const fileName of agentFiles) {
+      problems.push(...validateAgent({ fileName, source: readFileSync(join(agentsDir, fileName), 'utf8') }));
+    }
+  }
+
   problems.push(...validateManifestDoc(readFileSync(join(REPO_ROOT, 'references', 'manifest-schema.md'), 'utf8')));
 
   if (problems.length === 0) {
-    console.log(`✓ ${skillDirs.length} skills, ${commandFiles.length} commands, manifest doc OK`);
+    console.log(`✓ ${skillDirs.length} skills, ${commandFiles.length} commands, ${agentCount} agents, manifest doc OK`);
     return;
   }
   console.error(`✗ ${problems.length} problem(s):`);

--- a/ci/validate-skills.mjs
+++ b/ci/validate-skills.mjs
@@ -82,6 +82,14 @@ export function validateManifestDoc(source) {
   return [];
 }
 
+export function validateAgentRouting(source) {
+  const missing = ['fast', 'balanced', 'deep'].filter((tier) => !new RegExp(`\`${tier}\``).test(source));
+  if (missing.length) {
+    return [`references/agent-routing.md: must define tier(s): ${missing.join(', ')}`];
+  }
+  return [];
+}
+
 function isNonEmptyString(v) {
   return typeof v === 'string' && v.trim().length > 0;
 }
@@ -116,6 +124,11 @@ function main() {
     for (const fileName of agentFiles) {
       problems.push(...validateAgent({ fileName, source: readFileSync(join(agentsDir, fileName), 'utf8') }));
     }
+  }
+
+  const routingPath = join(REPO_ROOT, 'references', 'agent-routing.md');
+  if (existsSync(routingPath)) {
+    problems.push(...validateAgentRouting(readFileSync(routingPath, 'utf8')));
   }
 
   problems.push(...validateManifestDoc(readFileSync(join(REPO_ROOT, 'references', 'manifest-schema.md'), 'utf8')));

--- a/ci/validate-skills.test.mjs
+++ b/ci/validate-skills.test.mjs
@@ -3,12 +3,17 @@ import assert from 'node:assert/strict';
 import {
   validateSkill,
   validateCommand,
+  validateAgent,
   validateManifestDoc,
   MAX_DESCRIPTION,
 } from './validate-skills.mjs';
 
 function skillSource({ name = 'demo', description = 'a demo skill' } = {}) {
   return `---\nname: ${name}\ndescription: ${description}\n---\n# Demo\n`;
+}
+
+function agentSource({ name = 'code-executor', description = 'an agent', model = 'inherit' } = {}) {
+  return `---\nname: ${name}\ndescription: ${description}\nmodel: ${model}\n---\nbody\n`;
 }
 
 test('a well-formed skill produces no problems', () => {
@@ -71,4 +76,30 @@ test('flags a manifest doc whose schemaVersion is not an integer', () => {
 test('flags a manifest doc with no json block', () => {
   const problems = validateManifestDoc('no code block here');
   assert.ok(problems.some((p) => /no.*json.*block/i.test(p)));
+});
+
+test('a well-formed agent produces no problems', () => {
+  assert.deepEqual(validateAgent({ fileName: 'code-executor.md', source: agentSource() }), []);
+});
+
+test('flags an agent that hardcodes a concrete model', () => {
+  const problems = validateAgent({ fileName: 'code-executor.md', source: agentSource({ model: 'opus' }) });
+  assert.ok(problems.some((p) => /model.*must be.*inherit/i.test(p)));
+});
+
+test('flags an agent missing the model field', () => {
+  const src = `---\nname: code-executor\ndescription: an agent\n---\nbody\n`;
+  const problems = validateAgent({ fileName: 'code-executor.md', source: src });
+  assert.ok(problems.some((p) => /model.*must be.*inherit/i.test(p)));
+});
+
+test('flags an agent missing a description', () => {
+  const src = `---\nname: code-executor\nmodel: inherit\n---\nbody\n`;
+  const problems = validateAgent({ fileName: 'code-executor.md', source: src });
+  assert.ok(problems.some((p) => /"description" is required/.test(p)));
+});
+
+test('flags an agent whose name does not match the file', () => {
+  const problems = validateAgent({ fileName: 'code-executor.md', source: agentSource({ name: 'other' }) });
+  assert.ok(problems.some((p) => /must equal the file name/.test(p)));
 });

--- a/ci/validate-skills.test.mjs
+++ b/ci/validate-skills.test.mjs
@@ -5,6 +5,7 @@ import {
   validateCommand,
   validateAgent,
   validateManifestDoc,
+  validateAgentRouting,
   MAX_DESCRIPTION,
 } from './validate-skills.mjs';
 
@@ -102,4 +103,15 @@ test('flags an agent missing a description', () => {
 test('flags an agent whose name does not match the file', () => {
   const problems = validateAgent({ fileName: 'code-executor.md', source: agentSource({ name: 'other' }) });
   assert.ok(problems.some((p) => /must equal the file name/.test(p)));
+});
+
+test('agent-routing doc naming all three tiers passes', () => {
+  const src = '# Routing\n\n- `fast` — cheapest\n- `balanced` — mid\n- `deep` — most capable\n';
+  assert.deepEqual(validateAgentRouting(src), []);
+});
+
+test('agent-routing doc missing a tier is flagged', () => {
+  const src = '# Routing\n\n- `fast`\n- `balanced`\n';
+  const problems = validateAgentRouting(src);
+  assert.ok(problems.some((p) => /deep/.test(p)));
 });

--- a/docs/superpowers/plans/2026-07-04-subagent-routing-phase1-token-sync.md
+++ b/docs/superpowers/plans/2026-07-04-subagent-routing-phase1-token-sync.md
@@ -1,0 +1,504 @@
+# Subagent Routing — Phase 1 (token-sync pilot) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prove the model-tier routing mechanism on one skill — migrate `token-sync-layer` to dispatch named subagents whose model is chosen from a portable tier ladder, with the shared machinery (agent definitions, routing reference, a no-hardcoded-model check, cross-host degradation) that later phases reuse.
+
+**Architecture:** Introduce a Claude-only `agents/` directory holding two role agents (`code-executor`, `reviewer`), each `model: inherit`. A new `references/agent-routing.md` maps roles→tiers→models with a fallback so installers on any model plan resolve it. A CI validator enforces that agents never hardcode a model. The `token-sync-layer` skill's execution-model paragraph is rewritten to dispatch those agents via the reference, authored as a self-degrading conditional so the generated Codex/generic adapters fall back to inline execution (no subagents there). Adapters are regenerated so the drift guard stays green.
+
+**Tech Stack:** ESM Node ≥20, `node:test` + `node:assert/strict`, zero dependencies. Markdown skill/agent/reference files. Existing `scripts/adapters/*` generator + `ci/validate-*` validators.
+
+## Global Constraints
+
+- **ESM only, zero new dependencies** — Node built-ins only (matches `ci/` + `scripts/`).
+- **Tests run under `node --test`** (auto-discovers `*.test.mjs`); pure functions + colocated tests, CLI guarded by the `import.meta.url === pathToFileURL(process.argv[1]).href` idiom.
+- **No concrete model names in `agents/`** — every agent frontmatter is exactly `model: inherit`. Concrete names (`opus`/`sonnet`/`haiku`) are forbidden in `agents/` only; skills may still pin a model (`figma-environment-setup` legitimately uses `model: haiku`).
+- **`agents/` is Claude-only** — the adapter generator (`scripts/adapters/read-sources.mjs`) reads only `skills/`, `commands/`, `.mcp.json`, `plugin.json`, so it never emits agents. Ships to Claude Code via the git marketplace `source: "./"`; the `npx` installer deliberately does not stamp it into non-Claude projects.
+- **Tier vocabulary is exactly `fast` < `balanced` < `deep`** — used verbatim in the reference and agent bodies.
+- **Drift guard must stay green** — after any `skills/` or `scripts/adapters/` edit, `node scripts/adapters/generate.mjs` regenerates `adapters/`, and `node scripts/adapters/generate.mjs --check` must pass (CI runs it).
+- **Canonical source files stay hand-edited** — `SKILL.md` etc. are canonical; `adapters/` is generated.
+
+---
+
+### Task 1: Agent frontmatter validator (the no-hardcoded-model guard)
+
+Adds a pure `validateAgent` to the existing skill/command validator and wires it into the CLI so CI fails if any agent pins a concrete model or omits required frontmatter. Written first so the guard exists before any agent file does.
+
+**Files:**
+- Modify: `ci/validate-skills.mjs` (add `validateAgent`, enumerate `agents/` in `main`)
+- Test: `ci/validate-skills.test.mjs` (add `validateAgent` cases)
+
+**Interfaces:**
+- Consumes: `parseFrontmatter` (already imported from `./lib/frontmatter.mjs`, returns `{ data }` and throws on malformed frontmatter); `isNonEmptyString` (module-local helper).
+- Produces: `validateAgent({ fileName, source }) -> string[]` — array of problem strings, empty when valid.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `ci/validate-skills.test.mjs`:
+
+```javascript
+import {
+  validateAgent,
+} from './validate-skills.mjs';
+
+function agentSource({ name = 'code-executor', description = 'an agent', model = 'inherit', extra = '' } = {}) {
+  return `---\nname: ${name}\ndescription: ${description}\nmodel: ${model}\n${extra}---\nbody\n`;
+}
+
+test('a well-formed agent produces no problems', () => {
+  assert.deepEqual(validateAgent({ fileName: 'code-executor.md', source: agentSource() }), []);
+});
+
+test('flags an agent that hardcodes a concrete model', () => {
+  const problems = validateAgent({ fileName: 'code-executor.md', source: agentSource({ model: 'opus' }) });
+  assert.ok(problems.some((p) => /model.*must be.*inherit/i.test(p)));
+});
+
+test('flags an agent missing the model field', () => {
+  const src = `---\nname: code-executor\ndescription: an agent\n---\nbody\n`;
+  const problems = validateAgent({ fileName: 'code-executor.md', source: src });
+  assert.ok(problems.some((p) => /model.*must be.*inherit/i.test(p)));
+});
+
+test('flags an agent missing a description', () => {
+  const src = `---\nname: code-executor\nmodel: inherit\n---\nbody\n`;
+  const problems = validateAgent({ fileName: 'code-executor.md', source: src });
+  assert.ok(problems.some((p) => /"description" is required/.test(p)));
+});
+
+test('flags an agent whose name does not match the file', () => {
+  const problems = validateAgent({ fileName: 'code-executor.md', source: agentSource({ name: 'other' }) });
+  assert.ok(problems.some((p) => /must equal the file name/.test(p)));
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `node --test ci/validate-skills.test.mjs`
+Expected: FAIL — `validateAgent` is not exported (`SyntaxError`/`undefined is not a function`).
+
+- [ ] **Step 3: Implement `validateAgent` and wire it into `main`**
+
+In `ci/validate-skills.mjs`, add after `validateCommand`:
+
+```javascript
+export function validateAgent({ fileName, source }) {
+  let data;
+  try {
+    ({ data } = parseFrontmatter(source));
+  } catch (err) {
+    return [`agents/${fileName}: ${err.message}`];
+  }
+  const problems = [];
+  const expectedName = fileName.replace(/\.md$/, '');
+  if (!isNonEmptyString(data.name)) {
+    problems.push(`agents/${fileName}: "name" is required`);
+  } else if (data.name !== expectedName) {
+    problems.push(`agents/${fileName}: "name" (${data.name}) must equal the file name (${expectedName})`);
+  }
+  if (!isNonEmptyString(data.description)) {
+    problems.push(`agents/${fileName}: "description" is required`);
+  }
+  if (data.model !== 'inherit') {
+    problems.push(`agents/${fileName}: "model" must be exactly "inherit" (agents never hardcode a concrete model)`);
+  }
+  return problems;
+}
+```
+
+In `main()`, after the commands loop and before the manifest-doc check, add:
+
+```javascript
+  const agentsDir = join(REPO_ROOT, 'agents');
+  let agentCount = 0;
+  if (existsSync(agentsDir)) {
+    const agentFiles = readdirSync(agentsDir).filter((f) => f.endsWith('.md'));
+    agentCount = agentFiles.length;
+    for (const fileName of agentFiles) {
+      problems.push(...validateAgent({ fileName, source: readFileSync(join(agentsDir, fileName), 'utf8') }));
+    }
+  }
+```
+
+Update the success log line to include agents:
+
+```javascript
+    console.log(`✓ ${skillDirs.length} skills, ${commandFiles.length} commands, ${agentCount} agents, manifest doc OK`);
+```
+
+(`existsSync`, `readdirSync`, `readFileSync`, `join` are already imported.)
+
+- [ ] **Step 4: Run tests + the CLI to verify they pass**
+
+Run: `node --test ci/validate-skills.test.mjs`
+Expected: PASS (all new cases green).
+Run: `node ci/validate-skills.mjs`
+Expected: PASS — prints `✓ N skills, N commands, 0 agents, manifest doc OK` (no `agents/` dir yet, so `existsSync` is false).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ci/validate-skills.mjs ci/validate-skills.test.mjs
+git commit -m "feat(ci): validate agents/ frontmatter, forbid hardcoded models"
+```
+
+---
+
+### Task 2: Routing reference `references/agent-routing.md`
+
+The portable tier system: the `fast < balanced < deep` ladder, recommended mapping, fallback, one-place override, role table, spec-completeness gate, escalation ladder, and the Figma-lane concurrency note. A light validator asserts it defines all three tiers (mirrors `validateManifestDoc`).
+
+**Files:**
+- Create: `references/agent-routing.md`
+- Modify: `ci/validate-skills.mjs` (add `validateAgentRouting`, call in `main`)
+- Test: `ci/validate-skills.test.mjs` (add `validateAgentRouting` cases)
+
+**Interfaces:**
+- Produces: `validateAgentRouting(source) -> string[]` — empty when the doc names all three tiers, else one problem string.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `ci/validate-skills.test.mjs`:
+
+```javascript
+import {
+  validateAgentRouting,
+} from './validate-skills.mjs';
+
+test('agent-routing doc naming all three tiers passes', () => {
+  const src = '# Routing\n\n- `fast` — cheapest\n- `balanced` — mid\n- `deep` — most capable\n';
+  assert.deepEqual(validateAgentRouting(src), []);
+});
+
+test('agent-routing doc missing a tier is flagged', () => {
+  const src = '# Routing\n\n- `fast`\n- `balanced`\n';
+  const problems = validateAgentRouting(src);
+  assert.ok(problems.some((p) => /deep/.test(p)));
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `node --test ci/validate-skills.test.mjs`
+Expected: FAIL — `validateAgentRouting` is not exported.
+
+- [ ] **Step 3: Implement `validateAgentRouting` and wire it in**
+
+In `ci/validate-skills.mjs`, add after `validateManifestDoc`:
+
+```javascript
+export function validateAgentRouting(source) {
+  const missing = ['fast', 'balanced', 'deep'].filter((tier) => !new RegExp(`\`${tier}\``).test(source));
+  if (missing.length) {
+    return [`references/agent-routing.md: must define tier(s): ${missing.join(', ')}`];
+  }
+  return [];
+}
+```
+
+In `main()`, after the agents loop, add (guarded so the check only runs once the file exists):
+
+```javascript
+  const routingPath = join(REPO_ROOT, 'references', 'agent-routing.md');
+  if (existsSync(routingPath)) {
+    problems.push(...validateAgentRouting(readFileSync(routingPath, 'utf8')));
+  }
+```
+
+- [ ] **Step 4: Create `references/agent-routing.md`**
+
+```markdown
+# Agent routing — choosing a model per subagent
+
+**Claude-only.** This reference governs subagent dispatch, a Claude Code
+capability. Hosts without subagent dispatch (Codex, generic AGENTS.md) run the
+work inline on their single model and ignore this file.
+
+## Why route
+
+Do the *thinking* on the best model and the *doing* on a cheap one. Deciding a
+component's variant matrix, token architecture, or adapter strategy is reasoning
+— it earns the best model. Running the resulting spec — transcribing code,
+placing Figma nodes, emitting adapter output — is mechanical, and a cheap model
+does it well **once the plan is complete**.
+
+## The tier ladder
+
+Relative, never a hardcoded model name — installers have different plans, so we
+name a *capability tier* and resolve it against the models actually available.
+
+- `fast` — cheapest/fastest tier. Transcription-grade work from a complete spec.
+- `balanced` — mid tier. Judgment, integration, review scaled to risk.
+- `deep` — most capable tier available. Planning, architecture, hard reasoning.
+
+### Recommended mapping (Anthropic)
+
+| Tier | Recommended model |
+|---|---|
+| `fast` | Haiku |
+| `balanced` | Sonnet |
+| `deep` | Opus (or the most capable model you have) |
+
+**Override in one place:** edit this table for your plan. Everything downstream
+reads tiers, not model names.
+
+### Resolution + fallback
+
+At dispatch, resolve the role's tier to a concrete model **from the models you
+actually have**, then pass it explicitly (an omitted model inherits the session
+model — often the most expensive — which defeats routing). If a tier's model is
+unavailable, **collapse to the nearest lower tier you have**; `deep` always maps
+to the most capable model available. An installer with only one model degrades
+to that model everywhere — routing becomes a no-op, never a failure.
+
+## Roles → tiers
+
+| Agent | Tier | Concurrency | Role |
+|---|---|---|---|
+| `code-executor` | `fast` | parallel-safe | Transcribe code/adapter output from a complete spec; verify its own build. |
+| `reviewer` | `balanced` (scale to risk) | parallel-safe | Spec-compliance + quality gate; code-diff or Figma-visual mode. |
+| `architect` *(Phase 2)* | `deep` | 1 | Plan a stage; emit a transcription-grade spec in stable identifiers. |
+| `figma-executor` *(Phase 2)* | `fast`→`balanced` | **1 (bridge-locked)** | Run the architect's Figma script; screenshot-verify; finalize a named frame. |
+
+## The spec-completeness gate
+
+Dispatch an executor on `fast` **only when the spec is transcription-grade** —
+complete enough that execution is copying, not deciding. Turn count beats token
+price: a cheap model on a vague task takes 2–3× the turns and costs more. If the
+spec is incomplete, run the work inline on the stronger model instead.
+
+## Escalation
+
+A `BLOCKED` executor is re-dispatched **one tier up**, never the same model
+unchanged. If still blocked at `deep`, escalate to the human.
+
+## Concurrency
+
+Code-gen roles are parallel-safe. Figma work is **not**: the figma-console
+bridge is a single live connection with global selection/current-page state, so
+the entire Figma surface is concurrency-1 (Phase 2). Route Figma work through
+sequential subagents — model routing yes, parallelism never.
+```
+
+- [ ] **Step 5: Run the validator + tests to verify they pass**
+
+Run: `node --test ci/validate-skills.test.mjs`
+Expected: PASS.
+Run: `node ci/validate-skills.mjs`
+Expected: PASS — `agent-routing.md` names all three tiers.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add references/agent-routing.md ci/validate-skills.mjs ci/validate-skills.test.mjs
+git commit -m "feat(routing): add agent-routing tier reference + validator"
+```
+
+---
+
+### Task 3: Agent definitions (`code-executor`, `reviewer`)
+
+The two reusable Claude-only role agents this phase dispatches. Frontmatter is `model: inherit`; the body carries the tier, the verification contract, and a pointer to `agent-routing.md` for resolution. No domain logic lives here (that stays in skills), so these do not rot when skills improve.
+
+**Files:**
+- Create: `agents/code-executor.md`
+- Create: `agents/reviewer.md`
+
+**Interfaces:**
+- Consumes: the tier system in `references/agent-routing.md` (Task 2).
+- Produces: subagent types `code-executor` and `reviewer`, dispatchable by name (Task 4 references them).
+
+- [ ] **Step 1: Create `agents/code-executor.md`**
+
+```markdown
+---
+name: code-executor
+description: Transcribes code or generated output from a complete, transcription-grade spec and verifies its own build. Dispatched on the fast tier for mechanical, parallel-safe code-gen (per-adapter token output, per-component stories, SVGR transforms). Not for planning or design decisions — those belong to the dispatcher or the architect.
+model: inherit
+tools: Read, Write, Edit, Bash
+---
+
+# code-executor
+
+**Tier:** `fast` (see `${CLAUDE_PLUGIN_ROOT}/references/agent-routing.md`). **Concurrency:** parallel-safe.
+
+You receive a complete spec and produce exactly what it describes — no design
+decisions. If the spec is ambiguous or underspecified, do not guess: return
+`BLOCKED` naming the gap (the dispatcher will re-plan or escalate a tier up).
+
+## Contract
+
+1. Read the spec and the files it names.
+2. Produce the files the spec specifies, following existing repo patterns.
+3. **Verify your own work** — run the build/test the spec names and confirm the
+   expected artifacts appear (for token adapters: the config builds, expected
+   files exist, references resolve for web / flatten for native).
+4. Return a concise result: files written, verification command + outcome, and
+   one of `DONE` / `DONE_WITH_CONCERNS` / `BLOCKED`. Your final message IS the
+   return value — return data, not prose for a human.
+
+Never expand scope beyond the spec. Never mark `DONE` without running the
+verification step.
+```
+
+- [ ] **Step 2: Create `agents/reviewer.md`**
+
+```markdown
+---
+name: reviewer
+description: Reviews a completed unit of work for spec compliance and quality before it is combined or landed. Two modes — code-diff review (a git diff) and Figma-visual review (screenshot then analyze). Dispatched on the balanced tier, scaled to the diff's risk. Reports a verdict; does not fix.
+model: inherit
+tools: Read, Bash
+---
+
+# reviewer
+
+**Tier:** `balanced`, scaled to risk (see `${CLAUDE_PLUGIN_ROOT}/references/agent-routing.md`). **Concurrency:** parallel-safe.
+
+Review the unit you are given against its spec. Report; do not edit.
+
+## Mode: code-diff
+
+Given a spec and a diff:
+1. **Spec compliance** — does the diff do what the spec requires, and only that?
+2. **Quality** — correctness, DRY, repo conventions, dead code, tests that
+   assert something real.
+Return: `spec: ✅/❌ <reason>`, then quality findings ranked most-severe first,
+then an overall `approved` / `changes-requested`. Flag anything you cannot
+verify from the diff alone as `⚠️ cannot verify` — do not block on it; the
+dispatcher holds the cross-task context to resolve it.
+
+## Mode: Figma-visual *(exercised in Phase 2)*
+
+Figma work has no diff. Screenshot the result, then analyze alignment, spacing,
+proportions, and binding to tokens against the spec; report the same
+`approved` / `changes-requested` verdict. (Phase 2 wires the screenshot tools.)
+```
+
+- [ ] **Step 3: Verify the agents pass validation and break nothing**
+
+Run: `node ci/validate-skills.mjs`
+Expected: PASS — `✓ N skills, N commands, 2 agents, ...` (both agents valid, `model: inherit`).
+Run: `node --test`
+Expected: PASS — full suite still green.
+Run: `node scripts/adapters/generate.mjs --check`
+Expected: PASS — `agents/` is not read by the generator, so adapters are unchanged (no drift).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add agents/code-executor.md agents/reviewer.md
+git commit -m "feat(agents): add code-executor and reviewer role agents"
+```
+
+---
+
+### Task 4: Migrate `token-sync-layer` dispatch + regenerate adapters
+
+Rewrites the skill's execution-model paragraph to dispatch the new agents via the routing reference, authored as a **self-degrading conditional** so the generated Codex/generic prompts fall back to inline execution without a phrasing-map rule. Then regenerates adapters so the drift guard stays green, and spot-checks that the Codex prompt degraded correctly.
+
+**Files:**
+- Modify: `skills/token-sync-layer/SKILL.md:147-153` (the execution-model paragraph)
+- Modify (generated): `adapters/**` (regenerated, committed)
+- Test: `scripts/adapters/generate.test.mjs` (add a degradation spot-check for token-sync-layer)
+
+**Interfaces:**
+- Consumes: `code-executor`, `reviewer` (Task 3), `references/agent-routing.md` (Task 2).
+- Produces: canonical dispatch wording that the generator translates verbatim (agent names aren't `` `X` skill``, so the phrasing map leaves them alone; the text names no Claude-only product, so the `Claude Code`→target rule can't corrupt it).
+
+- [ ] **Step 1: Add the failing degradation spot-check**
+
+In `scripts/adapters/generate.test.mjs`, reuse the module-level `result = generate(readSources(REPO_ROOT))` that the file already defines. `generate()` returns `{ cursor, codex, generic }` (keyed by target; each file has `.path` and `.content` — note: `content`, not `contents`, and there is no `.target` field). Add:
+
+```javascript
+test('token-sync-layer dispatch degrades to inline for codex', () => {
+  const prompt = result.codex.find((f) => /token-sync-layer/.test(f.path));
+  assert.ok(prompt, 'expected a codex token-sync-layer prompt');
+  assert.match(prompt.content, /no subagent dispatch, generate and verify each adapter inline/);
+  assert.match(prompt.content, /\.throughline\/references\/agent-routing\.md/);
+  assert.doesNotMatch(prompt.content, /CLAUDE_PLUGIN_ROOT/);
+});
+```
+
+(Verified against the file: `result`, `REPO_ROOT`, `OUT_ROOT` are module-level; `readSources`/`generate` are already imported; the drift test uses `f.content` and `f.path`.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `node --test scripts/adapters/generate.test.mjs`
+Expected: FAIL — the skill still says "one subagent per adapter" and the codex prompt lacks the inline-fallback phrase.
+
+- [ ] **Step 3: Rewrite the skill's execution-model paragraph**
+
+In `skills/token-sync-layer/SKILL.md`, replace this exact block (lines 147–153):
+
+```
+**Execution model — subagent-driven for multiple platforms.** When more than one
+platform is targeted, generating each platform's output is independent and
+verifiable, so dispatch **one subagent per adapter**: each produces its
+platform's files and verifies them (the config builds, the expected files
+appear, references resolve correctly for web / flatten for native). Review each
+before combining. For a single platform, run inline. (See the selective-
+subagent decision: code-gen skills parallelize; Figma-authoring skills don't.)
+```
+
+with:
+
+```
+**Execution model — subagent dispatch with model routing.** Generating each
+platform's output is independent and verifiable. If your host supports subagent
+dispatch, dispatch **one `code-executor` per adapter** — each produces its
+platform's files and verifies them (the config builds, the expected files
+appear, references resolve for web / flatten for native) — then a **`reviewer`**
+to check each before combining. Choose each subagent's model from its role tier
+per `${CLAUDE_PLUGIN_ROOT}/references/agent-routing.md` (`code-executor` → fast,
+`reviewer` → balanced), and only dispatch once each adapter's spec is complete
+enough to transcribe. If your host has no subagent dispatch, generate and verify
+each adapter inline instead. For a single platform, run inline either way. This
+is a code-gen stage, so these subagents may run in parallel — unlike Figma
+authoring, which is always sequential.
+```
+
+- [ ] **Step 4: Regenerate adapters**
+
+Run: `node scripts/adapters/generate.mjs`
+Expected: rewrites files under `adapters/` (cursor/codex/generic token-sync-layer).
+
+- [ ] **Step 5: Run the full verification set**
+
+Run: `node --test`
+Expected: PASS — including the new degradation spot-check.
+Run: `node scripts/adapters/generate.mjs --check`
+Expected: PASS — committed adapters now match freshly generated output.
+Run: `node ci/validate-skills.mjs`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add skills/token-sync-layer/SKILL.md adapters scripts/adapters/generate.test.mjs
+git commit -m "feat(token-sync): dispatch code-executor/reviewer with tier routing"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (Phase 1 scope of `2026-07-04-subagent-driven-model-routing-design.md`):**
+- Cognition-split agents (`code-executor`, `reviewer`) → Task 3. (`architect`/`figma-executor` are explicitly Phase 2 per the spec's Phasing section.)
+- Relative tiers, `model: inherit`, resolve-at-dispatch, fallback, one-place override → `agent-routing.md` (Task 2) + validator (Task 1).
+- Spec-completeness gate → documented in `agent-routing.md` and referenced in the migrated skill (Tasks 2, 4).
+- Escalation ladder → `agent-routing.md` + `code-executor` `BLOCKED` contract (Tasks 2, 3).
+- Cross-host degradation (agents Claude-only; dispatch degrades to inline) → generator ignores `agents/` (Global Constraints) + self-degrading skill wording + codex spot-check (Task 4).
+- No-hardcoded-model test → Task 1.
+- Reviewer two modes → `reviewer.md` (Task 3); visual mode exercised in Phase 2.
+- Figma-lane lock, named working frame, screenshot-verify → **deferred to Phase 2** (noted, not a gap).
+- Observability → non-goal (not implemented, per spec).
+
+**Placeholder scan:** No TBD/TODO; every code and prose artifact is written in full. The one conditional instruction (Task 4 Step 1's note about `generate.test.mjs` imports) directs the implementer to match existing conventions and is a real safeguard, not a placeholder.
+
+**Type consistency:** `validateAgent({ fileName, source })` and `validateAgentRouting(source)` are defined in Task 1/2 and consumed by the same test files; `code-executor`/`reviewer` names are used identically in `agents/`, `agent-routing.md`, and the migrated skill; tier tokens are exactly `fast`/`balanced`/`deep` throughout.
+
+## Execution Notes
+
+- Task order is dependency-correct: the guard (1) precedes the reference (2) precedes the agents it validates (3) precedes the skill that dispatches them (4).
+- After Task 4, dogfood manually (out of automated scope): run `/sync-figma-tokens` against a multi-adapter system and confirm the orchestrator dispatches a `code-executor` per adapter on the fast tier and a `reviewer` on balanced — the real proof the routing works end to end.

--- a/docs/superpowers/plans/2026-07-05-subagent-routing-phase2-figma-handoff.md
+++ b/docs/superpowers/plans/2026-07-05-subagent-routing-phase2-figma-handoff.md
@@ -1,0 +1,58 @@
+# Subagent routing — Phase 2 (Figma path) handoff
+
+> **For the next session.** This is a handoff, not a plan. Read it, then read the
+> two source docs below, then start the Phase 2 spec→plan→build cycle. You have
+> zero context from the session that wrote this — everything you need is here or
+> linked.
+
+## How to start
+
+1. Read the parent spec: `docs/superpowers/specs/2026-07-04-subagent-driven-model-routing-design.md` — especially **Decisions 4–7** (Figma-lane lock, named working frame, two-mode reviewer, human gates) and the **Phasing → Phase 2** section. That spec is the design of record; this handoff does not restate it.
+2. Read the Phase 1 plan for the conventions Phase 2 must match: `docs/superpowers/plans/2026-07-04-subagent-routing-phase1-token-sync.md`.
+3. The Figma-specific mechanics below (named-frame protocol, screenshot-verify loop, name→nodeId resolution) were designed only to the *principle* level in the spec. **Brainstorm those into a concrete design first** (superpowers:brainstorming), then write the Phase 2 plan (superpowers:writing-plans), then execute it (superpowers:subagent-driven-development). Do not skip the brainstorm — Phase 2's risk lives in these mechanics, not in the routing (Phase 1 proved the routing).
+
+## What Phase 1 already established (merged, on `main`)
+
+Reuse these verbatim — do not reinvent them:
+
+- **`agents/` directory, Claude-only.** Two role agents exist: `agents/code-executor.md` (fast, parallel-safe) and `agents/reviewer.md` (balanced; already carries a **Figma-visual mode stub** awaiting Phase 2 tool-wiring). Every agent is `model: inherit`.
+- **`references/agent-routing.md`** — the `fast < balanced < deep` tier ladder, resolution/fallback, override, spec-completeness gate, escalation ladder, and Figma-lane concurrency note. Its roles table **already lists `architect` and `figma-executor` as Phase-2 rows** — flesh out their contracts, don't add new tiers.
+- **CI guard:** `ci/validate-skills.mjs` `validateAgent` fails CI on any `agents/*.md` that isn't `model: inherit`. New Phase 2 agents must satisfy it. `validateAgentRouting` checks the reference names all three tiers.
+- **Cross-host degradation = self-degrading conditional prose**, NOT phrasing-map entries. When you migrate a skill's dispatch, author it as *"if your host supports subagent dispatch, dispatch X per `agent-routing.md`; otherwise do the work inline"* and name **no Claude-only product** (so the `Claude Code`→target phrasing rule can't corrupt it). This is the proven, generator-safe idiom from `token-sync-layer` Step 3 — copy it.
+- **Adapter drift guard:** any `skills/*/SKILL.md` edit requires `node scripts/adapters/generate.mjs` then commit; CI runs `--check`. `agents/` is not read by the generator (no drift from adding agents).
+
+## Phase 2 goal
+
+Prove "plan deep, build cheap" on the **Figma surface** — the novel, risky core. Introduce the planner/executor split for Figma authoring and migrate the first Figma-authoring skills onto it.
+
+## What Phase 2 must build (from the spec, Phase 2 row)
+
+- **`agents/architect.md`** — `deep` tier, concurrency 1. Plans a stage (Figma variant matrix, token architecture, slot contract, adapter strategy) and emits a **transcription-grade spec in stable identifiers** (component/page/token *names*, never nodeIds).
+- **`agents/figma-executor.md`** — `fast`→`balanced`, concurrency **1 (bridge-locked)**. Resolves names→nodeIds at run time, builds, screenshot-verifies, finalizes.
+- **Reviewer visual mode** — wire the Figma screenshot tools into `agents/reviewer.md`'s existing Figma-visual stub.
+- **Migrate the first Figma-authoring skills** from "no subagents" to the architect→figma-executor split (sequential, routing yes / parallel never): start with **`component-builder`**, then **`token-builder`**. `token-sheet-builder` can follow or defer.
+- **Reframe `references/sync-adapters.md`** — its "Figma-authoring skills don't parallelize" line becomes "Figma work uses sequential subagents — routing yes, parallel never."
+
+## The hard Figma-specific design points — get these right (brainstorm targets)
+
+1. **Single stateful bridge = whole-surface serialization.** The figma-console MCP is one live connection with global selection/current-page state. Concurrency 1 applies to the **entire Figma lane** — architect-reading-Figma, figma-executor-writing, and visual-review-screenshotting all share the one bridge and must serialize. Decide *how the orchestrator enforces* this (never two Figma-touching subagents live at once).
+2. **nodeIds are session-specific and go stale.** The architect's spec MUST address elements by stable name; the figma-executor re-searches (`figma_search_components` / find-by-name) to resolve at run time. Design the handoff format.
+3. **No git for Figma → partial-failure recovery.** A dead figma-executor leaves a half-built component. Design chosen in the spec: **build into a clearly-named working frame, screenshot-verify, finalize/rename only on success** — so a failure leaves an obvious, named, resumable artifact. Nail down the exact protocol (naming, verify criteria, finalize/swap step).
+4. **Screenshot-verify loop.** The MCP mandates create → screenshot → analyze → iterate (max ~3). Decide how the figma-executor self-verifies vs. what the visual `reviewer` re-checks, to avoid double work.
+5. **Tool grants.** figma-executor and reviewer-visual need the figma-console MCP tools (execute, screenshot, search). Decide the minimal `tools:` list per agent.
+
+## Environment dependency
+
+Phase 2 cannot be built or dogfooded without the **Figma Console MCP bridge connected** (the desktop plugin running). Run `throughline:figma-environment-setup` / confirm `figma_get_status` before any Figma dispatch. (Note: the bridge was connected during Phase 1's design session but is not a given in a fresh session.)
+
+## Verification (same gates as Phase 1)
+
+- `node --test` → all green (Phase 1 baseline: 120 passing)
+- `node scripts/adapters/generate.mjs --check` → adapters in sync
+- `node ci/validate-skills.mjs` → skills + commands + agents OK (new agents must pass `validateAgent`)
+- `node ci/validate-plugin.mjs` → OK
+- **Dogfood:** with the bridge connected, build one real component through the migrated `component-builder` and confirm the architect dispatches on `deep`, the figma-executor on a cheaper tier, the Figma lane never runs two subagents at once, and a forced failure leaves a named working frame.
+
+## Deferred beyond Phase 2 (Phase 3)
+
+Generalize the proven pattern to the remaining subagent-driven skills: `storybook-chromatic-builder`, `icon-system-builder`, `token-sheet-builder`, and the `component-pipeline` sequencer. Not Phase 2's problem.

--- a/docs/superpowers/specs/2026-07-04-subagent-driven-model-routing-design.md
+++ b/docs/superpowers/specs/2026-07-04-subagent-driven-model-routing-design.md
@@ -144,6 +144,34 @@ Adopt the architect/executor split and reference `agent-routing.md`:
 `references/sync-adapters.md`'s "Figma-authoring skills don't parallelize"
 becomes **"Figma work uses sequential subagents — routing yes, parallel never."**
 
+## Phasing
+
+Prove the mechanism on one skill before touching the rest.
+
+- **Phase 1 — pilot on `token-sync-layer`.** It is already subagent-driven
+  (per-adapter) and lands a reviewable PR by its own rules, so the migration is
+  small and gives a real end-to-end signal. This phase builds the **shared**
+  machinery: `agents/code-executor.md` + `agents/reviewer.md`,
+  `references/agent-routing.md` (ladder, resolution, fallback, override,
+  escalation), the no-hardcoded-model check in `validate-plugin.mjs`, and the
+  Codex/generic degradation (conditional dispatch phrasing + phrasing-map
+  entries). Per-adapter generation → `code-executor` (fast tier); two-stage
+  review → `reviewer` (balanced). Planning stays inline on the orchestrator here
+  — the adapter strategy is preset-driven, so no separate `architect` yet.
+
+- **Phase 2 — Figma path via `component-builder`.** Introduces `architect`
+  (deep) and `figma-executor`, the stable-identifier handoff, the Figma-lane
+  bridge lock, the named-working-frame + screenshot-verify, and the reviewer's
+  visual mode. This is where "plan deep, build cheap" gets proven on Figma.
+
+- **Phase 3 — generalize.** Roll the proven pattern into the remaining skills:
+  `storybook-chromatic-builder`, `icon-system-builder`, `token-builder`,
+  `token-sheet-builder`, and the `component-pipeline` sequencer; reframe
+  `references/sync-adapters.md`.
+
+Each phase is its own spec → plan → implementation cycle. **This plan covers
+Phase 1 only.**
+
 ## Non-goals
 
 - Routing observability / telemetry (deferred).

--- a/docs/superpowers/specs/2026-07-04-subagent-driven-model-routing-design.md
+++ b/docs/superpowers/specs/2026-07-04-subagent-driven-model-routing-design.md
@@ -91,9 +91,11 @@ plan, the cheaper execution is *allowed* to be.
    translated to Codex/generic prompts, where subagents don't exist. So dispatch
    is authored to **degrade to inline single-model execution**: each dispatch
    site reads *"if your host supports subagent dispatch, route per
-   `agent-routing.md`; otherwise run inline,"* and the phrasing map neutralizes
-   dispatch idioms for non-Claude targets. `agent-routing.md` states its
-   Claude-specificity.
+   `agent-routing.md`; otherwise run inline."* `agent-routing.md` states its
+   Claude-specificity. **(Implemented as:** self-degrading conditional prose —
+   the else-branch governs on non-Claude hosts and the wording names no
+   Claude-only product, so no phrasing-map entry is needed. Phase 2/3 skills
+   reuse this exact conditional idiom rather than adding phrasing-map rules.)
 
 10. **Observability deferred.** A per-tier "who ran what" log to *prove* savings
     is a conscious v1 non-goal.
@@ -153,9 +155,9 @@ Prove the mechanism on one skill before touching the rest.
   small and gives a real end-to-end signal. This phase builds the **shared**
   machinery: `agents/code-executor.md` + `agents/reviewer.md`,
   `references/agent-routing.md` (ladder, resolution, fallback, override,
-  escalation), the no-hardcoded-model check in `validate-plugin.mjs`, and the
-  Codex/generic degradation (conditional dispatch phrasing + phrasing-map
-  entries). Per-adapter generation → `code-executor` (fast tier); two-stage
+  escalation), the no-hardcoded-model check in `ci/validate-skills.mjs`, and the
+  Codex/generic degradation (self-degrading conditional dispatch prose — no
+  phrasing-map entry needed). Per-adapter generation → `code-executor` (fast tier); two-stage
   review → `reviewer` (balanced). Planning stays inline on the orchestrator here
   — the adapter strategy is preset-driven, so no separate `architect` yet.
 
@@ -184,10 +186,12 @@ Phase 1 only.**
 
 - **Generator drift** — `generate.mjs --check` still passes with `agents/`
   present (agents are ignored, not emitted).
-- **No hardcoded models** — extend `scripts/validate-plugin.mjs` to assert every
-  `agents/*.md` frontmatter is `model: inherit` (fail on a concrete model name).
-- **Phrasing map** — `generate.test.mjs` covers the new dispatch-idiom → inline
-  substitutions for Codex/generic.
+- **No hardcoded models** — extend `ci/validate-skills.mjs` (`validateAgent`) to
+  assert every `agents/*.md` frontmatter is `model: inherit` (fail on a concrete
+  model name), scoped to `agents/` only so skills may still pin a model.
+- **Degradation** — `generate.test.mjs` spot-checks that the generated Codex
+  `token-sync-layer` prompt carries the inline-fallback branch and the rewritten
+  `.throughline/references/agent-routing.md` path with no `CLAUDE_PLUGIN_ROOT` leak.
 - **Dogfood** — run `component-pipeline` end-to-end; confirm the architect
   dispatches on the deep tier and executors on a cheaper tier, and that a Figma
   executor failure leaves a named working frame.

--- a/docs/superpowers/specs/2026-07-04-subagent-driven-model-routing-design.md
+++ b/docs/superpowers/specs/2026-07-04-subagent-driven-model-routing-design.md
@@ -1,0 +1,176 @@
+# Subagent-driven development & model-tier routing — design
+
+**Date:** 2026-07-04
+**Status:** Approved (design), pending implementation plan
+
+> **Terminology.** In this repo, *"multi-agent"* already means **multi-host** —
+> the Cursor/Codex/generic adapters (see `2026-07-02-multi-agent-adapters-design.md`).
+> This spec is about **subagents**: Claude Code `Task`-dispatched workers running
+> on a chosen model tier. Different axis, deliberately different word.
+
+## Problem
+
+Several skills already dispatch subagents — `storybook-chromatic-builder`
+(one per component for stories), `token-sync-layer` (one per adapter),
+`icon-system-builder`, and `component-pipeline` sequences them — but they do it
+**informally and never name a model.** An omitted model inherits the session's
+model, "often the most capable and most expensive, which silently defeats"
+cost control (the superpowers subagent-driven-development principle). Meanwhile
+the Figma-authoring skills say *"no subagents"* outright.
+
+The goal is **model/cost routing**: do the *thinking* on the best model and the
+*doing* on a cheap one — without pinning concrete model names (the plugin is
+installed by others whose available tiers differ), and without breaking the
+non-Claude host adapters that can't dispatch subagents at all.
+
+## The core idea: route by cognition, not by domain
+
+The wrong axis is *Figma vs. code*. The right axis is **decide vs. do**:
+
+- **Deciding** — the variant matrix, token architecture, slot contract, adapter
+  strategy, naming — is reasoning. Best model. Short and expensive.
+- **Doing** — running `figma_execute` to place nodes, transcribing component
+  code, SVGR transforms, adapter output — is mechanical. Cheap model. Long.
+
+Figma authoring, *once planned*, is mechanical. So a Figma stage only touches
+the best model for its short planning slice. This is the superpowers lever:
+**"when the task's plan text contains the complete code to write, the
+implementation is transcription — use the cheapest tier."** The better the
+plan, the cheaper execution is *allowed* to be.
+
+## Decisions
+
+1. **Cognition split.** An `architect` (deep tier) plans any stage and emits a
+   transcription-grade spec; executors (fast→balanced) carry it out; a
+   `reviewer` (balanced) gates. Planning is deep **by construction** — an
+   explicit deep-tier dispatch, never left to the session default — so the
+   "plan is always the better model" invariant holds even on a cheap session.
+
+2. **Relative tiers, never hardcoded models** (portability). `model:` frontmatter
+   only accepts concrete names or `inherit`; there is no "cheapest available"
+   token. So every agent is **`model: inherit`**, and `references/agent-routing.md`
+   holds a *relative ladder* (`fast < balanced < deep`) with a recommended
+   Anthropic mapping and explicit fallback: **a missing tier collapses to the
+   nearest lower tier the installer has; `deep` = the most capable available.**
+   The live orchestrator resolves tier→model at dispatch against the models it
+   actually has and passes an explicit `model`. One installer edits one table.
+
+3. **Spec-completeness gate** (the money-saver). An executor is dispatched on a
+   cheap tier **only when the spec is transcription-grade**; otherwise the work
+   runs inline on the stronger model. Rationale: *turn count beats token price* —
+   a cheap model on a vague task takes 2–3× the turns and costs more. Incomplete
+   plan ⇒ the optimization inverts, so the gate protects it.
+
+4. **Figma-lane lock.** The figma-console bridge is one live connection with
+   global selection/current-page state. The **entire Figma surface is
+   concurrency-1** — architect-reading-Figma, `figma-executor`, and visual
+   review all serialize through the one bridge. A preflight `figma_get_status`
+   (reconnect if needed) precedes any Figma dispatch; the bridge can be down.
+
+5. **Figma partial-failure = named working frame.** Figma writes aren't
+   git-committable, so a dead executor would leave a half-built component. The
+   `figma-executor` **builds into a clearly-named working frame, screenshot-
+   verifies, and finalizes/renames only on success.** A failure leaves an
+   obvious, named, resumable artifact instead of corrupting the real component.
+
+6. **Reviewer has two modes.** Code work reviews a **git diff**; Figma work has
+   no diff — its review is **screenshot → analyze → iterate** (mandated by the
+   MCP). `reviewer` carries both a code-diff mode and a Figma-visual mode.
+
+7. **Human gates vs. continuous execution.** `component-pipeline` confirms with
+   the human *between* stages; subagent-driven execution *never pauses* within a
+   task. Reconciliation: **the orchestrator keeps its human gates BETWEEN
+   stages; subagents run continuously WITHIN a stage.**
+
+8. **Escalate, don't retry.** A `BLOCKED` executor is re-dispatched **one tier
+   up**, never the same model unchanged.
+
+9. **Cross-host degradation.** `agents/` is **Claude-only** — the adapter
+   generator (`read-sources.mjs`) reads only `skills/`, `commands/`, `.mcp.json`,
+   `plugin.json`, so it ignores `agents/` cleanly. But skill *bodies* get
+   translated to Codex/generic prompts, where subagents don't exist. So dispatch
+   is authored to **degrade to inline single-model execution**: each dispatch
+   site reads *"if your host supports subagent dispatch, route per
+   `agent-routing.md`; otherwise run inline,"* and the phrasing map neutralizes
+   dispatch idioms for non-Claude targets. `agent-routing.md` states its
+   Claude-specificity.
+
+10. **Observability deferred.** A per-tier "who ran what" log to *prove* savings
+    is a conscious v1 non-goal.
+
+## Architecture
+
+### New: `agents/` (Claude-native)
+
+Four role agents, each `model: inherit`, tools scoped to their surface, body
+carrying the role contract + verification — **not** domain logic (that stays in
+the skills, so agents don't rot when skills improve):
+
+| Agent | Tier | Concurrency | Job |
+|---|---|---|---|
+| `architect` | deep | 1 | Plans any stage (Figma variant matrix, token architecture, slot contract, adapter strategy). Emits a spec in **stable identifiers** (component/page/token *names*, never nodeIds). |
+| `figma-executor` | fast→balanced | **1 (bridge-locked)** | Resolves names→nodeIds at run time, builds into a named working frame, screenshot-verifies, finalizes on success. |
+| `code-executor` | fast→balanced | parallel-safe | Transcribes component code / stories / adapter output from spec; verifies its own build. |
+| `reviewer` | balanced (scaled to risk) | parallel-safe | Code-diff review *or* Figma-visual review. |
+
+### The handoff contract (architect → executor)
+
+The architect's spec is addressed in **stable identifiers only** — nodeIds are
+session-specific and go stale. The `figma-executor` **re-searches** to resolve
+names→nodeIds at run time. This is what makes a spec survive a session roll.
+
+### New: `references/agent-routing.md` (Claude-specific)
+
+The single source for: the `fast < balanced < deep` ladder, the recommended
+Anthropic mapping, the fallback algorithm, the one-place installer override, the
+concurrency policy (Figma-lane lock), the spec-completeness gate, and the
+escalation ladder.
+
+### Skill migrations
+
+Adopt the architect/executor split and reference `agent-routing.md`:
+
+- `storybook-chromatic-builder` (Step 3 story-gen) — already subagent-driven;
+  add tier naming + code-executor + reviewer.
+- `token-sync-layer` (per-adapter) — already subagent-driven; add tiers.
+- `icon-system-builder` (SVGR pass) — mechanical → fast tier.
+- `component-builder`, `token-builder`, `token-sheet-builder` — reframe from
+  *"no subagents"* to **sequential subagents for routing** (architect plans deep,
+  figma-executor builds cheap; never parallel).
+- `component-pipeline` — unchanged sequencer; keeps human gates between stages.
+
+### Reference reframing
+
+`references/sync-adapters.md`'s "Figma-authoring skills don't parallelize"
+becomes **"Figma work uses sequential subagents — routing yes, parallel never."**
+
+## Non-goals
+
+- Routing observability / telemetry (deferred).
+- A top-level "conductor" agent (fights `component-pipeline`'s human gates).
+- Parallel Figma execution (the bridge forbids it).
+- New host targets or changes to the human-gate UX.
+- Hardcoding any concrete model name anywhere.
+
+## Testing
+
+- **Generator drift** — `generate.mjs --check` still passes with `agents/`
+  present (agents are ignored, not emitted).
+- **No hardcoded models** — extend `scripts/validate-plugin.mjs` to assert every
+  `agents/*.md` frontmatter is `model: inherit` (fail on a concrete model name).
+- **Phrasing map** — `generate.test.mjs` covers the new dispatch-idiom → inline
+  substitutions for Codex/generic.
+- **Dogfood** — run `component-pipeline` end-to-end; confirm the architect
+  dispatches on the deep tier and executors on a cheaper tier, and that a Figma
+  executor failure leaves a named working frame.
+
+## Risks / open items
+
+- **Agent/skill drift.** Agents duplicating skill logic would rot. Mitigation:
+  agents hold *role + verification contract only*; domain logic stays in skills.
+- **Resolution depends on the orchestrator honoring the reference** — the same
+  reliance superpowers accepts; the routing reference is prescriptive prose, not
+  an enforced mechanism.
+- **Bridge disconnect mid-flow** — the preflight `figma_get_status` check is the
+  guard; a mid-stage drop still surfaces as a `figma-executor` failure with a
+  resumable named frame.

--- a/references/agent-routing.md
+++ b/references/agent-routing.md
@@ -1,0 +1,70 @@
+# Agent routing — choosing a model per subagent
+
+**Claude-only.** This reference governs subagent dispatch, a Claude Code
+capability. Hosts without subagent dispatch (Codex, generic AGENTS.md) run the
+work inline on their single model and ignore this file.
+
+## Why route
+
+Do the *thinking* on the best model and the *doing* on a cheap one. Deciding a
+component's variant matrix, token architecture, or adapter strategy is reasoning
+— it earns the best model. Running the resulting spec — transcribing code,
+placing Figma nodes, emitting adapter output — is mechanical, and a cheap model
+does it well **once the plan is complete**.
+
+## The tier ladder
+
+Relative, never a hardcoded model name — installers have different plans, so we
+name a *capability tier* and resolve it against the models actually available.
+
+- `fast` — cheapest/fastest tier. Transcription-grade work from a complete spec.
+- `balanced` — mid tier. Judgment, integration, review scaled to risk.
+- `deep` — most capable tier available. Planning, architecture, hard reasoning.
+
+### Recommended mapping (Anthropic)
+
+| Tier | Recommended model |
+|---|---|
+| `fast` | Haiku |
+| `balanced` | Sonnet |
+| `deep` | Opus (or the most capable model you have) |
+
+**Override in one place:** edit this table for your plan. Everything downstream
+reads tiers, not model names.
+
+### Resolution + fallback
+
+At dispatch, resolve the role's tier to a concrete model **from the models you
+actually have**, then pass it explicitly (an omitted model inherits the session
+model — often the most expensive — which defeats routing). If a tier's model is
+unavailable, **collapse to the nearest lower tier you have**; `deep` always maps
+to the most capable model available. An installer with only one model degrades
+to that model everywhere — routing becomes a no-op, never a failure.
+
+## Roles → tiers
+
+| Agent | Tier | Concurrency | Role |
+|---|---|---|---|
+| `code-executor` | `fast` | parallel-safe | Transcribe code/adapter output from a complete spec; verify its own build. |
+| `reviewer` | `balanced` (scale to risk) | parallel-safe | Spec-compliance + quality gate; code-diff or Figma-visual mode. |
+| `architect` *(Phase 2)* | `deep` | 1 | Plan a stage; emit a transcription-grade spec in stable identifiers. |
+| `figma-executor` *(Phase 2)* | `fast`→`balanced` | **1 (bridge-locked)** | Run the architect's Figma script; screenshot-verify; finalize a named frame. |
+
+## The spec-completeness gate
+
+Dispatch an executor on `fast` **only when the spec is transcription-grade** —
+complete enough that execution is copying, not deciding. Turn count beats token
+price: a cheap model on a vague task takes 2–3× the turns and costs more. If the
+spec is incomplete, run the work inline on the stronger model instead.
+
+## Escalation
+
+A `BLOCKED` executor is re-dispatched **one tier up**, never the same model
+unchanged. If still blocked at `deep`, escalate to the human.
+
+## Concurrency
+
+Code-gen roles are parallel-safe. Figma work is **not**: the figma-console
+bridge is a single live connection with global selection/current-page state, so
+the entire Figma surface is concurrency-1 (Phase 2). Route Figma work through
+sequential subagents — model routing yes, parallelism never.

--- a/scripts/adapters/generate.test.mjs
+++ b/scripts/adapters/generate.test.mjs
@@ -38,6 +38,15 @@ test('codex skill and command prompt names do not collide', () => {
   assert.equal(new Set(promptPaths).size, promptPaths.length);
 });
 
+test('token-sync-layer dispatch degrades to inline for codex', () => {
+  const prompt = result.codex.find((f) => /token-sync-layer/.test(f.path));
+  assert.ok(prompt, 'expected a codex token-sync-layer prompt');
+  const norm = prompt.content.replace(/\s+/g, ' ');
+  assert.match(norm, /no subagent dispatch, generate and verify each adapter inline/);
+  assert.match(prompt.content, /\.throughline\/references\/agent-routing\.md/);
+  assert.doesNotMatch(prompt.content, /CLAUDE_PLUGIN_ROOT/);
+});
+
 test('diffTargets flags an orphan file on disk', () => {
   // A result that expects NOTHING under a target whose real dir has files
   // → every real file becomes an orphan. Use the real OUT_ROOT read-only.

--- a/skills/token-sync-layer/SKILL.md
+++ b/skills/token-sync-layer/SKILL.md
@@ -144,13 +144,18 @@ register the platform, transform group, format, and `outputReferences`
 flattens). Web adapters emit `:root`/`.dark` (or `[data-theme]`); the shadcn
 adapter also emits a Tailwind preset.
 
-**Execution model — subagent-driven for multiple platforms.** When more than one
-platform is targeted, generating each platform's output is independent and
-verifiable, so dispatch **one subagent per adapter**: each produces its
+**Execution model — subagent dispatch with model routing.** Generating each
+platform's output is independent and verifiable. If your host supports subagent
+dispatch, dispatch **one `code-executor` per adapter** — each produces its
 platform's files and verifies them (the config builds, the expected files
-appear, references resolve correctly for web / flatten for native). Review each
-before combining. For a single platform, run inline. (See the selective-
-subagent decision: code-gen skills parallelize; Figma-authoring skills don't.)
+appear, references resolve for web / flatten for native) — then a **`reviewer`**
+to check each before combining. Choose each subagent's model from its role tier
+per `${CLAUDE_PLUGIN_ROOT}/references/agent-routing.md` (`code-executor` → fast,
+`reviewer` → balanced), and only dispatch once each adapter's spec is complete
+enough to transcribe. If your host has no subagent dispatch, generate and verify
+each adapter inline instead. For a single platform, run inline either way. This
+is a code-gen stage, so these subagents may run in parallel — unlike Figma
+authoring, which is always sequential.
 
 ## Step 4 — Build and place outputs
 


### PR DESCRIPTION
## What & why

Introduces **subagent-driven model-tier routing** to the plugin — do the *thinking* on a strong model and the *doing* on a cheap one — proven on one skill first (`token-sync-layer`) before rolling out. Route by **cognition, not domain**: a planner earns the best model, execution from a complete spec drops to the cheapest tier.

The mechanism is **portable**: agents never hardcode a model name (which would break installers on a different plan). They declare `model: inherit`; a relative `fast < balanced < deep` ladder in `references/agent-routing.md` is resolved at dispatch against whatever models the installer actually has, with a documented fallback and one-place override.

## What's in Phase 1 (shared machinery)

- **`ci/validate-skills.mjs`** — new `validateAgent` guard: every `agents/*.md` must be `model: inherit` (fails CI on a concrete model name). Scoped to `agents/` only, so skills that legitimately pin a model (e.g. `figma-environment-setup` → `haiku`) are untouched. Plus `validateAgentRouting`.
- **`references/agent-routing.md`** — the tier ladder, recommended mapping, resolution + fallback, one-place override, spec-completeness gate, escalation ladder, and the Figma-lane concurrency note. Claude-only; states its own degradation.
- **`agents/code-executor.md`, `agents/reviewer.md`** — two reusable role agents (`model: inherit`), carrying role + verification contract only (no domain logic, so they don't rot when skills improve).
- **`skills/token-sync-layer`** — execution-model paragraph migrated to dispatch `code-executor` (fast) per adapter + `reviewer` (balanced), routing via the reference, gated on spec completeness. Authored as a **self-degrading conditional** so generated Codex/generic adapters fall back to inline execution — names no Claude-only product and needs no phrasing-map rule. Adapters regenerated; drift guard green.

## Not in scope (deferred)

- **Phase 2** — the Figma path: `architect` + `figma-executor`, stable-identifier handoff, bridge lane-lock, named-working-frame + screenshot-verify, reviewer visual mode.
- **Phase 3** — generalize to the remaining subagent-driven skills.
- Routing observability — conscious non-goal.

## How it was built

Dogfooded: executed via subagent-driven development — each task implemented by a cheap-tier subagent, reviewed by a mid-tier reviewer, with a final opus whole-branch review (verdict: ready to merge, no Critical/Important). Spec + plan live under `docs/superpowers/`.

## Verification

- `node --test` → **120/120**, zero failures
- `node scripts/adapters/generate.mjs --check` → adapters in sync (agents/ causes no drift)
- `node ci/validate-skills.mjs` → 12 skills, 4 commands, 2 agents OK
- `node ci/validate-plugin.mjs` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154PRfuofND56WtowiFuJyb