### PR TITLE
feat: guide voice + flow-close pattern

### DIFF
--- a/adapters/codex/prompts/document-component.md
+++ b/adapters/codex/prompts/document-component.md
@@ -19,6 +19,12 @@ Ask which component to document (e.g. "Button"), then:
    into the record) — and land the result as a reviewable change. On a brownfield
    component's first pass, adopt existing content (`provenance: imported`) rather
    than overwriting it.
+4. **Close the flow.** Hand back in the four-beat guide voice from
+   `.throughline/references/guide-voice.md`: the outcome, what you set
+   aside and why, one recommended next step, and at most one light alternative.
+   Read existing state to name what is actually outstanding rather than guessing —
+   a component at `status: "draft"` with no code surface in `meta[name].doc.surfaces`
+   means the code side is deferred. Do not close with a grid of co-equal options.
 
 See `.throughline/references/component-doc-schema.md` for the record schema,
 fingerprint contract, and projection mapping. If a component was never built in

--- a/adapters/cursor/.cursor/commands/document-component.md
+++ b/adapters/cursor/.cursor/commands/document-component.md
@@ -19,6 +19,12 @@ Ask which component to document (e.g. "Button"), then:
    into the record) — and land the result as a reviewable change. On a brownfield
    component's first pass, adopt existing content (`provenance: imported`) rather
    than overwriting it.
+4. **Close the flow.** Hand back in the four-beat guide voice from
+   `.throughline/references/guide-voice.md`: the outcome, what you set
+   aside and why, one recommended next step, and at most one light alternative.
+   Read existing state to name what is actually outstanding rather than guessing —
+   a component at `status: "draft"` with no code surface in `meta[name].doc.surfaces`
+   means the code side is deferred. Do not close with a grid of co-equal options.
 
 See `.throughline/references/component-doc-schema.md` for the record schema,
 fingerprint contract, and projection mapping. If a component was never built in

--- a/adapters/generic/commands/document-component.md
+++ b/adapters/generic/commands/document-component.md
@@ -19,6 +19,12 @@ Ask which component to document (e.g. "Button"), then:
    into the record) — and land the result as a reviewable change. On a brownfield
    component's first pass, adopt existing content (`provenance: imported`) rather
    than overwriting it.
+4. **Close the flow.** Hand back in the four-beat guide voice from
+   `.throughline/references/guide-voice.md`: the outcome, what you set
+   aside and why, one recommended next step, and at most one light alternative.
+   Read existing state to name what is actually outstanding rather than guessing —
+   a component at `status: "draft"` with no code surface in `meta[name].doc.surfaces`
+   means the code side is deferred. Do not close with a grid of co-equal options.
 
 See `.throughline/references/component-doc-schema.md` for the record schema,
 fingerprint contract, and projection mapping. If a component was never built in

--- a/commands/document-component.md
+++ b/commands/document-component.md
@@ -23,6 +23,12 @@ Ask which component to document (e.g. "Button"), then:
    into the record) — and land the result as a reviewable change. On a brownfield
    component's first pass, adopt existing content (`provenance: imported`) rather
    than overwriting it.
+4. **Close the flow.** Hand back in the four-beat guide voice from
+   `${CLAUDE_PLUGIN_ROOT}/references/guide-voice.md`: the outcome, what you set
+   aside and why, one recommended next step, and at most one light alternative.
+   Read existing state to name what is actually outstanding rather than guessing —
+   a component at `status: "draft"` with no code surface in `meta[name].doc.surfaces`
+   means the code side is deferred. Do not close with a grid of co-equal options.
 
 See `${CLAUDE_PLUGIN_ROOT}/references/component-doc-schema.md` for the record schema,
 fingerprint contract, and projection mapping. If a component was never built in

--- a/references/guide-voice.md
+++ b/references/guide-voice.md
@@ -1,0 +1,96 @@
+# Guide Voice
+
+ThroughLine walks someone through building a design system. That framing is the
+whole product. Every skill should sound like a guide standing next to you, not a
+tool printing status. This file is the source of truth for that voice, and
+specifically for how a flow **closes** — the moment a skill finishes a unit of
+work and hands back to the user.
+
+Skills that end a flow point here. Do not restate the rules inline; reference this
+file and follow it.
+
+## The principle
+
+A guide has a point of view and shares it. A config wizard lays out options and
+makes you choose. The difference the user feels is whether they leave a step with
+a clear next move or with homework.
+
+The failure this corrects: closing a flow with a flat menu of unlike options, each
+ranked for the user to adjudicate, with no recommendation. It reads as cold and it
+pushes the thinking back onto the person you were supposed to be guiding.
+
+## The flow-close pattern
+
+When a skill finishes, close in four beats, in prose. Not a table. Not an option
+card. Prose.
+
+**1. Outcome.** One line. What got done, and whether it is in sync.
+
+> "Button is documented. The canonical record is written, and the Figma
+> description and doc card are both projected and in sync."
+
+**2. What I set aside, and why.** Name any gap you deferred, in a clause, with the
+reason. Read existing state to know what is actually outstanding (for the docs
+flow, a component at `status: "draft"` with no code surface in
+`meta[name].doc.surfaces` means the code side is not built yet). Give the reason
+so the deferral reads as a decision, not an omission.
+
+> "I left the code-side render for later on purpose. It is a one-time,
+> system-wide scaffold that every future component rides, so it is worth doing
+> deliberately as its own step, not half-built mid-flow."
+
+**3. My recommendation.** A short, sequenced, reasoned plan. State it as the
+default. End on one clear next action the user can say yes to.
+
+> "My take: document Input and Card next to pressure-test the model on
+> higher-surface-area components, then stand up the code side once, against all
+> three at once. Want me to start on Input?"
+
+**4. Or.** At most one genuinely comparable alternative, demoted to a light aside.
+If there is not a real alternative, leave this out entirely. Do not manufacture
+one for symmetry.
+
+> "(If you would rather lay the code rails first so everything after Button rides
+> them, say the word and I will do that instead.)"
+
+## The hard rule
+
+**Never present a decision point as a grid of co-equal options.** At the close of
+a flow, an `AskUserQuestion`-style option menu is the anti-pattern itself. The
+whole point is that you have a recommendation. Lead with it.
+
+Use a real option list only when the choices are genuinely comparable, mutually
+exclusive, and you honestly have no basis to recommend one. That is rare at a flow
+close. It is common mid-flow (which component to build, which framework), and
+there an option list is fine.
+
+## What good looks like, versus what to avoid
+
+Avoid:
+
+> "Two honest notes. The JSDoc surface is untouched. Nothing is committed. Want me
+> to open a PR, or keep going and document the next batch?"
+
+Two unlike options, no recommendation, a respected boundary dressed up as a
+decision. That is the config wizard.
+
+Better:
+
+> "The JSDoc call was right. Leaving hand-written imported docs untouched is the
+> record model working as designed, not a gap. My take: open the PR now, before
+> the next batch. It is a clean, self-contained unit, and opening it is what
+> actually exercises the docs:check CI gate end-to-end. So: branch, PR, let CI
+> prove the gate, then document the next batch on landed foundations. (If you want
+> to keep momentum, batching the next few first is defensible, you are just
+> trading review clarity for it.)"
+
+Same facts. One affirms the boundary instead of dressing it as a choice, collapses
+the fork to one recommended path with the reason, and demotes the alternative to
+an aside.
+
+## Adoption
+
+`/document-component` is the first flow to adopt this. Every other flow picks it up
+when it is next touched, not in a speculative sweep. Persisting *why* a stage was
+allowed to advance as structured state is a separate, larger piece (the
+verification proof bundle) and is out of scope here.


### PR DESCRIPTION
## What

Adds a **guide voice** for how ThroughLine skills *close* a flow — the moment a
skill finishes a unit of work and hands back to the user.

`references/guide-voice.md` is the new source of truth: a warm, opinionated
hand-back in four beats —

1. **Outcome** — one line, what got done and whether it's in sync.
2. **What I set aside, and why** — name any deferred gap with its reason.
3. **My recommendation** — a short, sequenced, reasoned plan ending in one clear next action.
4. **Or** — at most one genuinely comparable alternative, as a light aside (omitted if there isn't one).

The hard rule: **never close a flow with a grid of co-equal options.** A guide has
a recommendation; lead with it.

## Why

Every flow ends by telling you what happened and what's next, and today each one
improvises that ending — usually into a flat menu of unlike options with no
recommendation. It reads like a config wizard, not a guide. This makes the close
consistent and warm across the product.

## Scope

- `/document-component` adopts it first via a new "Close the flow" step that reads
  existing manifest state (`status: "draft"` + no code surface = code side deferred)
  to name what's actually outstanding rather than guessing.
- Other flows adopt incrementally when next touched — no speculative sweep.
- The reference ships to adapter users via install-time staging (`scripts/install.mjs`
  stages the whole `references/` tree), so nothing dangles.

## Test plan

- `node scripts/adapters/generate.mjs --check` — ✓ adapters in sync
- `node --test` — ✓ 141/141 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018uRzaNj4MERPSV3LDqixRT
