### PR TITLE
feat: deterministic doc-card builder — layout phase (plan 1/2)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "throughline",
   "description": "ThroughLine — build a complete design system end to end. Author tokens, styles, icons, and components in Figma, then stand up a monorepo, sync tokens to framework-specific code via Style Dictionary, and generate Storybook stories with Chromatic. One unbroken line from design to code. Built for designers becoming developers; explanation scales to your comfort level.",
-  "version": "0.14.0",
+  "version": "0.15.0-doc-card.1",
   "author": {
     "name": "Jordan Pease"
   },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,5 @@ jobs:
         run: node ci/validate-skills.mjs
       - name: Check adapters are up to date
         run: node scripts/adapters/generate.mjs --check
+      - name: Check doc-card builder is up to date
+        run: node scripts/build-doc-card-builder.mjs --check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,8 @@ jobs:
         run: node ci/validate-skills.mjs
       - name: Check adapters are up to date
         run: node scripts/adapters/generate.mjs --check
+      - name: Check doc-card builder is up to date
+        run: node scripts/build-doc-card-builder.mjs --check
       - name: Extract release notes
         run: node ci/extract-changelog.mjs "${GITHUB_REF_NAME#v}" > "$RUNNER_TEMP/notes.md"
       - name: Update npm (trusted publishing needs npm >= 11.5)

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 BACKLOG.md
 HANDOFF.md
 
+# Brainstorming companion mockups
+.superpowers/
+
 # OS cruft
 .DS_Store
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ to [Semantic Versioning](https://semver.org).
   copied doc scripts are current before trusting `docs:check`, and offers to
   refresh them from the plugin when they've fallen behind.
 
+## [0.14.0] - 2026-07-14
+
 ### Added
 - **Component documentation layer ("ThroughLine Docs").** Every component gets a
   structured, AI-first canonical doc record (`design-system/docs/components/<Name>.doc.json`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,19 @@ to [Semantic Versioning](https://semver.org).
   `layout-upgrade-available`, never as drift. CI gates the generated snippet
   with `build-doc-card-builder.mjs --check`.
 
-## [0.14.0] - 2026-07-14
+### Fixed
+- **Doc-card post-dogfood fixes.** Column count is now capped by content, not
+  just specimen width (`cardColumns` clamps to the max blocks in any row), so
+  a wide specimen with sparse Usage content no longer mints dead columns;
+  `DOC_CARD_RENDERER_VERSION` bumps to `"3"` and old-layout cards re-flag
+  `layout-upgrade-available`. The builder now refuses to render a card that
+  already carries a foreign `Usage — *` band (documents more than one
+  component) instead of silently accumulating one. The `Usage` frame sets
+  `clipsContent = false`. The specimen lookup is the card's `COMPONENT_SET`
+  only — the never-executed named-`"Specimen"`-band path is removed.
+  `/document-component`'s drift-reconcile step now checks that the repo's
+  copied doc scripts are current before trusting `docs:check`, and offers to
+  refresh them from the plugin when they've fallen behind.
 
 ### Added
 - **Component documentation layer ("ThroughLine Docs").** Every component gets a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to ThroughLine are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+
+### Added
+- **Deterministic doc-card builder (layout phase).** The doc card's `Usage` band
+  is now rendered by a canonical, generated `figma_execute` snippet
+  (`references/doc-card-builder.md`) built from a pure, unit-tested layout
+  planner (`scripts/lib/doc-card-plan.mjs`) — a column-unit grid (three
+  wrapping rows, four closed block types) whose width grows with the variant
+  matrix instead of stretching text. Cards stamp a `renderer` version into the
+  manifest; `docs:check` reports old-layout cards as the informational
+  `layout-upgrade-available`, never as drift. CI gates the generated snippet
+  with `build-doc-card-builder.mjs --check`.
+
 ## [0.14.0] - 2026-07-14
 
 ### Added

--- a/adapters/codex/prompts/component-builder.md
+++ b/adapters/codex/prompts/component-builder.md
@@ -268,19 +268,24 @@ stamp `provenance` per block):**
   when-to-use/not, do's/don'ts, and the a11y summary — and append a fingerprint
   marker line `<!-- tl:doc <fp> -->` (this is the surface Dev Mode and Code Connect
   read).
-- **Doc card body.** Extend the existing doc card (name/short-desc/status/date, per
-  `.throughline/references/figma-component-standards.md`) with a usage body:
-  when-to-use, do's/don'ts, an a11y line, and a variant/state legend — all
-  token-bound (no hardcoded hex/px). Add a metadata text node named
-  `Doc Fingerprint` holding `<fp>`.
+- **Doc card body.** Render the card's `Usage` band with the canonical builder
+  snippet in `.throughline/references/doc-card-builder.md` (via
+  `figma_execute` with an explicit `timeout`, one card per call): fill the
+  RECORD/CANONICAL_FP slots, resolve the nine required semantic variables and
+  the `Body/Default` text style per that file's call contract, run it, and
+  verify the returned summary (`rowsRendered`, `blocksCreated`, `cardWidth`) —
+  not a screenshot. The builder creates the `Doc Fingerprint` node itself and
+  is the only thing that may build the usage body — never hand-assemble it.
 - Compute `<fp>` as the canonical fingerprint defined in the schema reference
   (sha256 of the projected record without `provenance`, first 16 hex chars).
 
 **Update the manifest (fields this skill owns):** set
 `components.meta[<Name>].doc` to `{ path, fingerprint: <fp>, surfaces: {
 figmaDescription: { src: <fp>, render: <hash of the description text> }, docCard: {
-src: <fp>, render: <hash of the card body content> } } }`. The code surfaces
-(`storybookMdx`) are added later by `storybook-chromatic-builder`.
+src: <fp>, render: <summary.renderHash>, renderer: <summary.rendererVersion> } } }`
+— the docCard entry is stamped from the builder's returned summary, never by
+re-reading the card. The code surfaces (`storybookMdx`) are added later by
+`storybook-chromatic-builder`.
 
 Run the standard doc-card visual-validation + post-build audit
 (`.throughline/references/figma-component-standards.md`) after enriching

--- a/adapters/codex/prompts/document-component.md
+++ b/adapters/codex/prompts/document-component.md
@@ -24,9 +24,9 @@ Ask which component to document (e.g. "Button"), then:
    "no drift" is meaningless — say so plainly, and offer to refresh the repo's
    doc scripts from the plugin copy (`build-docs-digest.mjs`, `docs-check.mjs`,
    `lib/doc-record.mjs`, `lib/doc-card-plan.mjs` — the same files
-   `storybook-chromatic-builder` installed at setup), then re-run `docs:check`
-   with the refreshed scripts. Then run `docs:check`. For each drifted surface,
-   offer a per-item choice — **re-render** (canonical wins) or **pull-back**
+   `storybook-chromatic-builder` installed at setup). Run `docs:check` (with the
+   refreshed scripts, if any). For each drifted surface, offer a per-item
+   choice — **re-render** (canonical wins) or **pull-back**
    (fold the surface edit into the record) — and land the result as a reviewable
    change. On a brownfield component's first pass, adopt existing content
    (`provenance: imported`) rather than overwriting it.

--- a/adapters/codex/prompts/document-component.md
+++ b/adapters/codex/prompts/document-component.md
@@ -11,14 +11,19 @@ Ask which component to document (e.g. "Button"), then:
    interview. The user approves the drafted record; `imported`/`user` blocks are
    never overwritten.
 2. **Project it.** Write `design-system/docs/components/<Name>.doc.json`, set the
-   Figma component `description`, enrich the doc card, and (if the repo/code side
-   exists) render MDX/JSDoc and run `docs:digest` per the
-   `storybook-chromatic-builder` render step.
+   Figma component `description`, rebuild the doc card's `Usage` band with the
+   canonical builder (`.throughline/references/doc-card-builder.md` —
+   verify its returned summary and stamp `surfaces.docCard.{src,render,renderer}`
+   from it), and (if the repo/code side exists) render MDX/JSDoc and run
+   `docs:digest` per the `storybook-chromatic-builder` render step.
 3. **Reconcile drift.** Run `docs:check`. For each drifted surface, offer a per-item
    choice — **re-render** (canonical wins) or **pull-back** (fold the surface edit
    into the record) — and land the result as a reviewable change. On a brownfield
    component's first pass, adopt existing content (`provenance: imported`) rather
    than overwriting it.
+   `docs:check` may also report `layout-upgrade-available` (informational, never
+   failing): the card's layout predates the current builder. Offer to re-render
+   the `Usage` band now — rebuild happens on this touch, never unprompted.
 4. **Close the flow.** Hand back in the four-beat guide voice from
    `.throughline/references/guide-voice.md`: the outcome, what you set
    aside and why, one recommended next step, and at most one light alternative.

--- a/adapters/codex/prompts/document-component.md
+++ b/adapters/codex/prompts/document-component.md
@@ -16,11 +16,20 @@ Ask which component to document (e.g. "Button"), then:
    verify its returned summary and stamp `surfaces.docCard.{src,render,renderer}`
    from it), and (if the repo/code side exists) render MDX/JSDoc and run
    `docs:digest` per the `storybook-chromatic-builder` render step.
-3. **Reconcile drift.** Run `docs:check`. For each drifted surface, offer a per-item
-   choice — **re-render** (canonical wins) or **pull-back** (fold the surface edit
-   into the record) — and land the result as a reviewable change. On a brownfield
-   component's first pass, adopt existing content (`provenance: imported`) rather
-   than overwriting it.
+3. **Reconcile drift.** Before trusting `docs:check`, confirm the repo's copy of
+   the doc scripts is current: compare `DOC_CARD_RENDERER_VERSION` in the repo's
+   `scripts/lib/doc-card-plan.mjs` against the same constant in
+   `.throughline/scripts/lib/doc-card-plan.mjs`. If the repo file is
+   missing, or its version is lower, `docs:check` is reading stale rules and its
+   "no drift" is meaningless — say so plainly, and offer to refresh the repo's
+   doc scripts from the plugin copy (`build-docs-digest.mjs`, `docs-check.mjs`,
+   `lib/doc-record.mjs`, `lib/doc-card-plan.mjs` — the same files
+   `storybook-chromatic-builder` installed at setup), then re-run `docs:check`
+   with the refreshed scripts. Then run `docs:check`. For each drifted surface,
+   offer a per-item choice — **re-render** (canonical wins) or **pull-back**
+   (fold the surface edit into the record) — and land the result as a reviewable
+   change. On a brownfield component's first pass, adopt existing content
+   (`provenance: imported`) rather than overwriting it.
    `docs:check` may also report `layout-upgrade-available` (informational, never
    failing): the card's layout predates the current builder. Offer to re-render
    the `Usage` band now — rebuild happens on this touch, never unprompted.

--- a/adapters/codex/prompts/storybook-chromatic-builder.md
+++ b/adapters/codex/prompts/storybook-chromatic-builder.md
@@ -28,8 +28,9 @@ real design tokens (import the generated CSS/theme). Checkpoint: confirm
 Storybook runs and shows the token-themed canvas.
 
 Install the documentation scripts alongside the token scripts (copy from the
-plugin's `scripts/` — `build-docs-digest.mjs`, `docs-check.mjs`, and
-`lib/doc-record.mjs` — into the repo and register npm scripts):
+plugin's `scripts/` — `build-docs-digest.mjs`, `docs-check.mjs`,
+`lib/doc-record.mjs`, and `lib/doc-card-plan.mjs` — into the repo and register
+npm scripts):
 
 - `"docs:digest": "node scripts/build-docs-digest.mjs"`
 - `"docs:check": "node scripts/docs-check.mjs"`

--- a/adapters/codex/prompts/storybook-chromatic-builder.md
+++ b/adapters/codex/prompts/storybook-chromatic-builder.md
@@ -36,7 +36,9 @@ npm scripts):
 - `"docs:check": "node scripts/docs-check.mjs"`
 
 These are the documentation analog of `tokens:validate`; see
-`.throughline/scripts/README.md`.
+`.throughline/scripts/README.md`. This copy is setup, not a forever-fork:
+`/document-component` re-checks these files' freshness on every run and refreshes
+them from the plugin when it has moved on.
 
 **pnpm build-script allowlist (first-run gotcha).** On pnpm workspaces, the
 `@storybook/react-vite` install pulls `esbuild`, whose postinstall is blocked by

--- a/adapters/cursor/.cursor/commands/document-component.md
+++ b/adapters/cursor/.cursor/commands/document-component.md
@@ -24,9 +24,9 @@ Ask which component to document (e.g. "Button"), then:
    "no drift" is meaningless — say so plainly, and offer to refresh the repo's
    doc scripts from the plugin copy (`build-docs-digest.mjs`, `docs-check.mjs`,
    `lib/doc-record.mjs`, `lib/doc-card-plan.mjs` — the same files
-   `storybook-chromatic-builder` installed at setup), then re-run `docs:check`
-   with the refreshed scripts. Then run `docs:check`. For each drifted surface,
-   offer a per-item choice — **re-render** (canonical wins) or **pull-back**
+   `storybook-chromatic-builder` installed at setup). Run `docs:check` (with the
+   refreshed scripts, if any). For each drifted surface, offer a per-item
+   choice — **re-render** (canonical wins) or **pull-back**
    (fold the surface edit into the record) — and land the result as a reviewable
    change. On a brownfield component's first pass, adopt existing content
    (`provenance: imported`) rather than overwriting it.

--- a/adapters/cursor/.cursor/commands/document-component.md
+++ b/adapters/cursor/.cursor/commands/document-component.md
@@ -11,14 +11,19 @@ Ask which component to document (e.g. "Button"), then:
    interview. The user approves the drafted record; `imported`/`user` blocks are
    never overwritten.
 2. **Project it.** Write `design-system/docs/components/<Name>.doc.json`, set the
-   Figma component `description`, enrich the doc card, and (if the repo/code side
-   exists) render MDX/JSDoc and run `docs:digest` per the
-   `storybook-chromatic-builder` render step.
+   Figma component `description`, rebuild the doc card's `Usage` band with the
+   canonical builder (`.throughline/references/doc-card-builder.md` —
+   verify its returned summary and stamp `surfaces.docCard.{src,render,renderer}`
+   from it), and (if the repo/code side exists) render MDX/JSDoc and run
+   `docs:digest` per the `storybook-chromatic-builder` render step.
 3. **Reconcile drift.** Run `docs:check`. For each drifted surface, offer a per-item
    choice — **re-render** (canonical wins) or **pull-back** (fold the surface edit
    into the record) — and land the result as a reviewable change. On a brownfield
    component's first pass, adopt existing content (`provenance: imported`) rather
    than overwriting it.
+   `docs:check` may also report `layout-upgrade-available` (informational, never
+   failing): the card's layout predates the current builder. Offer to re-render
+   the `Usage` band now — rebuild happens on this touch, never unprompted.
 4. **Close the flow.** Hand back in the four-beat guide voice from
    `.throughline/references/guide-voice.md`: the outcome, what you set
    aside and why, one recommended next step, and at most one light alternative.

--- a/adapters/cursor/.cursor/commands/document-component.md
+++ b/adapters/cursor/.cursor/commands/document-component.md
@@ -16,11 +16,20 @@ Ask which component to document (e.g. "Button"), then:
    verify its returned summary and stamp `surfaces.docCard.{src,render,renderer}`
    from it), and (if the repo/code side exists) render MDX/JSDoc and run
    `docs:digest` per the `storybook-chromatic-builder` render step.
-3. **Reconcile drift.** Run `docs:check`. For each drifted surface, offer a per-item
-   choice — **re-render** (canonical wins) or **pull-back** (fold the surface edit
-   into the record) — and land the result as a reviewable change. On a brownfield
-   component's first pass, adopt existing content (`provenance: imported`) rather
-   than overwriting it.
+3. **Reconcile drift.** Before trusting `docs:check`, confirm the repo's copy of
+   the doc scripts is current: compare `DOC_CARD_RENDERER_VERSION` in the repo's
+   `scripts/lib/doc-card-plan.mjs` against the same constant in
+   `.throughline/scripts/lib/doc-card-plan.mjs`. If the repo file is
+   missing, or its version is lower, `docs:check` is reading stale rules and its
+   "no drift" is meaningless — say so plainly, and offer to refresh the repo's
+   doc scripts from the plugin copy (`build-docs-digest.mjs`, `docs-check.mjs`,
+   `lib/doc-record.mjs`, `lib/doc-card-plan.mjs` — the same files
+   `storybook-chromatic-builder` installed at setup), then re-run `docs:check`
+   with the refreshed scripts. Then run `docs:check`. For each drifted surface,
+   offer a per-item choice — **re-render** (canonical wins) or **pull-back**
+   (fold the surface edit into the record) — and land the result as a reviewable
+   change. On a brownfield component's first pass, adopt existing content
+   (`provenance: imported`) rather than overwriting it.
    `docs:check` may also report `layout-upgrade-available` (informational, never
    failing): the card's layout predates the current builder. Offer to re-render
    the `Usage` band now — rebuild happens on this touch, never unprompted.

--- a/adapters/cursor/.cursor/rules/component-builder.mdc
+++ b/adapters/cursor/.cursor/rules/component-builder.mdc
@@ -272,19 +272,24 @@ stamp `provenance` per block):**
   when-to-use/not, do's/don'ts, and the a11y summary — and append a fingerprint
   marker line `<!-- tl:doc <fp> -->` (this is the surface Dev Mode and Code Connect
   read).
-- **Doc card body.** Extend the existing doc card (name/short-desc/status/date, per
-  `.throughline/references/figma-component-standards.md`) with a usage body:
-  when-to-use, do's/don'ts, an a11y line, and a variant/state legend — all
-  token-bound (no hardcoded hex/px). Add a metadata text node named
-  `Doc Fingerprint` holding `<fp>`.
+- **Doc card body.** Render the card's `Usage` band with the canonical builder
+  snippet in `.throughline/references/doc-card-builder.md` (via
+  `figma_execute` with an explicit `timeout`, one card per call): fill the
+  RECORD/CANONICAL_FP slots, resolve the nine required semantic variables and
+  the `Body/Default` text style per that file's call contract, run it, and
+  verify the returned summary (`rowsRendered`, `blocksCreated`, `cardWidth`) —
+  not a screenshot. The builder creates the `Doc Fingerprint` node itself and
+  is the only thing that may build the usage body — never hand-assemble it.
 - Compute `<fp>` as the canonical fingerprint defined in the schema reference
   (sha256 of the projected record without `provenance`, first 16 hex chars).
 
 **Update the manifest (fields this skill owns):** set
 `components.meta[<Name>].doc` to `{ path, fingerprint: <fp>, surfaces: {
 figmaDescription: { src: <fp>, render: <hash of the description text> }, docCard: {
-src: <fp>, render: <hash of the card body content> } } }`. The code surfaces
-(`storybookMdx`) are added later by `storybook-chromatic-builder`.
+src: <fp>, render: <summary.renderHash>, renderer: <summary.rendererVersion> } } }`
+— the docCard entry is stamped from the builder's returned summary, never by
+re-reading the card. The code surfaces (`storybookMdx`) are added later by
+`storybook-chromatic-builder`.
 
 Run the standard doc-card visual-validation + post-build audit
 (`.throughline/references/figma-component-standards.md`) after enriching

--- a/adapters/cursor/.cursor/rules/storybook-chromatic-builder.mdc
+++ b/adapters/cursor/.cursor/rules/storybook-chromatic-builder.mdc
@@ -32,8 +32,9 @@ real design tokens (import the generated CSS/theme). Checkpoint: confirm
 Storybook runs and shows the token-themed canvas.
 
 Install the documentation scripts alongside the token scripts (copy from the
-plugin's `scripts/` — `build-docs-digest.mjs`, `docs-check.mjs`, and
-`lib/doc-record.mjs` — into the repo and register npm scripts):
+plugin's `scripts/` — `build-docs-digest.mjs`, `docs-check.mjs`,
+`lib/doc-record.mjs`, and `lib/doc-card-plan.mjs` — into the repo and register
+npm scripts):
 
 - `"docs:digest": "node scripts/build-docs-digest.mjs"`
 - `"docs:check": "node scripts/docs-check.mjs"`

--- a/adapters/cursor/.cursor/rules/storybook-chromatic-builder.mdc
+++ b/adapters/cursor/.cursor/rules/storybook-chromatic-builder.mdc
@@ -40,7 +40,9 @@ npm scripts):
 - `"docs:check": "node scripts/docs-check.mjs"`
 
 These are the documentation analog of `tokens:validate`; see
-`.throughline/scripts/README.md`.
+`.throughline/scripts/README.md`. This copy is setup, not a forever-fork:
+`/document-component` re-checks these files' freshness on every run and refreshes
+them from the plugin when it has moved on.
 
 **pnpm build-script allowlist (first-run gotcha).** On pnpm workspaces, the
 `@storybook/react-vite` install pulls `esbuild`, whose postinstall is blocked by

--- a/adapters/generic/commands/document-component.md
+++ b/adapters/generic/commands/document-component.md
@@ -24,9 +24,9 @@ Ask which component to document (e.g. "Button"), then:
    "no drift" is meaningless — say so plainly, and offer to refresh the repo's
    doc scripts from the plugin copy (`build-docs-digest.mjs`, `docs-check.mjs`,
    `lib/doc-record.mjs`, `lib/doc-card-plan.mjs` — the same files
-   `storybook-chromatic-builder` installed at setup), then re-run `docs:check`
-   with the refreshed scripts. Then run `docs:check`. For each drifted surface,
-   offer a per-item choice — **re-render** (canonical wins) or **pull-back**
+   `storybook-chromatic-builder` installed at setup). Run `docs:check` (with the
+   refreshed scripts, if any). For each drifted surface, offer a per-item
+   choice — **re-render** (canonical wins) or **pull-back**
    (fold the surface edit into the record) — and land the result as a reviewable
    change. On a brownfield component's first pass, adopt existing content
    (`provenance: imported`) rather than overwriting it.

--- a/adapters/generic/commands/document-component.md
+++ b/adapters/generic/commands/document-component.md
@@ -11,14 +11,19 @@ Ask which component to document (e.g. "Button"), then:
    interview. The user approves the drafted record; `imported`/`user` blocks are
    never overwritten.
 2. **Project it.** Write `design-system/docs/components/<Name>.doc.json`, set the
-   Figma component `description`, enrich the doc card, and (if the repo/code side
-   exists) render MDX/JSDoc and run `docs:digest` per the
-   `storybook-chromatic-builder` render step.
+   Figma component `description`, rebuild the doc card's `Usage` band with the
+   canonical builder (`.throughline/references/doc-card-builder.md` —
+   verify its returned summary and stamp `surfaces.docCard.{src,render,renderer}`
+   from it), and (if the repo/code side exists) render MDX/JSDoc and run
+   `docs:digest` per the `storybook-chromatic-builder` render step.
 3. **Reconcile drift.** Run `docs:check`. For each drifted surface, offer a per-item
    choice — **re-render** (canonical wins) or **pull-back** (fold the surface edit
    into the record) — and land the result as a reviewable change. On a brownfield
    component's first pass, adopt existing content (`provenance: imported`) rather
    than overwriting it.
+   `docs:check` may also report `layout-upgrade-available` (informational, never
+   failing): the card's layout predates the current builder. Offer to re-render
+   the `Usage` band now — rebuild happens on this touch, never unprompted.
 4. **Close the flow.** Hand back in the four-beat guide voice from
    `.throughline/references/guide-voice.md`: the outcome, what you set
    aside and why, one recommended next step, and at most one light alternative.

--- a/adapters/generic/commands/document-component.md
+++ b/adapters/generic/commands/document-component.md
@@ -16,11 +16,20 @@ Ask which component to document (e.g. "Button"), then:
    verify its returned summary and stamp `surfaces.docCard.{src,render,renderer}`
    from it), and (if the repo/code side exists) render MDX/JSDoc and run
    `docs:digest` per the `storybook-chromatic-builder` render step.
-3. **Reconcile drift.** Run `docs:check`. For each drifted surface, offer a per-item
-   choice — **re-render** (canonical wins) or **pull-back** (fold the surface edit
-   into the record) — and land the result as a reviewable change. On a brownfield
-   component's first pass, adopt existing content (`provenance: imported`) rather
-   than overwriting it.
+3. **Reconcile drift.** Before trusting `docs:check`, confirm the repo's copy of
+   the doc scripts is current: compare `DOC_CARD_RENDERER_VERSION` in the repo's
+   `scripts/lib/doc-card-plan.mjs` against the same constant in
+   `.throughline/scripts/lib/doc-card-plan.mjs`. If the repo file is
+   missing, or its version is lower, `docs:check` is reading stale rules and its
+   "no drift" is meaningless — say so plainly, and offer to refresh the repo's
+   doc scripts from the plugin copy (`build-docs-digest.mjs`, `docs-check.mjs`,
+   `lib/doc-record.mjs`, `lib/doc-card-plan.mjs` — the same files
+   `storybook-chromatic-builder` installed at setup), then re-run `docs:check`
+   with the refreshed scripts. Then run `docs:check`. For each drifted surface,
+   offer a per-item choice — **re-render** (canonical wins) or **pull-back**
+   (fold the surface edit into the record) — and land the result as a reviewable
+   change. On a brownfield component's first pass, adopt existing content
+   (`provenance: imported`) rather than overwriting it.
    `docs:check` may also report `layout-upgrade-available` (informational, never
    failing): the card's layout predates the current builder. Offer to re-render
    the `Usage` band now — rebuild happens on this touch, never unprompted.

--- a/adapters/generic/skills/component-builder/SKILL.md
+++ b/adapters/generic/skills/component-builder/SKILL.md
@@ -268,19 +268,24 @@ stamp `provenance` per block):**
   when-to-use/not, do's/don'ts, and the a11y summary — and append a fingerprint
   marker line `<!-- tl:doc <fp> -->` (this is the surface Dev Mode and Code Connect
   read).
-- **Doc card body.** Extend the existing doc card (name/short-desc/status/date, per
-  `.throughline/references/figma-component-standards.md`) with a usage body:
-  when-to-use, do's/don'ts, an a11y line, and a variant/state legend — all
-  token-bound (no hardcoded hex/px). Add a metadata text node named
-  `Doc Fingerprint` holding `<fp>`.
+- **Doc card body.** Render the card's `Usage` band with the canonical builder
+  snippet in `.throughline/references/doc-card-builder.md` (via
+  `figma_execute` with an explicit `timeout`, one card per call): fill the
+  RECORD/CANONICAL_FP slots, resolve the nine required semantic variables and
+  the `Body/Default` text style per that file's call contract, run it, and
+  verify the returned summary (`rowsRendered`, `blocksCreated`, `cardWidth`) —
+  not a screenshot. The builder creates the `Doc Fingerprint` node itself and
+  is the only thing that may build the usage body — never hand-assemble it.
 - Compute `<fp>` as the canonical fingerprint defined in the schema reference
   (sha256 of the projected record without `provenance`, first 16 hex chars).
 
 **Update the manifest (fields this skill owns):** set
 `components.meta[<Name>].doc` to `{ path, fingerprint: <fp>, surfaces: {
 figmaDescription: { src: <fp>, render: <hash of the description text> }, docCard: {
-src: <fp>, render: <hash of the card body content> } } }`. The code surfaces
-(`storybookMdx`) are added later by `storybook-chromatic-builder`.
+src: <fp>, render: <summary.renderHash>, renderer: <summary.rendererVersion> } } }`
+— the docCard entry is stamped from the builder's returned summary, never by
+re-reading the card. The code surfaces (`storybookMdx`) are added later by
+`storybook-chromatic-builder`.
 
 Run the standard doc-card visual-validation + post-build audit
 (`.throughline/references/figma-component-standards.md`) after enriching

--- a/adapters/generic/skills/storybook-chromatic-builder/SKILL.md
+++ b/adapters/generic/skills/storybook-chromatic-builder/SKILL.md
@@ -28,8 +28,9 @@ real design tokens (import the generated CSS/theme). Checkpoint: confirm
 Storybook runs and shows the token-themed canvas.
 
 Install the documentation scripts alongside the token scripts (copy from the
-plugin's `scripts/` — `build-docs-digest.mjs`, `docs-check.mjs`, and
-`lib/doc-record.mjs` — into the repo and register npm scripts):
+plugin's `scripts/` — `build-docs-digest.mjs`, `docs-check.mjs`,
+`lib/doc-record.mjs`, and `lib/doc-card-plan.mjs` — into the repo and register
+npm scripts):
 
 - `"docs:digest": "node scripts/build-docs-digest.mjs"`
 - `"docs:check": "node scripts/docs-check.mjs"`

--- a/adapters/generic/skills/storybook-chromatic-builder/SKILL.md
+++ b/adapters/generic/skills/storybook-chromatic-builder/SKILL.md
@@ -36,7 +36,9 @@ npm scripts):
 - `"docs:check": "node scripts/docs-check.mjs"`
 
 These are the documentation analog of `tokens:validate`; see
-`.throughline/scripts/README.md`.
+`.throughline/scripts/README.md`. This copy is setup, not a forever-fork:
+`/document-component` re-checks these files' freshness on every run and refreshes
+them from the plugin when it has moved on.
 
 **pnpm build-script allowlist (first-run gotcha).** On pnpm workspaces, the
 `@storybook/react-vite` install pulls `esbuild`, whose postinstall is blocked by

--- a/commands/document-component.md
+++ b/commands/document-component.md
@@ -28,9 +28,9 @@ Ask which component to document (e.g. "Button"), then:
    "no drift" is meaningless — say so plainly, and offer to refresh the repo's
    doc scripts from the plugin copy (`build-docs-digest.mjs`, `docs-check.mjs`,
    `lib/doc-record.mjs`, `lib/doc-card-plan.mjs` — the same files
-   `storybook-chromatic-builder` installed at setup), then re-run `docs:check`
-   with the refreshed scripts. Then run `docs:check`. For each drifted surface,
-   offer a per-item choice — **re-render** (canonical wins) or **pull-back**
+   `storybook-chromatic-builder` installed at setup). Run `docs:check` (with the
+   refreshed scripts, if any). For each drifted surface, offer a per-item
+   choice — **re-render** (canonical wins) or **pull-back**
    (fold the surface edit into the record) — and land the result as a reviewable
    change. On a brownfield component's first pass, adopt existing content
    (`provenance: imported`) rather than overwriting it.

--- a/commands/document-component.md
+++ b/commands/document-component.md
@@ -15,14 +15,19 @@ Ask which component to document (e.g. "Button"), then:
    interview. The user approves the drafted record; `imported`/`user` blocks are
    never overwritten.
 2. **Project it.** Write `design-system/docs/components/<Name>.doc.json`, set the
-   Figma component `description`, enrich the doc card, and (if the repo/code side
-   exists) render MDX/JSDoc and run `docs:digest` per the
-   `storybook-chromatic-builder` render step.
+   Figma component `description`, rebuild the doc card's `Usage` band with the
+   canonical builder (`${CLAUDE_PLUGIN_ROOT}/references/doc-card-builder.md` —
+   verify its returned summary and stamp `surfaces.docCard.{src,render,renderer}`
+   from it), and (if the repo/code side exists) render MDX/JSDoc and run
+   `docs:digest` per the `storybook-chromatic-builder` render step.
 3. **Reconcile drift.** Run `docs:check`. For each drifted surface, offer a per-item
    choice — **re-render** (canonical wins) or **pull-back** (fold the surface edit
    into the record) — and land the result as a reviewable change. On a brownfield
    component's first pass, adopt existing content (`provenance: imported`) rather
    than overwriting it.
+   `docs:check` may also report `layout-upgrade-available` (informational, never
+   failing): the card's layout predates the current builder. Offer to re-render
+   the `Usage` band now — rebuild happens on this touch, never unprompted.
 4. **Close the flow.** Hand back in the four-beat guide voice from
    `${CLAUDE_PLUGIN_ROOT}/references/guide-voice.md`: the outcome, what you set
    aside and why, one recommended next step, and at most one light alternative.

--- a/commands/document-component.md
+++ b/commands/document-component.md
@@ -20,11 +20,20 @@ Ask which component to document (e.g. "Button"), then:
    verify its returned summary and stamp `surfaces.docCard.{src,render,renderer}`
    from it), and (if the repo/code side exists) render MDX/JSDoc and run
    `docs:digest` per the `storybook-chromatic-builder` render step.
-3. **Reconcile drift.** Run `docs:check`. For each drifted surface, offer a per-item
-   choice — **re-render** (canonical wins) or **pull-back** (fold the surface edit
-   into the record) — and land the result as a reviewable change. On a brownfield
-   component's first pass, adopt existing content (`provenance: imported`) rather
-   than overwriting it.
+3. **Reconcile drift.** Before trusting `docs:check`, confirm the repo's copy of
+   the doc scripts is current: compare `DOC_CARD_RENDERER_VERSION` in the repo's
+   `scripts/lib/doc-card-plan.mjs` against the same constant in
+   `${CLAUDE_PLUGIN_ROOT}/scripts/lib/doc-card-plan.mjs`. If the repo file is
+   missing, or its version is lower, `docs:check` is reading stale rules and its
+   "no drift" is meaningless — say so plainly, and offer to refresh the repo's
+   doc scripts from the plugin copy (`build-docs-digest.mjs`, `docs-check.mjs`,
+   `lib/doc-record.mjs`, `lib/doc-card-plan.mjs` — the same files
+   `storybook-chromatic-builder` installed at setup), then re-run `docs:check`
+   with the refreshed scripts. Then run `docs:check`. For each drifted surface,
+   offer a per-item choice — **re-render** (canonical wins) or **pull-back**
+   (fold the surface edit into the record) — and land the result as a reviewable
+   change. On a brownfield component's first pass, adopt existing content
+   (`provenance: imported`) rather than overwriting it.
    `docs:check` may also report `layout-upgrade-available` (informational, never
    failing): the card's layout predates the current builder. Offer to re-render
    the `Usage` band now — rebuild happens on this touch, never unprompted.

--- a/docs/superpowers/plans/2026-08-09-doc-card-builder.md
+++ b/docs/superpowers/plans/2026-08-09-doc-card-builder.md
@@ -1,0 +1,1370 @@
+# Doc-Card Builder Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the improvised, per-run doc-card documentation body with a deterministic, tested builder — a pure layout planner unit-tested in Node, a Figma renderer template stitched into a generated reference snippet, a renderer version stamp in the manifest, and an informational `layout-upgrade-available` classification in `docs:check`.
+
+**Architecture:** A pure planner (`scripts/lib/doc-card-plan.mjs`, zero imports) decides everything testable — block selection, row assignment, column-unit and card-width math. A Figma-API renderer template (`scripts/lib/doc-card-render.figma.js`) walks the plan and makes the plugin-API calls. A build script inlines both into the generated `references/doc-card-builder.md` — the snippet skills hand to `figma_execute` — and a `--check` mode gates CI exactly like the existing adapter check. `docs:check` learns to report old-layout cards informationally via a `renderer` stamp.
+
+**Tech Stack:** Node ≥20 (built-in `node:test`, `node:assert/strict`), zero third-party dependencies. Figma plugin API (dynamic-page mode) via the Figma Console MCP's `figma_execute`. GitHub Actions CI.
+
+**Spec:** `docs/superpowers/specs/2026-08-09-doc-card-layout-and-voice-design.md` — this is **plan 1 of 2** (the *Layout* phase in the spec's Phasing section). Plan 2 (writing standard, archetype pass, `docs-lint`, authoring-pipeline wiring) is separate; nothing in this plan touches `references/doc-writing-standard.md` or `scripts/docs-lint.mjs`.
+
+## Global Constraints
+
+- **Zero runtime dependencies** in every `scripts/*.mjs` — stdlib only (matches every existing script).
+- **`scripts/lib/doc-card-plan.mjs` must have ZERO imports** (not even `node:` builtins) and use only `export const` / `export function` — it is inlined verbatim into the Figma snippet, which runs where no module system exists. The build script enforces this and throws otherwise.
+- **Scripts are pure-functions + a CLI guard:** export the logic; guard the CLI with `if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href)`. Every runnable script has a colocated `*.test.mjs`; tests run via bare `node --test` from the repo root.
+- **Column unit (exact):** `columnUnit = clamp(round(bodyFontSize × 30), 280, 480)` px. The body font size comes from the user's `Body/Default` text style.
+- **Card width (exact):** `cardWidth = max(specimenWidth, 3 × columnUnit)` rounded UP to a whole unit — i.e. `columns = max(3, ceil(specimenWidth / columnUnit))`, `cardWidth = columns × columnUnit`.
+- **Definition term column:** `round(columnUnit × 0.3)`; long terms wrap, never truncate.
+- **Eyebrow chrome (exact):** derived from `Body/Default` — `fontSize × 0.65` rounded, minimum 8; weight Bold (fall back to the body style's own weight if the family has no Bold); uppercase; letter-spacing +8%.
+- **Deterministic node names:** `Usage`, `Usage Row 1..3` (canonical numbering — an absent row's number is skipped, never renumbered), `Block: <Eyebrow>` (e.g. `Block: Overview`, `Block: Do`, `Block: Don't`, `Block: What each variant means`, `Block: Accessibility`), `Row Divider`, `Doc Fingerprint`.
+- **Bind-or-throw:** colors and the `Body/Default` content type style resolve to the user's variables/styles or the builder throws — never a hex/px fallback. The two documented exceptions (layout chrome, not design values): the computed column unit, and the derived eyebrow type.
+- **Rebuild scope:** the builder removes and rebuilds ONLY the frame named `Usage`. Header and specimen are never touched (delete-and-recreate of a component set detaches downstream instances — `skills/component-builder/SKILL.md:347-351`).
+- **Row alignment:** every usage row sets `counterAxisAlignItems = "MIN"` AND `primaryAxisAlignItems = "MIN"` (top-aligned, left-packed — never center or space-between).
+- **Renderer version:** `DOC_CARD_RENDERER_VERSION = '2'`, exported from `scripts/lib/doc-card-plan.mjs` — the single source; `docs-check.mjs` imports it; the build script inlines it into the generated snippet.
+- **`figma_execute` discipline** (from `references/figma-scripting.md`): async APIs only (`getNodeByIdAsync`, `setTextStyleIdAsync`); set the text style/font BEFORE writing `.characters`; load all fonts up front; explicit `timeout` (~30s cap); after any `resize()` on an auto-layout frame, re-assert the sizing modes (VERTICAL frames: counter = width, primary = height); seed bound paints with a light-gray approximation, never pure black.
+- **CI gates that must stay green:** `node --test`, `node ci/validate-plugin.mjs`, `node ci/validate-skills.mjs`, `node scripts/adapters/generate.mjs --check` — plus, after Task 6, `node scripts/build-doc-card-builder.mjs --check`.
+- **Any skill/command edit REQUIRES regenerating adapters** (`node scripts/adapters/generate.mjs`) and committing the regenerated `adapters/` tree, or CI's `--check` fails.
+- **Branch:** all work lands on `feat/doc-card-builder` (created in Task 1).
+
+---
+
+## Interface contracts (used by every task — read first)
+
+**Planner** (pure, inlinable, Node-tested):
+
+```
+planDocCard(record, specimenWidth, bodyTextStyle) → plan
+  record        — a parsed .doc.json record (see references/component-doc-schema.md)
+  specimenWidth — number, px (measured in Figma at run time)
+  bodyTextStyle — { fontSize: number }  (only fontSize is read; passing a full
+                  Figma TextStyle object is fine)
+
+plan = {
+  rendererVersion: '2',
+  columnUnit: number,       // clamp(round(fontSize×30), 280, 480)
+  columns: number,          // max(3, ceil(specimenWidth / columnUnit))
+  cardWidth: number,        // columns × columnUnit
+  termColumn: number,       // round(columnUnit × 0.3)
+  rows: [ { name: 'Usage Row 1'|'Usage Row 2'|'Usage Row 3', blocks: [Block] } ],
+                            // empty rows omitted; names keep canonical numbers
+}
+
+Block =
+  { type: 'prose',      name: 'Block: Overview',            eyebrow: 'Overview',            text: string }
+| { type: 'list',       name: 'Block: <Eyebrow>',           eyebrow: string,                items: string[] }
+| { type: 'list-tone',  name: 'Block: Do'|"Block: Don't",   eyebrow: '✓ Do'|"✕ Don't",      tone: 'positive'|'negative', items: string[] }
+| { type: 'definition', name: 'Block: What each <x> means', eyebrow: 'What each <x> means', terms: [{ term: string, meaning: string }] }
+```
+
+Row composition (spec §"Three rows, wrapping independently"):
+- **Usage Row 1:** Overview (`description`) · When to use (`whenToUse`) · When not to use (`whenNotToUse`)
+- **Usage Row 2:** Do (`dos`) · Don't (`donts`)
+- **Usage Row 3:** one definition block per `variants` axis in key order (`What each <axis> means`), then `What each state means` (`states`), then Accessibility (`accessibility.keyboard` entries followed by `accessibility.notes`; `accessibility.role` is not rendered — it lives in the description field/MDX surfaces)
+
+**Renderer** (Figma-API, inlined into the generated snippet, never imported):
+
+```
+renderDocCard({ card, record, vars, bodyTextStyle }) → summary   (async)
+  card          — the doc-card FrameNode (caller resolves via getNodeByIdAsync)
+  record        — the parsed .doc.json record
+  vars          — map of resolved Figma Variable OBJECTS (not ids), all 9 required:
+                  textDefault, textMuted, tonePositive, toneNegative, border,
+                  spacePadding, spaceRowGap, spaceBlockGap, spaceItemGap
+  bodyTextStyle — the user's Body/Default TextStyle (caller finds it by name;
+                  renderer throws if missing)
+
+summary = {
+  rendererVersion: '2', columnUnit, columns, cardWidth,
+  rowsRendered: number, blocksCreated: string[],   // the Block names, in order
+  fingerprint: string,   // CANONICAL_FP (snippet slot, filled by the caller)
+  renderHash: string,    // fnv1a(JSON.stringify(plan)) — 8 hex chars
+}
+```
+
+The snippet has two **slots** the calling agent fills before executing:
+`const RECORD = <parsed .doc.json>;` and `const CANONICAL_FP = '<fp>';` where
+`<fp>` is `canonicalFingerprint(RECORD)` computed in Node via
+`scripts/lib/doc-record.mjs` (sha256 is unavailable inside the Figma sandbox, so
+the canonical fingerprint is computed outside and passed in; the render hash uses
+in-snippet FNV-1a, which only ever compares against itself).
+
+**Manifest stamping (the skill writes this from the summary, never by re-reading
+the card):** `components.meta[<Name>].doc.surfaces.docCard = { src: summary.fingerprint, render: summary.renderHash, renderer: summary.rendererVersion }`.
+
+---
+
+## Task 1: Planner — renderer version, column unit, card width
+
+**Files:**
+- Create: `scripts/lib/doc-card-plan.mjs`
+- Create: `scripts/lib/doc-card-plan.test.mjs`
+
+**Interfaces:**
+- Consumes: nothing (pure module, zero imports).
+- Produces: `DOC_CARD_RENDERER_VERSION` (`'2'`, string), `columnUnit(bodyFontSize) → number`, `cardColumns(specimenWidth, unit) → number`. Task 2 adds `planDocCard` to this same file; Task 3 imports `DOC_CARD_RENDERER_VERSION`; Task 5 inlines the whole file.
+
+- [ ] **Step 1: Create the branch**
+
+```bash
+git checkout -b feat/doc-card-builder
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `scripts/lib/doc-card-plan.test.mjs`:
+
+```js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { DOC_CARD_RENDERER_VERSION, columnUnit, cardColumns } from './doc-card-plan.mjs';
+
+test('DOC_CARD_RENDERER_VERSION is the string "2"', () => {
+  assert.equal(DOC_CARD_RENDERER_VERSION, '2');
+});
+
+test('columnUnit: clamp(round(fontSize × 30), 280, 480)', () => {
+  assert.equal(columnUnit(14), 420);  // 14 × 30 = 420, inside the clamp
+  assert.equal(columnUnit(16), 480);  // 16 × 30 = 480, exactly the ceiling
+  assert.equal(columnUnit(9), 280);   // 270 clamps up to the floor
+  assert.equal(columnUnit(20), 480);  // 600 clamps down to the ceiling
+  assert.equal(columnUnit(13.5), 405); // rounds: 13.5 × 30 = 405
+});
+
+test('cardColumns: max(3, ceil(specimenWidth / unit)) — width rounds UP to whole units', () => {
+  assert.equal(cardColumns(1500, 420), 4); // ceil(3.57) = 4
+  assert.equal(cardColumns(1260, 420), 3); // exact multiple stays 3
+  assert.equal(cardColumns(200, 480), 3);  // narrow specimen: 3-unit floor
+  assert.equal(cardColumns(0, 480), 3);    // degenerate specimen still floors at 3
+});
+```
+
+- [ ] **Step 3: Run the test — verify it fails**
+
+```bash
+node --test scripts/lib/doc-card-plan.test.mjs
+```
+
+Expected failure: `Cannot find module … doc-card-plan.mjs` (the module doesn't exist yet).
+
+- [ ] **Step 4: Implement**
+
+Create `scripts/lib/doc-card-plan.mjs`:
+
+```js
+// Pure layout planner for the component doc card's Usage band.
+// ZERO imports, `export const`/`export function` only — this module is inlined
+// verbatim into the generated Figma snippet (references/doc-card-builder.md) by
+// build-doc-card-builder.mjs, so it must run in both Node and the Figma plugin
+// sandbox. build-doc-card-builder.mjs enforces the no-imports rule.
+//
+// Layout contract: docs/superpowers/specs/2026-08-09-doc-card-layout-and-voice-design.md
+
+// Single source of truth for the doc-card layout version. Imported by
+// docs-check.mjs and embedded (via inlining) into the generated builder snippet.
+export const DOC_CARD_RENDERER_VERSION = '2';
+
+// columnUnit = clamp(round(bodyFontSize × 30), 280, 480) px.
+// 30 ≈ 60ch × ~0.5em average glyph width for UI text faces. Layout chrome, not
+// a design value — the one documented exception to the no-hardcoded-px rule.
+export function columnUnit(bodyFontSize) {
+  return Math.min(480, Math.max(280, Math.round(bodyFontSize * 30)));
+}
+
+// cardWidth = max(specimenWidth, 3 units) rounded UP to a whole unit.
+export function cardColumns(specimenWidth, unit) {
+  return Math.max(3, Math.ceil(specimenWidth / unit));
+}
+```
+
+- [ ] **Step 5: Run the test — verify it passes**
+
+```bash
+node --test scripts/lib/doc-card-plan.test.mjs
+```
+
+Expected: all 3 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/lib/doc-card-plan.mjs scripts/lib/doc-card-plan.test.mjs
+git commit -m "feat(docs): doc-card layout planner — renderer version, column unit, card width"
+```
+
+---
+
+## Task 2: Planner — block selection and row assignment
+
+**Files:**
+- Modify: `scripts/lib/doc-card-plan.mjs` (append `planDocCard` after `cardColumns`)
+- Modify: `scripts/lib/doc-card-plan.test.mjs` (append tests)
+
+**Interfaces:**
+- Consumes: `columnUnit`, `cardColumns` (Task 1, same file).
+- Produces: `planDocCard(record, specimenWidth, bodyTextStyle) → plan` with the exact plan/Block shapes from *Interface contracts* above. Tasks 4–5 inline it; the renderer walks `plan.rows`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/lib/doc-card-plan.test.mjs` (add `planDocCard` to the existing import):
+
+```js
+import { planDocCard } from './doc-card-plan.mjs';
+
+const FULL_RECORD = {
+  name: 'Button',
+  summary: 'Triggers an action or event.',
+  description: 'A clickable control that starts an action.',
+  whenToUse: ['Something happens on the current page'],
+  whenNotToUse: ['Moving to another page or URL. Use a Link instead.'],
+  variants: {
+    variant: { default: 'The one main action in a view.', secondary: 'Sits alongside a main action.' },
+    size: { sm: 'Dense layouts and toolbars.', md: 'The default size.' },
+  },
+  states: { hover: 'The pointer is over the button.', disabled: "Can't be clicked or tabbed to." },
+  dos: ['Start the label with a verb.'],
+  donts: ["Don't use a button to navigate. Use a Link."],
+  accessibility: {
+    role: 'button',
+    keyboard: ['Enter and Space activate it.'],
+    notes: ['An icon-only button needs an aria-label so screen readers can announce it.'],
+  },
+};
+
+test('planDocCard: full record → three rows with the canonical block layout', () => {
+  const plan = planDocCard(FULL_RECORD, 1500, { fontSize: 14 });
+  assert.equal(plan.rendererVersion, '2');
+  assert.equal(plan.columnUnit, 420);
+  assert.equal(plan.columns, 4);          // ceil(1500 / 420)
+  assert.equal(plan.cardWidth, 1680);     // 4 × 420
+  assert.equal(plan.termColumn, 126);     // round(420 × 0.3)
+  assert.deepEqual(plan.rows.map((r) => r.name), ['Usage Row 1', 'Usage Row 2', 'Usage Row 3']);
+  assert.deepEqual(plan.rows[0].blocks.map((b) => b.name),
+    ['Block: Overview', 'Block: When to use', 'Block: When not to use']);
+  assert.deepEqual(plan.rows[1].blocks.map((b) => [b.name, b.tone]),
+    [['Block: Do', 'positive'], ["Block: Don't", 'negative']]);
+  assert.deepEqual(plan.rows[2].blocks.map((b) => b.name), [
+    'Block: What each variant means',   // one definition block per variants axis, in key order
+    'Block: What each size means',
+    'Block: What each state means',
+    'Block: Accessibility',
+  ]);
+});
+
+test('planDocCard: definition terms preserve key order; accessibility = keyboard then notes, role dropped', () => {
+  const plan = planDocCard(FULL_RECORD, 1500, { fontSize: 14 });
+  const variantBlock = plan.rows[2].blocks[0];
+  assert.equal(variantBlock.type, 'definition');
+  assert.deepEqual(variantBlock.terms, [
+    { term: 'default', meaning: 'The one main action in a view.' },
+    { term: 'secondary', meaning: 'Sits alongside a main action.' },
+  ]);
+  const a11y = plan.rows[2].blocks[3];
+  assert.equal(a11y.type, 'list');
+  assert.deepEqual(a11y.items, [
+    'Enter and Space activate it.',
+    'An icon-only button needs an aria-label so screen readers can announce it.',
+  ]);
+});
+
+test('planDocCard: tone blocks carry the glyph eyebrows, plain deterministic names', () => {
+  const plan = planDocCard(FULL_RECORD, 1500, { fontSize: 14 });
+  assert.deepEqual(plan.rows[1].blocks.map((b) => b.eyebrow), ['✓ Do', "✕ Don't"]);
+});
+
+test('planDocCard: sparse record → only Usage Row 1 with Overview; empty rows collapse', () => {
+  const plan = planDocCard(
+    { name: 'Badge', summary: 's', description: 'A small label.' }, 200, { fontSize: 16 },
+  );
+  assert.equal(plan.columnUnit, 480);
+  assert.equal(plan.columns, 3);         // 3-unit floor
+  assert.equal(plan.cardWidth, 1440);
+  assert.deepEqual(plan.rows.map((r) => r.name), ['Usage Row 1']);
+  assert.deepEqual(plan.rows[0].blocks.map((b) => b.name), ['Block: Overview']);
+});
+
+test('planDocCard: row names keep canonical numbers when an earlier row is absent', () => {
+  const plan = planDocCard(
+    { name: 'X', summary: 's', description: '', states: { hover: 'Pointer over it.' } },
+    200, { fontSize: 16 },
+  );
+  // No description/whenToUse (row 1 empty), no dos/donts (row 2 empty) — the
+  // states row is still named Usage Row 3, never renumbered.
+  assert.deepEqual(plan.rows.map((r) => r.name), ['Usage Row 3']);
+});
+
+test('planDocCard: empty arrays and empty objects are skipped like absent fields', () => {
+  const plan = planDocCard(
+    { name: 'X', summary: 's', description: 'd', whenToUse: [], variants: {}, dos: [] },
+    200, { fontSize: 16 },
+  );
+  assert.deepEqual(plan.rows.map((r) => r.name), ['Usage Row 1']);
+  assert.deepEqual(plan.rows[0].blocks.map((b) => b.name), ['Block: Overview']);
+});
+```
+
+- [ ] **Step 2: Run the tests — verify they fail**
+
+```bash
+node --test scripts/lib/doc-card-plan.test.mjs
+```
+
+Expected failure: `planDocCard` is not exported (SyntaxError on the named import).
+
+- [ ] **Step 3: Implement**
+
+Append to `scripts/lib/doc-card-plan.mjs`:
+
+```js
+function listBlock(eyebrow, items) {
+  if (!Array.isArray(items) || items.length === 0) return null;
+  return { type: 'list', name: `Block: ${eyebrow}`, eyebrow, items };
+}
+
+function definitionBlock(eyebrow, meanings) {
+  const terms = Object.keys(meanings || {}).map((k) => ({ term: k, meaning: meanings[k] }));
+  if (terms.length === 0) return null;
+  return { type: 'definition', name: `Block: ${eyebrow}`, eyebrow, terms };
+}
+
+// The whole layout decision, as data. Rows keep canonical numbering (an absent
+// row's number is skipped, never renumbered) so node names stay stable across
+// sparse records. bodyTextStyle: only .fontSize is read — passing a full Figma
+// TextStyle object is fine.
+export function planDocCard(record, specimenWidth, bodyTextStyle) {
+  const unit = columnUnit(bodyTextStyle.fontSize);
+  const columns = cardColumns(specimenWidth, unit);
+
+  const row1 = [];
+  if (typeof record.description === 'string' && record.description.trim() !== '') {
+    row1.push({ type: 'prose', name: 'Block: Overview', eyebrow: 'Overview', text: record.description });
+  }
+  const whenTo = listBlock('When to use', record.whenToUse);
+  if (whenTo) row1.push(whenTo);
+  const whenNot = listBlock('When not to use', record.whenNotToUse);
+  if (whenNot) row1.push(whenNot);
+
+  const row2 = [];
+  if (Array.isArray(record.dos) && record.dos.length) {
+    row2.push({ type: 'list-tone', name: 'Block: Do', eyebrow: '✓ Do', tone: 'positive', items: record.dos });
+  }
+  if (Array.isArray(record.donts) && record.donts.length) {
+    row2.push({ type: 'list-tone', name: "Block: Don't", eyebrow: "✕ Don't", tone: 'negative', items: record.donts });
+  }
+
+  const row3 = [];
+  for (const axis of Object.keys(record.variants || {})) {
+    const block = definitionBlock(`What each ${axis} means`, record.variants[axis]);
+    if (block) row3.push(block);
+  }
+  const stateBlock = definitionBlock('What each state means', record.states);
+  if (stateBlock) row3.push(stateBlock);
+  const a11y = record.accessibility || {};
+  // role is not rendered on the card — it lives in the description field / MDX.
+  const a11yBlock = listBlock('Accessibility', [...(a11y.keyboard || []), ...(a11y.notes || [])]);
+  if (a11yBlock) row3.push(a11yBlock);
+
+  const rows = [
+    { name: 'Usage Row 1', blocks: row1 },
+    { name: 'Usage Row 2', blocks: row2 },
+    { name: 'Usage Row 3', blocks: row3 },
+  ].filter((r) => r.blocks.length > 0);
+
+  return {
+    rendererVersion: DOC_CARD_RENDERER_VERSION,
+    columnUnit: unit,
+    columns,
+    cardWidth: columns * unit,
+    termColumn: Math.round(unit * 0.3),
+    rows,
+  };
+}
+```
+
+- [ ] **Step 4: Run the tests — verify they pass**
+
+```bash
+node --test scripts/lib/doc-card-plan.test.mjs
+```
+
+Expected: all 9 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lib/doc-card-plan.mjs scripts/lib/doc-card-plan.test.mjs
+git commit -m "feat(docs): doc-card planner — block selection and row assignment"
+```
+
+---
+
+## Task 3: `docs:check` — the `layout-upgrade-available` classification
+
+**Files:**
+- Modify: `scripts/docs-check.mjs` — header comment (line 5), `classifySurface` (line 21), the surface loop in `checkComponent` (line 60), the info print in `main()` (line 92). The `FAILING` set (line 75) is NOT modified.
+- Modify: `scripts/docs-check.test.mjs` (append tests)
+
+**Interfaces:**
+- Consumes: `DOC_CARD_RENDERER_VERSION` from `scripts/lib/doc-card-plan.mjs` (Task 1).
+- Produces: `classifySurface({ …, expectedRenderer })` — a new optional param, `null` by default (existing call sites unaffected). When set and `surface.renderer` is missing or numerically lower, the flags include `'layout-upgrade-available'`. `checkComponent` passes `expectedRenderer` only for the `docCard` surface.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/docs-check.test.mjs`:
+
+```js
+test('classifySurface: layout-upgrade-available when docCard renderer is missing', () => {
+  assert.deepEqual(
+    classifySurface({ currentCanonical: 'a', surface: { src: 'a', render: 'r' }, currentRenderHash: 'r', expectedRenderer: '2' }),
+    ['layout-upgrade-available'],
+  );
+});
+
+test('classifySurface: layout-upgrade-available when renderer is lower; silent when equal or higher', () => {
+  const base = { currentCanonical: 'a', currentRenderHash: 'r' };
+  assert.deepEqual(
+    classifySurface({ ...base, surface: { src: 'a', render: 'r', renderer: '1' }, expectedRenderer: '2' }),
+    ['layout-upgrade-available'],
+  );
+  assert.deepEqual(
+    classifySurface({ ...base, surface: { src: 'a', render: 'r', renderer: '2' }, expectedRenderer: '2' }),
+    [],
+  );
+  assert.deepEqual(
+    classifySurface({ ...base, surface: { src: 'a', render: 'r', renderer: '3' }, expectedRenderer: '2' }),
+    [],
+  );
+});
+
+test('classifySurface: no renderer check when expectedRenderer is null (non-docCard surfaces)', () => {
+  assert.deepEqual(
+    classifySurface({ currentCanonical: 'a', surface: { src: 'a', render: 'r' }, currentRenderHash: 'r' }),
+    [],
+  );
+});
+
+test('checkAll: an old-layout docCard is informational, never in the failing set', () => {
+  const { root, manifest, fp } = fixture();
+  manifest.components.meta.Button.doc.surfaces.docCard = { src: fp, render: 'whatever' };
+  const results = checkAll(manifest, root);
+  const docCard = results.find((r) => r.surface === 'docCard');
+  assert.ok(docCard, 'docCard surface should be reported');
+  assert.ok(docCard.flags.includes('layout-upgrade-available'));
+  // Every docCard flag must be informational — none from the failing set.
+  const failing = new Set(['canonical-changed', 'stale', 'edited', 'missing-record', 'missing-surface']);
+  assert.ok(docCard.flags.every((f) => !failing.has(f)), `unexpected failing flag in ${docCard.flags.join(',')}`);
+});
+
+test('checkAll: a stamped docCard (renderer "2") reports no layout upgrade', () => {
+  const { root, manifest, fp } = fixture();
+  manifest.components.meta.Button.doc.surfaces.docCard = { src: fp, render: 'whatever', renderer: '2' };
+  const results = checkAll(manifest, root);
+  const docCard = results.find((r) => r.surface === 'docCard');
+  // Still edit-unverified (the CLI can't read Figma), but no layout flag.
+  assert.ok(!docCard || !docCard.flags.includes('layout-upgrade-available'));
+});
+```
+
+- [ ] **Step 2: Run the tests — verify they fail**
+
+```bash
+node --test scripts/docs-check.test.mjs
+```
+
+Expected: the first two new `classifySurface` renderer tests and the first new `checkAll` test fail (`layout-upgrade-available` never appears — `expectedRenderer` is silently ignored as an unknown property). The `expectedRenderer`-null test and the stamped-docCard test pass even now (they assert absences) — they are regression guards. The existing 9 tests still pass.
+
+- [ ] **Step 3: Implement**
+
+In `scripts/docs-check.mjs`:
+
+**(a)** Replace the drift-class comment (lines 5–9):
+
+```js
+// Drift classes: canonical-changed | stale | edited | missing-surface | edit-unverified
+//                | layout-upgrade-available
+// (edit-unverified = a surface the CLI cannot read, e.g. Figma — informational;
+//  it is checked live by the Figma-connected skill instead.
+//  missing-surface = a repo surface that declares a file which is now gone — failing;
+//  distinct from edit-unverified, which has no file to read in the first place.
+//  layout-upgrade-available = informational, docCard only: the card's layout
+//  predates DOC_CARD_RENDERER_VERSION — re-render on next touch, never a failure.)
+```
+
+**(b)** Add the import (after line 16, below the existing `doc-record.mjs` import):
+
+```js
+import { DOC_CARD_RENDERER_VERSION } from './lib/doc-card-plan.mjs';
+```
+
+**(c)** Replace `classifySurface` (lines 21–32):
+
+```js
+export function classifySurface({ currentCanonical, surface, currentRenderHash, fileMissing = false, expectedRenderer = null }) {
+  const flags = [];
+  if (surface.src !== currentCanonical) flags.push('stale');
+  if (fileMissing) {
+    flags.push('missing-surface');
+  } else if (currentRenderHash === null) {
+    flags.push('edit-unverified');
+  } else if (surface.render !== currentRenderHash) {
+    flags.push('edited');
+  }
+  if (expectedRenderer !== null
+      && (!surface.renderer || Number(surface.renderer) < Number(expectedRenderer))) {
+    flags.push('layout-upgrade-available');
+  }
+  return flags;
+}
+```
+
+**(d)** In `checkComponent`, replace the `classifySurface` call (line 60):
+
+```js
+    const flags = classifySurface({
+      currentCanonical, surface, currentRenderHash, fileMissing,
+      expectedRenderer: surfaceName === 'docCard' ? DOC_CARD_RENDERER_VERSION : null,
+    });
+```
+
+**(e)** In `main()`, replace the info print (line 92) so the Figma-session suffix only appears where it applies:
+
+```js
+  for (const r of info) {
+    const note = r.flags.includes('edit-unverified') ? ' (check in a Figma session)' : '';
+    console.log(`  ~ ${r.name} · ${r.surface}: ${r.flags.join(', ')}${note}`);
+  }
+```
+
+Wait — step 1's new `classifySurface` tests pass a `currentRenderHash` that matches `render`, so `edit-unverified`/`edited` don't fire and the renderer flag is isolated. The `checkAll` docCard tests exercise the real path where `currentRenderHash` is `null` (Figma surface), so `edit-unverified` co-occurs — that's why the first `checkAll` assertion checks `includes`, not `deepEqual`.
+
+- [ ] **Step 4: Run the full suite — verify everything passes**
+
+```bash
+node --test
+```
+
+Expected: all tests pass (the 5 new ones and every pre-existing test across the repo).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/docs-check.mjs scripts/docs-check.test.mjs
+git commit -m "feat(docs): informational layout-upgrade-available classification in docs:check"
+```
+
+---
+
+## Task 4: The Figma renderer template
+
+**Files:**
+- Create: `scripts/lib/doc-card-render.figma.js`
+
+**Interfaces:**
+- Consumes: `planDocCard`, `DOC_CARD_RENDERER_VERSION` — NOT via import: the build script (Task 5) concatenates the planner source above this template, so the template references them as in-scope globals. It also references two slot constants the calling agent defines: `RECORD` (unused by the template itself — the caller passes it into `renderDocCard`) and `CANONICAL_FP`.
+- Produces: `renderDocCard({ card, record, vars, bodyTextStyle }) → summary` (shapes in *Interface contracts*), plus `fnv1a(str) → 8-hex-char string`. This file is plain text to Node — never imported, never tested directly; it is validated by `node --check` (syntax) here and by the build test (Task 5).
+
+- [ ] **Step 1: Write the template**
+
+Create `scripts/lib/doc-card-render.figma.js`:
+
+```js
+// Figma plugin-API renderer for the doc-card Usage band. This file is NOT a
+// Node module — build-doc-card-builder.mjs concatenates it after the inlined
+// planner (doc-card-plan.mjs) into references/doc-card-builder.md, and the
+// result runs inside figma_execute (dynamic-page mode). Constraints honored
+// here (see references/figma-scripting.md): async APIs only, style/font set
+// BEFORE .characters, fonts loaded up front, resize() sizing modes re-asserted,
+// bound paints seeded light-gray (never pure black).
+//
+// In-scope globals when assembled: planDocCard, DOC_CARD_RENDERER_VERSION
+// (inlined planner) and the caller-filled slots RECORD, CANONICAL_FP.
+
+// 32-bit FNV-1a — the render hash. Only ever compared against itself (the
+// manifest's surfaces.docCard.render), so it does not need to match the
+// sha256-based canonical fingerprint, which cannot run in the Figma sandbox.
+function fnv1a(str) {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h.toString(16).padStart(8, '0');
+}
+
+const REQUIRED_VARS = [
+  'textDefault', 'textMuted', 'tonePositive', 'toneNegative', 'border',
+  'spacePadding', 'spaceRowGap', 'spaceBlockGap', 'spaceItemGap',
+];
+
+// Bound paint, seeded with a light-gray approximation — a failed/late bind must
+// never render pure black (reads as accidental dark mode).
+function boundPaint(variable) {
+  return figma.variables.setBoundVariableForPaint(
+    { type: 'SOLID', color: { r: 0.85, g: 0.85, b: 0.87 } }, 'color', variable,
+  );
+}
+
+async function renderDocCard({ card, record, vars, bodyTextStyle }) {
+  // Bind-or-throw: a missing variable or style is a gap in the token set —
+  // never fall back to a hex/px.
+  for (const key of REQUIRED_VARS) {
+    if (!vars || !vars[key]) {
+      throw new Error('renderDocCard: missing required variable "' + key
+        + '" — resolve it via figma_get_variables / getVariableByIdAsync and pass the Variable object in vars');
+    }
+  }
+  if (!bodyTextStyle) {
+    throw new Error('renderDocCard: bodyTextStyle is required — find the "Body/Default" text style via getLocalTextStylesAsync');
+  }
+
+  // Fonts, up front — before any text node exists. Eyebrow chrome is Bold of
+  // the body family; fall back to the body style's own font if no Bold exists.
+  const bodyFont = bodyTextStyle.fontName;
+  await figma.loadFontAsync(bodyFont);
+  let eyebrowFont = { family: bodyFont.family, style: 'Bold' };
+  try { await figma.loadFontAsync(eyebrowFont); } catch (e) { eyebrowFont = bodyFont; }
+
+  // Measure the specimen: the band named "Specimen", or (older cards) the
+  // component set inside the card.
+  const specimen = card.findChild((n) => n.name === 'Specimen')
+    || card.findOne((n) => n.type === 'COMPONENT_SET');
+  if (!specimen) {
+    throw new Error('renderDocCard: no "Specimen" frame or COMPONENT_SET found inside the card');
+  }
+
+  const plan = planDocCard(record, specimen.width, { fontSize: bodyTextStyle.fontSize });
+
+  // Eyebrow chrome (derived, not bound — layout chrome like the column unit):
+  // fontSize × 0.65 rounded, min 8; Bold; uppercase; letter-spacing +8%.
+  const eyebrowSize = Math.max(8, Math.round(bodyTextStyle.fontSize * 0.65));
+
+  // Idempotent + scoped: rebuild ONLY the Usage frame. Header and specimen are
+  // never touched — recreating a component set detaches downstream instances.
+  const existing = card.findChild((n) => n.name === 'Usage');
+  if (existing) existing.remove();
+
+  const eyebrowText = (chars, colorVar) => {
+    const t = figma.createText();
+    t.fontName = eyebrowFont;          // loaded above — set BEFORE .characters
+    t.fontSize = eyebrowSize;
+    t.letterSpacing = { value: 8, unit: 'PERCENT' };
+    t.textCase = 'UPPER';
+    t.characters = chars;
+    t.fills = [boundPaint(colorVar)];
+    return t;
+  };
+
+  const bodyText = async (chars, colorVar) => {
+    const t = figma.createText();
+    await t.setTextStyleIdAsync(bodyTextStyle.id);  // style BEFORE characters
+    t.characters = chars;
+    t.fills = [boundPaint(colorVar)];
+    return t;
+  };
+
+  // Appends `t` to `parent` as a full-width, height-hugging text node.
+  const fillWidth = (parent, t) => {
+    parent.appendChild(t);
+    t.textAutoResize = 'HEIGHT';
+    t.layoutSizingHorizontal = 'FILL';
+  };
+
+  const usage = figma.createFrame();
+  usage.name = 'Usage';
+  usage.layoutMode = 'VERTICAL';
+  usage.fills = [];
+  card.appendChild(usage);
+  usage.resize(plan.cardWidth, usage.height);
+  usage.counterAxisSizingMode = 'FIXED';  // VERTICAL frame: counter = width
+  usage.primaryAxisSizingMode = 'AUTO';   // height hugs — re-asserted after resize()
+  usage.setBoundVariable('paddingLeft', vars.spacePadding);
+  usage.setBoundVariable('paddingRight', vars.spacePadding);
+  usage.setBoundVariable('paddingTop', vars.spacePadding);
+  usage.setBoundVariable('paddingBottom', vars.spacePadding);
+  usage.setBoundVariable('itemSpacing', vars.spaceRowGap);
+
+  // If the card is narrower than the computed width and not hugging, widen it —
+  // this touches only the card's own size, never its children.
+  if (card.width < plan.cardWidth && !(card.layoutMode === 'VERTICAL' && card.counterAxisSizingMode === 'AUTO')) {
+    card.resize(plan.cardWidth, card.height);
+    if (card.layoutMode === 'VERTICAL') card.primaryAxisSizingMode = 'AUTO';
+  }
+
+  const blocksCreated = [];
+  let first = true;
+  for (const row of plan.rows) {
+    if (!first) {
+      const divider = figma.createFrame();
+      divider.name = 'Row Divider';
+      divider.fills = [boundPaint(vars.border)];
+      usage.appendChild(divider);
+      divider.layoutSizingHorizontal = 'FILL';
+      divider.resize(divider.width, 1);
+    }
+    first = false;
+
+    const rowFrame = figma.createFrame();
+    rowFrame.name = row.name;
+    rowFrame.layoutMode = 'HORIZONTAL';
+    rowFrame.layoutWrap = 'WRAP';
+    rowFrame.fills = [];
+    rowFrame.counterAxisAlignItems = 'MIN';  // top-aligned…
+    rowFrame.primaryAxisAlignItems = 'MIN';  // …left-packed; never center/space-between
+    usage.appendChild(rowFrame);
+    rowFrame.layoutSizingHorizontal = 'FILL';
+    rowFrame.layoutSizingVertical = 'HUG';
+    rowFrame.setBoundVariable('itemSpacing', vars.spaceBlockGap);
+    rowFrame.setBoundVariable('counterAxisSpacing', vars.spaceRowGap);
+
+    for (const block of row.blocks) {
+      const bf = figma.createFrame();
+      bf.name = block.name;
+      bf.layoutMode = 'VERTICAL';
+      bf.fills = [];
+      rowFrame.appendChild(bf);
+      bf.resize(plan.columnUnit, bf.height);   // every block is exactly one unit wide
+      bf.counterAxisSizingMode = 'FIXED';
+      bf.primaryAxisSizingMode = 'AUTO';
+      bf.setBoundVariable('itemSpacing', vars.spaceItemGap);
+
+      const eyebrowColor = block.type === 'list-tone'
+        ? (block.tone === 'positive' ? vars.tonePositive : vars.toneNegative)
+        : vars.textMuted;
+      const eb = eyebrowText(block.eyebrow, eyebrowColor);
+      bf.appendChild(eb);
+      eb.textAutoResize = 'HEIGHT';
+      eb.layoutSizingHorizontal = 'FILL';
+
+      if (block.type === 'prose') {
+        fillWidth(bf, await bodyText(block.text, vars.textDefault));
+      } else if (block.type === 'list' || block.type === 'list-tone') {
+        for (const item of block.items) {
+          fillWidth(bf, await bodyText('• ' + item, vars.textDefault));
+        }
+      } else if (block.type === 'definition') {
+        for (const pair of block.terms) {
+          const pf = figma.createFrame();
+          pf.name = 'Definition: ' + pair.term;
+          pf.layoutMode = 'HORIZONTAL';
+          pf.fills = [];
+          bf.appendChild(pf);
+          pf.layoutSizingHorizontal = 'FILL';
+          pf.layoutSizingVertical = 'HUG';
+          pf.setBoundVariable('itemSpacing', vars.spaceItemGap);
+          const term = await bodyText(pair.term, vars.textDefault);
+          pf.appendChild(term);
+          term.textAutoResize = 'HEIGHT';        // long terms wrap, never truncate
+          term.resize(plan.termColumn, term.height);
+          term.layoutSizingHorizontal = 'FIXED'; // fixed term column: 30% of the unit
+          const meaning = await bodyText(pair.meaning, vars.textMuted);
+          pf.appendChild(meaning);
+          meaning.textAutoResize = 'HEIGHT';
+          meaning.layoutSizingHorizontal = 'FILL';
+        }
+      }
+      blocksCreated.push(block.name);
+    }
+  }
+
+  // Metadata node — hidden, machine-read by the drift check's Figma-side pass.
+  const fp = eyebrowText(CANONICAL_FP, vars.textMuted);
+  fp.name = 'Doc Fingerprint';
+  fp.visible = false;
+  usage.appendChild(fp);
+
+  return {
+    rendererVersion: DOC_CARD_RENDERER_VERSION,
+    columnUnit: plan.columnUnit,
+    columns: plan.columns,
+    cardWidth: plan.cardWidth,
+    rowsRendered: plan.rows.length,
+    blocksCreated,
+    fingerprint: CANONICAL_FP,
+    renderHash: fnv1a(JSON.stringify(plan)),
+  };
+}
+```
+
+- [ ] **Step 2: Verify the template is syntactically valid JavaScript**
+
+```bash
+node --check scripts/lib/doc-card-render.figma.js
+```
+
+Expected: exits 0 with no output (`figma`, `planDocCard`, `DOC_CARD_RENDERER_VERSION`, `RECORD`, and `CANONICAL_FP` are unresolved identifiers, which is fine — `--check` parses without executing).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/lib/doc-card-render.figma.js
+git commit -m "feat(docs): Figma renderer template for the doc-card Usage band"
+```
+
+---
+
+## Task 5: The build script and the generated reference
+
+**Files:**
+- Create: `scripts/build-doc-card-builder.mjs`
+- Create: `scripts/build-doc-card-builder.test.mjs`
+- Create (generated): `references/doc-card-builder.md`
+
+**Interfaces:**
+- Consumes: `scripts/lib/doc-card-plan.mjs` (read as text), `scripts/lib/doc-card-render.figma.js` (read as text).
+- Produces: `buildDocCardBuilder({ plannerSource, rendererSource }) → string` (the full markdown), CLI `node scripts/build-doc-card-builder.mjs` (writes `references/doc-card-builder.md`) and `--check` (exit 1 + diff message when out of date — the CI gate Task 6 wires). Skills consume `references/doc-card-builder.md` via `${CLAUDE_PLUGIN_ROOT}` (Task 8).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `scripts/build-doc-card-builder.test.mjs`:
+
+```js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildDocCardBuilder } from './build-doc-card-builder.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const realPlanner = () => readFileSync(join(HERE, 'lib', 'doc-card-plan.mjs'), 'utf8');
+const realRenderer = () => readFileSync(join(HERE, 'lib', 'doc-card-render.figma.js'), 'utf8');
+
+test('build: inlines the planner with export keywords stripped, no module syntax survives', () => {
+  const md = buildDocCardBuilder({ plannerSource: realPlanner(), rendererSource: realRenderer() });
+  assert.match(md, /function planDocCard\(/);
+  assert.match(md, /const DOC_CARD_RENDERER_VERSION = '2'/);
+  assert.match(md, /async function renderDocCard\(/);
+  const snippet = md.slice(md.indexOf('```js'), md.lastIndexOf('```'));
+  assert.ok(!/^\s*(import|export)\b/m.test(snippet), 'snippet must contain no import/export lines');
+});
+
+test('build: refuses a planner that has imports (the inlinability guard)', () => {
+  assert.throws(
+    () => buildDocCardBuilder({
+      plannerSource: "import { x } from 'node:fs';\nexport function planDocCard() {}\n",
+      rendererSource: realRenderer(),
+    }),
+    /import-free/,
+  );
+});
+
+test('build: the generated markdown carries the do-not-edit warning and the slot instructions', () => {
+  const md = buildDocCardBuilder({ plannerSource: realPlanner(), rendererSource: realRenderer() });
+  assert.match(md, /GENERATED FILE — do not edit by hand/);
+  assert.match(md, /const RECORD =/);
+  assert.match(md, /const CANONICAL_FP =/);
+  assert.match(md, /spaceItemGap/); // the vars contract is documented
+});
+
+test('build: output is deterministic', () => {
+  const args = { plannerSource: realPlanner(), rendererSource: realRenderer() };
+  assert.equal(buildDocCardBuilder(args), buildDocCardBuilder(args));
+});
+
+test('generated reference on disk is in sync with the sources', () => {
+  const expected = buildDocCardBuilder({ plannerSource: realPlanner(), rendererSource: realRenderer() });
+  const onDisk = readFileSync(join(HERE, '..', 'references', 'doc-card-builder.md'), 'utf8');
+  assert.equal(onDisk, expected, 'run: node scripts/build-doc-card-builder.mjs');
+});
+```
+
+- [ ] **Step 2: Run the tests — verify they fail**
+
+```bash
+node --test scripts/build-doc-card-builder.test.mjs
+```
+
+Expected failure: `Cannot find module … build-doc-card-builder.mjs`.
+
+- [ ] **Step 3: Implement the build script**
+
+Create `scripts/build-doc-card-builder.mjs`. The markdown header/footer are built as line arrays (not template literals) so the emitted `` ` `` and `${…}` need no escaping:
+
+```js
+// Generates references/doc-card-builder.md — the canonical figma_execute
+// snippet that renders a doc card's Usage band — by inlining the pure planner
+// (lib/doc-card-plan.mjs) above the Figma renderer template
+// (lib/doc-card-render.figma.js). Mirrors the adapters generate.mjs idiom:
+// run bare to write, run with --check to gate CI. Zero dependencies.
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const PLANNER = join(REPO_ROOT, 'scripts', 'lib', 'doc-card-plan.mjs');
+const RENDERER = join(REPO_ROOT, 'scripts', 'lib', 'doc-card-render.figma.js');
+const OUT = join(REPO_ROOT, 'references', 'doc-card-builder.md');
+
+const HEADER = [
+  '# Doc-card Usage-band builder (GENERATED)',
+  '',
+  '> **GENERATED FILE — do not edit by hand.** Sources: `scripts/lib/doc-card-plan.mjs`',
+  '> (the pure planner, unit-tested in Node) + `scripts/lib/doc-card-render.figma.js`',
+  '> (the Figma renderer). Regenerate with `node scripts/build-doc-card-builder.mjs`;',
+  '> CI gates freshness with `--check`.',
+  '',
+  'The canonical `figma_execute` snippet that renders a component doc card\'s',
+  '`Usage` band from its `.doc.json` record. Every card is identical by',
+  'construction — never hand-build the usage body. The snippet rebuilds ONLY the',
+  'frame named `Usage`; the header and specimen bands are never touched.',
+  '',
+  '## How to call it',
+  '',
+  '1. Load the record and compute its canonical fingerprint in Node',
+  '   (`canonicalFingerprint` in `scripts/lib/doc-record.mjs`).',
+  '2. Resolve the nine required semantic variables via `figma_get_variables`,',
+  '   then in the script fetch each as a Variable object with',
+  '   `figma.variables.getVariableByIdAsync(id)`:',
+  '   `textDefault`, `textMuted` (text colors), `tonePositive`, `toneNegative`',
+  '   (Do/Don\'t eyebrow colors — success/danger roles), `border` (row dividers),',
+  '   `spacePadding`, `spaceRowGap`, `spaceBlockGap`, `spaceItemGap` (spacing',
+  '   roles: band padding, row gap, block gutter, within-block gap).',
+  '3. Find the body text style: `(await figma.getLocalTextStylesAsync())',
+  '   .find((s) => s.name === \'Body/Default\')`. Missing variables or style =',
+  '   the builder throws (bind-or-throw — the gap is in the token set; fix it',
+  '   there, never hardcode around it).',
+  '4. Prepend the two slots, then the snippet below, then the call:',
+  '',
+  '```js',
+  'const RECORD = /* the parsed .doc.json object */;',
+  'const CANONICAL_FP = \'/* canonicalFingerprint(RECORD), 16 hex chars */\';',
+  '// … the generated snippet …',
+  'const card = await figma.getNodeByIdAsync(cardNodeId);',
+  'const summary = await renderDocCard({ card, record: RECORD, vars, bodyTextStyle });',
+  '```',
+  '',
+  '5. Pass an explicit `timeout` (30000 is right for one card; the ~30s',
+  '   `figma_execute` ceiling fits a single card comfortably — render cards one',
+  '   call at a time, never batched).',
+  '6. Verify from the returned summary — `rowsRendered`, `blocksCreated`,',
+  '   `cardWidth` — not from a screenshot, then stamp the manifest from it:',
+  '   `surfaces.docCard = { src: summary.fingerprint, render: summary.renderHash,',
+  '   renderer: summary.rendererVersion }`. Never re-read the card to stamp.',
+  '',
+  '## The snippet',
+  '',
+  '```js',
+].join('\n');
+
+const FOOTER = [
+  '```',
+  '',
+  'Layout contract and rationale:',
+  '`docs/superpowers/specs/2026-08-09-doc-card-layout-and-voice-design.md`.',
+  '',
+].join('\n');
+
+export function buildDocCardBuilder({ plannerSource, rendererSource }) {
+  const inlined = plannerSource
+    .replace(/^export const /gm, 'const ')
+    .replace(/^export function /gm, 'function ');
+  for (const [name, src] of [['doc-card-plan.mjs', inlined], ['doc-card-render.figma.js', rendererSource]]) {
+    if (/^\s*(import|export)\b/m.test(src)) {
+      throw new Error(`${name} must stay import-free (only top-level \`export const\`/\`export function\` allowed in the planner) — it is inlined into the Figma snippet where no module system exists`);
+    }
+  }
+  return `${HEADER}\n${inlined}\n${rendererSource}${FOOTER}`;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const result = buildDocCardBuilder({
+    plannerSource: readFileSync(PLANNER, 'utf8'),
+    rendererSource: readFileSync(RENDERER, 'utf8'),
+  });
+  if (process.argv.includes('--check')) {
+    let onDisk = null;
+    try { onDisk = readFileSync(OUT, 'utf8'); } catch (e) { /* missing counts as drift */ }
+    if (onDisk !== result) {
+      console.error('✗ references/doc-card-builder.md out of date; run: node scripts/build-doc-card-builder.mjs');
+      process.exit(1);
+    }
+    console.log('✓ doc-card builder in sync');
+  } else {
+    writeFileSync(OUT, result);
+    console.log('✓ wrote references/doc-card-builder.md');
+  }
+}
+```
+
+- [ ] **Step 4: Generate the reference, then run the tests — verify they pass**
+
+```bash
+node scripts/build-doc-card-builder.mjs
+node --test scripts/build-doc-card-builder.test.mjs
+```
+
+Expected: `✓ wrote references/doc-card-builder.md`, then all 5 tests pass (the in-sync test now finds the file on disk).
+
+- [ ] **Step 5: Verify the --check mode gates drift**
+
+```bash
+node scripts/build-doc-card-builder.mjs --check && echo IN-SYNC
+printf '\n' >> references/doc-card-builder.md
+node scripts/build-doc-card-builder.mjs --check; echo "exit: $?"
+node scripts/build-doc-card-builder.mjs
+```
+
+Expected: `IN-SYNC`; then the drift message with `exit: 1`; then the file is regenerated clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/build-doc-card-builder.mjs scripts/build-doc-card-builder.test.mjs references/doc-card-builder.md
+git commit -m "feat(docs): generate references/doc-card-builder.md from planner + renderer (--check gate)"
+```
+
+---
+
+## Task 6: CI wiring and the scripts README
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (insert after line 23 — the `node scripts/adapters/generate.mjs --check` run line)
+- Modify: `.github/workflows/release.yml` (insert after line 41 — same run line)
+- Modify: `scripts/README.md` (append two table rows after the `docs-check.mjs` row, line 16)
+
+**Interfaces:**
+- Consumes: `node scripts/build-doc-card-builder.mjs --check` (Task 5).
+- Produces: CI/release gates; no code interfaces.
+
+- [ ] **Step 1: Wire ci.yml**
+
+In `.github/workflows/ci.yml`, after the existing adapter check (lines 22–23):
+
+```yaml
+      - name: Check adapters are up to date
+        run: node scripts/adapters/generate.mjs --check
+```
+
+insert:
+
+```yaml
+      - name: Check doc-card builder is up to date
+        run: node scripts/build-doc-card-builder.mjs --check
+```
+
+- [ ] **Step 2: Wire release.yml**
+
+In `.github/workflows/release.yml`, insert the identical two lines after the adapter check at lines 40–41.
+
+- [ ] **Step 3: Add the README rows**
+
+In `scripts/README.md`, after the `docs-check.mjs` row (line 16), append to the table:
+
+```markdown
+| `lib/doc-card-plan.mjs` | Pure layout planner for the doc card's `Usage` band + `DOC_CARD_RENDERER_VERSION` (single source of the layout version). Inlined into `references/doc-card-builder.md`; imported by `docs-check.mjs`. | inlined into the generated builder |
+| `build-doc-card-builder.mjs` | Generate `references/doc-card-builder.md` from the planner + the Figma renderer template (`lib/doc-card-render.figma.js`). `--check` gates CI. | plugin-internal (not installed) |
+```
+
+- [ ] **Step 4: Verify the gates run clean locally**
+
+```bash
+node scripts/build-doc-card-builder.mjs --check && node scripts/adapters/generate.mjs --check && node --test
+```
+
+Expected: `✓ doc-card builder in sync`, `✓ adapters in sync`, all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/ci.yml .github/workflows/release.yml scripts/README.md
+git commit -m "ci: gate doc-card builder generation in CI and release"
+```
+
+---
+
+## Task 7: Document the `renderer` field in the schema references
+
+**Files:**
+- Modify: `references/component-doc-schema.md` — the manifest-pointer JSON (line 108) + the bullet list under it (after line 118) + the drift contract (after line 129)
+- Modify: `references/manifest-schema.md` — the `meta[name].doc` shape (line 256) + a following sentence
+
+**Interfaces:**
+- Consumes: the `renderer` semantics from Tasks 3–5 (`DOC_CARD_RENDERER_VERSION`, `layout-upgrade-available`).
+- Produces: documentation only — the contract Task 8's skill wiring cites.
+
+- [ ] **Step 1: Update component-doc-schema.md**
+
+**(a)** In the manifest-pointer JSON block, replace line 108:
+
+```json
+      "docCard":          { "src": "<fp>", "render": "<hash of card content>" },
+```
+
+with:
+
+```json
+      "docCard":          { "src": "<fp>", "render": "<hash of card content>", "renderer": "2" },
+```
+
+**(b)** After the `file` bullet (line 118), add:
+
+```markdown
+- `renderer` — (docCard only) the layout version of the builder that last
+  rendered the card: `DOC_CARD_RENDERER_VERSION` in `scripts/lib/doc-card-plan.mjs`,
+  currently `"2"`. Additive and optional — absence means the card predates the
+  versioned builder. Stamped from the builder's returned summary, never by
+  re-reading the card.
+```
+
+**(c)** In the drift contract list (after the `edited` entry at line 125), add:
+
+```markdown
+- **layout-upgrade-available** — informational, never failing, docCard only:
+  `surfaces.docCard.renderer` is missing or lower than the current
+  `DOC_CARD_RENDERER_VERSION`. The card's content is not in drift — its layout
+  predates the current builder. Re-render on next touch (no unprompted Figma
+  writes; untouched brownfield cards must not generate a standing warning wall).
+```
+
+- [ ] **Step 2: Update manifest-schema.md**
+
+Replace the shape on line 256:
+
+```markdown
+  `{ path, fingerprint, surfaces: { <surfaceName>: { src, render, file? } } }`,
+```
+
+with:
+
+```markdown
+  `{ path, fingerprint, surfaces: { <surfaceName>: { src, render, file?, renderer? } } }`,
+```
+
+and, in the explanatory sentences that follow (lines 257–263), after the `render` explanation, add:
+
+```markdown
+  `renderer` (docCard only) is the layout version of the builder that last
+  rendered the card (`DOC_CARD_RENDERER_VERSION`); missing/lower is reported by
+  `docs:check` as the informational `layout-upgrade-available`, never as drift.
+```
+
+- [ ] **Step 3: Verify plugin validation still passes**
+
+```bash
+node ci/validate-plugin.mjs && node ci/validate-skills.mjs
+```
+
+Expected: both exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add references/component-doc-schema.md references/manifest-schema.md
+git commit -m "docs: renderer version field on the docCard surface (schema + manifest references)"
+```
+
+---
+
+## Task 8: Wire the builder into the standards doc, skill, and command; regenerate adapters
+
+**Files:**
+- Modify: `references/figma-component-standards.md` — the doc-card intro (lines 284–286), the auto-layout section (line 406+), the audit exception in item 3 (line 486+), a new audit item 11 (after item 10, line 523–524), the closing count (line 527–528)
+- Modify: `skills/component-builder/SKILL.md` — the *Doc card body* bullet (lines 276–280), the manifest bullet (lines 284–288)
+- Modify: `commands/document-component.md` — step 2 (lines 17–20), step 3 (lines 21–25)
+- Modify: `CHANGELOG.md` — add an `## [Unreleased]` section (after line 6)
+- Modify (generated): `adapters/**` — regenerated, never hand-edited
+
+**Interfaces:**
+- Consumes: `references/doc-card-builder.md` (Task 5), the summary/manifest-stamping contract (*Interface contracts*), `layout-upgrade-available` (Task 3).
+- Produces: the prose wiring skills follow at run time. No code.
+
+- [ ] **Step 1: Rewrite the doc-card intro to the three-band architecture**
+
+In `references/figma-component-standards.md`, replace lines 284–286:
+
+```markdown
+Wrap each generated component in a "doc card" — a frame that holds the component
+plus a small header. Never leave components floating on bare canvas. The card
+shows:
+```
+
+with:
+
+```markdown
+Wrap each generated component in a "doc card" — a **vertical, three-band
+auto-layout frame**: a **header** band, a **specimen** band (a frame named
+`Specimen` holding the component set), and a **`Usage`** band holding the
+documentation body. Never leave components floating on bare canvas.
+
+**The `Usage` band is never hand-built.** It is rendered by the canonical
+builder snippet in `${CLAUDE_PLUGIN_ROOT}/references/doc-card-builder.md`
+(generated — that file carries the full call contract: the record/fingerprint
+slots, the nine required semantic variables, the `Body/Default` text style, and
+the returned summary you verify and stamp the manifest from). The builder
+computes the card's width from the specimen and the body type — a column-unit
+grid whose text fills its block, not the card — and rebuilds only the `Usage`
+frame, leaving header and specimen untouched. The header's short-description
+text node is clamped to one column unit wide (`summary.columnUnit` from the
+builder's return), so it never stretches across a wide matrix.
+
+The header shows:
+```
+
+- [ ] **Step 2: Point the auto-layout section at the builder**
+
+In the same file, in "### Auto layout inside the card" (lines 404–411), after the sentence ending "proper auto layout eliminates it." (line 411), append to the paragraph:
+
+```markdown
+The `Usage` band's internal layout (rows, wrapping, block widths) is entirely
+the builder's job — these auto-layout rules apply to the header band and any
+hand-built chrome, not to nodes inside `Usage`.
+```
+
+- [ ] **Step 3: Amend audit item 3's exception and add audit item 11**
+
+**(a)** In audit item 3 ("Variables bound", lines 486–492), after "No hardcoded values anywhere in the doc-card chrome." (line 488), insert:
+
+```markdown
+   **Two documented exceptions inside the `Usage` band** (layout chrome, not
+   design values, both produced by the builder): the computed column-unit width
+   on blocks, and the derived eyebrow type (size/case/tracking/weight). All
+   other `Usage` properties — padding, gaps, text colors, dividers — must still
+   resolve to bound variables.
+```
+
+**(b)** After item 10 ("Visual", lines 523–524), add:
+
+```markdown
+11. **Usage band rendered by the builder** — the card's `Usage` frame was
+   created by `renderDocCard`
+   (`${CLAUDE_PLUGIN_ROOT}/references/doc-card-builder.md`) in this session, and
+   the returned summary matches the record: `rowsRendered` and `blocksCreated`
+   line up with the record's populated blocks, `cardWidth` is a whole multiple
+   of `columnUnit` (minimum 3), and the frame contains the deterministic names
+   (`Usage`, `Usage Row 1..3`, `Block: …`, `Doc Fingerprint`). Verify from the
+   summary, not a screenshot. A hand-assembled usage body is a fail.
+```
+
+**(c)** Update the closing count (lines 527–528): replace "Only when all ten pass is the build done." with "Only when all eleven pass is the build done."
+
+- [ ] **Step 4: Update the component-builder skill**
+
+In `skills/component-builder/SKILL.md`:
+
+**(a)** Replace the *Doc card body* bullet (lines 276–280):
+
+```markdown
+- **Doc card body.** Extend the existing doc card (name/short-desc/status/date, per
+  `${CLAUDE_PLUGIN_ROOT}/references/figma-component-standards.md`) with a usage body:
+  when-to-use, do's/don'ts, an a11y line, and a variant/state legend — all
+  token-bound (no hardcoded hex/px). Add a metadata text node named
+  `Doc Fingerprint` holding `<fp>`.
+```
+
+with:
+
+```markdown
+- **Doc card body.** Render the card's `Usage` band with the canonical builder
+  snippet in `${CLAUDE_PLUGIN_ROOT}/references/doc-card-builder.md` (via
+  `figma_execute` with an explicit `timeout`, one card per call): fill the
+  RECORD/CANONICAL_FP slots, resolve the nine required semantic variables and
+  the `Body/Default` text style per that file's call contract, run it, and
+  verify the returned summary (`rowsRendered`, `blocksCreated`, `cardWidth`) —
+  not a screenshot. The builder creates the `Doc Fingerprint` node itself and
+  is the only thing that may build the usage body — never hand-assemble it.
+```
+
+**(b)** Replace the manifest bullet (lines 284–288):
+
+```markdown
+**Update the manifest (fields this skill owns):** set
+`components.meta[<Name>].doc` to `{ path, fingerprint: <fp>, surfaces: {
+figmaDescription: { src: <fp>, render: <hash of the description text> }, docCard: {
+src: <fp>, render: <hash of the card body content> } } }`. The code surfaces
+(`storybookMdx`) are added later by `storybook-chromatic-builder`.
+```
+
+with:
+
+```markdown
+**Update the manifest (fields this skill owns):** set
+`components.meta[<Name>].doc` to `{ path, fingerprint: <fp>, surfaces: {
+figmaDescription: { src: <fp>, render: <hash of the description text> }, docCard: {
+src: <fp>, render: <summary.renderHash>, renderer: <summary.rendererVersion> } } }`
+— the docCard entry is stamped from the builder's returned summary, never by
+re-reading the card. The code surfaces (`storybookMdx`) are added later by
+`storybook-chromatic-builder`.
+```
+
+- [ ] **Step 5: Update the document-component command**
+
+In `commands/document-component.md`:
+
+**(a)** Replace step 2 (lines 17–20):
+
+```markdown
+2. **Project it.** Write `design-system/docs/components/<Name>.doc.json`, set the
+   Figma component `description`, enrich the doc card, and (if the repo/code side
+   exists) render MDX/JSDoc and run `docs:digest` per the
+   `storybook-chromatic-builder` render step.
+```
+
+with:
+
+```markdown
+2. **Project it.** Write `design-system/docs/components/<Name>.doc.json`, set the
+   Figma component `description`, rebuild the doc card's `Usage` band with the
+   canonical builder (`${CLAUDE_PLUGIN_ROOT}/references/doc-card-builder.md` —
+   verify its returned summary and stamp `surfaces.docCard.{src,render,renderer}`
+   from it), and (if the repo/code side exists) render MDX/JSDoc and run
+   `docs:digest` per the `storybook-chromatic-builder` render step.
+```
+
+**(b)** In step 3 (lines 21–25), after the sentence ending "rather than overwriting it." (line 25), append:
+
+```markdown
+   `docs:check` may also report `layout-upgrade-available` (informational, never
+   failing): the card's layout predates the current builder. Offer to re-render
+   the `Usage` band now — rebuild happens on this touch, never unprompted.
+```
+
+- [ ] **Step 6: Add the CHANGELOG entry**
+
+In `CHANGELOG.md`, after the intro paragraph (line 6, before `## [0.14.0]`), insert:
+
+```markdown
+## [Unreleased]
+
+### Added
+- **Deterministic doc-card builder (layout phase).** The doc card's `Usage` band
+  is now rendered by a canonical, generated `figma_execute` snippet
+  (`references/doc-card-builder.md`) built from a pure, unit-tested layout
+  planner (`scripts/lib/doc-card-plan.mjs`) — a column-unit grid (three
+  wrapping rows, four closed block types) whose width grows with the variant
+  matrix instead of stretching text. Cards stamp a `renderer` version into the
+  manifest; `docs:check` reports old-layout cards as the informational
+  `layout-upgrade-available`, never as drift. CI gates the generated snippet
+  with `build-doc-card-builder.mjs --check`.
+```
+
+- [ ] **Step 7: Regenerate adapters and verify everything**
+
+```bash
+node scripts/adapters/generate.mjs
+node scripts/adapters/generate.mjs --check
+node scripts/build-doc-card-builder.mjs --check
+node ci/validate-plugin.mjs && node ci/validate-skills.mjs
+node --test
+```
+
+Expected: adapters regenerated then `✓ adapters in sync`; `✓ doc-card builder in sync`; both validators exit 0; all tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add references/figma-component-standards.md skills/component-builder/SKILL.md commands/document-component.md CHANGELOG.md adapters/
+git commit -m "feat(docs): three-band doc card — builder wiring in standards, skill, and command"
+```
+
+---
+
+## Done — acceptance check against the spec
+
+Plan-1 slice of the spec's success criteria (the dogfood on `throughline-sample`, criterion 6, runs after this plan lands and needs a live Figma session — it is the acceptance test, not a task here):
+
+- Criterion 2: `node --test` locks block selection, row assignment, per-axis definition blocks, column-unit computation, and card-width rounding (Tasks 1–2); `build-doc-card-builder.mjs --check` passes in CI (Tasks 5–6).
+- Criterion 3: rebuild scoped to the `Usage` frame only (Task 4's renderer; audit item 11 in Task 8 enforces it at run time).
+- Criterion 5: `docs:check` reports an old-layout card as `layout-upgrade-available` without failing, and a re-rendered card stamps `renderer: "2"` (Task 3; stamping contract in Tasks 5 and 8).
+- Criteria 1 and 4 belong to run-time skill behavior (1) and plan 2 (4).

--- a/docs/superpowers/specs/2026-08-09-doc-card-layout-and-voice-design.md
+++ b/docs/superpowers/specs/2026-08-09-doc-card-layout-and-voice-design.md
@@ -128,6 +128,14 @@ A wider matrix buys more columns rather than longer lines; a narrow specimen
 one modular rhythm instead of being raggedly sized. `specimenWidth` is measured
 in Figma at run time and passed to the planner as an input.
 
+The planner's `cardWidth` is the **content-grid** width. At render time the
+builder derives the `Usage` frame's outer width as
+`cardWidth + 2·padding + (columns − 1)·blockGap`, reading the resolved px of
+the bound spacing tokens via `resolveForConsumer`, and widens the card
+(its own padding included) when it is fixed-width and narrower. Without this,
+padding and gutters eat the content box and the last column always wraps. The
+card itself must be a VERTICAL auto-layout frame — the builder throws otherwise.
+
 ### Four block types — a closed set
 
 | Type | Renders | Used for |

--- a/docs/superpowers/specs/2026-08-09-doc-card-layout-and-voice-design.md
+++ b/docs/superpowers/specs/2026-08-09-doc-card-layout-and-voice-design.md
@@ -1,0 +1,446 @@
+# Doc-card layout system & documentation voice — design
+
+**Date:** 2026-08-09
+**Status:** Approved (design), pending implementation plan
+**Scope:** The **Figma component doc card** (the documentation that lives on
+component artboards) and the **writing standard** for all doc-record content.
+Builds directly on the Component Documentation Layer
+(`2026-07-14-component-documentation-layer-design.md`); the record schema, the
+four-source authoring pipeline, provenance, and the projection model are
+unchanged. The Foundations/token sheet and the icon card are out of scope.
+
+## Problem
+
+The v0.14.0 documentation layer works — records are authored, projected, and
+drift-checked — but the first real output surfaced two defects.
+
+**1. The doc card has no layout system.** The card chrome (frame, header, status
+chip, divider, token binding, audit gates) is specified in detail, but the
+documentation *body* gets one sentence of instruction
+(`skills/component-builder/SKILL.md:276`): "extend the existing doc card … with a
+usage body." An agent improvises the rest from scratch, differently every time.
+Worse, the existing card rules mandate that text nodes **fill the card width**
+(`references/figma-component-standards.md:407-408`) while the card is as wide as
+the variant matrix inside it — so a Button with 6 variants × 5 states produces a
+very wide card whose paragraphs stretch into unreadable single lines. On wide
+artboards the documentation looks broken; on all artboards it is plain text with
+none of the structure a published design system's documentation page has.
+
+**2. The copy is written for the machine that made it.** From the real dogfooded
+record (`throughline-sample/design-system/docs/components/Button.doc.json`):
+
+> "…It comes in six emphasis variants across three sizes, supports optional
+> leading and trailing icons and a loading state, and **binds every color,
+> spacing, radius, and type value to the system's semantic tokens**."
+
+Five recurring habits: inventory instead of guidance ("six emphasis variants
+across three sizes" — the specimen above already shows this); build-compliance
+assertions in user-facing prose (the token-binding clause); `whenToUse[0]`
+restating `summary` nearly verbatim; variant/state meanings written as verb-less
+spec fragments; and framework trivia in accessibility notes ("Renders a native
+`<button>`, so `role="button"` is implicit"). The archetype seeds read well —
+the drift happens in the AI-inferred blocks, where no writing standard holds the
+line.
+
+Both defects share a root cause: **the layout and the voice are produced by
+prose instruction and model judgment**, the same mechanism whose drift the rest
+of the plugin exists to prevent.
+
+## Goals
+
+1. A **designer-complete** doc card: everything a designer needs without leaving
+   Figma (what it is, when to use/not use, do's & don'ts, variant + state
+   meanings, accessibility). Engineering depth (props, tokens, code) stays in
+   Storybook.
+2. A **closed, deterministic layout system** whose line lengths stay readable at
+   any specimen width — the wider the variant matrix, the more columns, never
+   longer lines.
+3. Layout produced by a **canonical builder function**, not per-run
+   improvisation: every card identical by construction, verified from a
+   structured return value rather than a screenshot.
+4. A **writing standard** that reads like published design-system documentation
+   (Polaris/Carbon register), with a narrow mechanical lint for the observed
+   failure modes.
+5. **One set of strings** for humans and AI. Machine-legibility comes from the
+   record's structure (named blocks, arrays, stable keys), which already exists;
+   the jargon was never helping.
+6. **Safe migration**: rebuild on next touch, no unprompted Figma writes, no
+   standing warning wall for untouched cards.
+
+## Non-goals
+
+- The Foundations/token-sheet page and the icon card (this spec is scoped to
+  component artboards).
+- The deferred `anatomy`, `content`, and `examples` blocks — the card reads as
+  finished without them.
+- Tokenizing the column unit (it is a layout measure, not a design value).
+- Gating CI on the copy lint (warnings only).
+- Balanced column heights / masonry packing — **explicitly rejected**, even if
+  requested later: every increment of layout intelligence moves decisions out of
+  the testable planner and back into judgment, and judgment is what produced the
+  current cards. The design's value is that it is boring and closed.
+
+## The layout system
+
+Three stacked bands, top to bottom:
+
+1. **Header** — name, `summary` as a lede, status chip, last-updated. Unchanged
+   from today's card except the lede is clamped to one column unit.
+2. **Specimen** — the ComponentSet under a "Variants & states" eyebrow label.
+   Structurally unchanged.
+3. **Usage** — new. The documentation body, built from the rules below.
+
+### The column unit
+
+One fixed width per card, **computed** from the resolved body text style so a
+line of body text lands near a 60-character measure:
+
+```
+columnUnit = clamp(round(bodyFontSize × 30), 280, 480)   // px
+```
+
+(30 ≈ 60ch × ~0.5em average glyph width for UI text faces.) Every usage block is
+exactly one unit wide; **text fills its block, not the card**. This is the
+literal fix for the wrapping defect. The computation is deterministic — same
+record, same body style, same width — and lives in the planner where its output
+is unit-tested.
+
+**The body text style is the user's `Body/Default` text style** —
+token-builder's naming convention (`skills/token-builder/SKILL.md:323`). The
+prose blocks bind this same style, so the existing bind-or-throw policy already
+guarantees it exists by render time; the unit derivation reads `fontSize` from
+it.
+
+The column unit is **layout chrome, not a design value**: it is the one
+documented exception to the no-hardcoded-px audit rule. Everything else in the
+usage band — padding, gaps (`itemSpacing`), radius, colors, dividers — stays
+token-bound exactly as the existing audit requires
+(`references/figma-component-standards.md:486-492`).
+
+### Card width
+
+```
+cardWidth = max(specimenWidth, 3 × columnUnit)  rounded UP to a whole unit
+```
+
+A wider matrix buys more columns rather than longer lines; a narrow specimen
+(Badge) still gets a minimum three-column card; and cards across the page share
+one modular rhythm instead of being raggedly sized. `specimenWidth` is measured
+in Figma at run time and passed to the planner as an input.
+
+### Four block types — a closed set
+
+| Type | Renders | Used for |
+|---|---|---|
+| `prose` | eyebrow + paragraph | Overview (`description`) |
+| `list` | eyebrow + bulleted list | `whenToUse`, `whenNotToUse`, `accessibility` |
+| `list·tone` | tone-colored eyebrow (✓ green / ✕ red) + list | `dos` / `donts` |
+| `definition` | eyebrow + term/meaning pairs | `variants` axes, `states` |
+
+Closed is the point: a closed set is what makes a deterministic builder
+possible. Definition blocks use a fixed term column at **30% of the column
+unit**; long terms **wrap, never truncate**. **One definition block per variant
+axis** — "What each variant means", "What each size means", etc. — plus one
+"What each state means" block, so multi-axis components (Button's `variant` +
+`size`) have a defined home for every axis.
+
+### Three rows, wrapping independently
+
+Each row is its own `layoutWrap: "WRAP"` auto-layout frame, filling the card
+width:
+
+1. **Overview · When to use · When not to use**
+2. **Do · Don't** (same row, so a wrap boundary can never separate them)
+3. **Definition blocks (one per axis, then states) · Accessibility**
+
+Absent blocks are skipped; empty rows collapse entirely. Rows are top-aligned
+and left-packed (`counterAxisAlignItems = "MIN"`,
+`primaryAxisAlignItems = "MIN"` — blocks never center or space-between); ragged
+bottoms are accepted (see *Risks*). A 1px rule bound to `Border/Semantic`
+separates rows.
+
+## The deterministic builder
+
+**`renderDocCard({ card, record, vars, bodyTextStyle })`** — one canonical
+function, run verbatim inside `figma_execute`. The generated snippet inlines
+**both** `planDocCard` and the renderer; `renderDocCard` measures
+`specimenWidth` itself from the named specimen frame inside `card`, calls the
+inlined `planDocCard(record, specimenWidth, bodyTextStyle) → plan` (the plan
+contains `columnUnit`), then renders the plan. **`columnUnit` is never a caller
+input.** Five contractual behaviors:
+
+1. **Idempotent, and scoped.** Finds the frame named `Usage` inside the card,
+   removes it, rebuilds it. **Header and specimen are never touched.** This
+   scoping is what keeps re-rendering safe to run repeatedly: deleting and
+   recreating a component set detaches every downstream instance
+   (`skills/component-builder/SKILL.md:347-351`), so the rebuild never crosses
+   into the specimen band.
+2. **Fonts loaded up front.** Every font style is `loadFontAsync`'d before the
+   first text node exists, and callers pass an explicit `timeout` — the default
+   ~5s budget is already documented as too short for multi-card font-loading
+   writes (`references/figma-component-standards.md:349-350`).
+3. **Binds or throws — with one chrome carve-out.** The caller resolves variable
+   IDs via `figma_get_variables` and passes them as `vars`; the builder uses
+   `setBoundVariable` throughout. **Colors and semantic content type styles
+   (body text, definition terms) bind-or-throw**: a missing variable or style
+   throws rather than falling back to a hex — a card that can't be built from
+   tokens is surfacing a real gap in the token set. **Card-chrome type (the
+   eyebrow labels) is derived, not bound**: the user's system has no reason to
+   contain a tiny-uppercase-label style, so the builder derives one from
+   `Body/Default` — `fontSize × 0.65` rounded (minimum 8), weight Bold,
+   uppercase, letter-spacing +8%. These constants live in the renderer template
+   and are locked by the `--check` like everything else generated. Chrome
+   derivation is documented alongside the column-unit exception.
+4. **Deterministic node names**: `Usage`, `Usage Row 1..3`, `Block: Overview`,
+   `Block: Do`, `Block: Don't`, `Doc Fingerprint`, etc. — same discipline as the
+   existing `Status` / `Status Label` / `Last Updated` contract.
+5. **Returns a structured summary**: blocks created, rows rendered, computed
+   card width, the canonical fingerprint, and the **rendered-content hash**. The
+   executor verifies against this return value instead of squinting at a
+   screenshot, and **the skill stamps the manifest from the return value** —
+   `surfaces.docCard.{src, render, renderer}` — never by re-reading the card.
+
+### Planner / renderer split (how it gets tested)
+
+The renderer needs the Figma plugin API and cannot run in Node, so the logic
+splits:
+
+- **`scripts/lib/doc-card-plan.mjs`** — pure function
+  `(record, specimenWidth, bodyTextStyle) → plan`: which blocks exist, which row
+  each lands in, per-axis definition blocks, computed column unit and card
+  width, what is skipped for a sparse record. Unit-tested in
+  `doc-card-plan.test.mjs` like every other `scripts/lib` module.
+- A **thin Figma renderer** walks the plan and makes the API calls.
+- **`scripts/build-doc-card-builder.mjs`** stitches the planner source and the
+  renderer template into the generated reference
+  **`references/doc-card-builder.md`** — the snippet skills hand to
+  `figma_execute`. A `--check` mode is wired into CI next to the existing
+  adapter check (`.github/workflows/ci.yml:23`, `release.yml:41`;
+  same idiom as `scripts/adapters/generate.mjs --check`). The generated file is
+  never hand-edited.
+
+The rejected alternative — hand-maintaining the snippet with no tests — would
+leave the only deterministic thing in this design unverified, in a repo whose
+whole thesis is drift detection.
+
+## Renderer version stamp
+
+Content fingerprints cannot drive layout migration: a card built with the old
+layout from an unchanged record has a matching fingerprint and would look clean
+forever. So:
+
+- The builder stamps **`renderer: "2"`** into the manifest's
+  `surfaces.docCard` entry (additive optional field; documented in
+  `references/component-doc-schema.md`; no schemaVersion bump — absence simply
+  means "built before v2").
+- The current version has **one source of truth**: an exported constant
+  `DOC_CARD_RENDERER_VERSION` in `scripts/lib/doc-card-plan.mjs`.
+  `docs-check.mjs` imports it; the build script embeds it into the generated
+  builder snippet. One source, three consumers.
+- `scripts/docs-check.mjs` reports a missing or lower `renderer` as a
+  **separate, informational** classification — **`layout-upgrade-available`** —
+  never mixed into the failing drift set (`canonical-changed` / `stale` /
+  `edited` / `missing-record` / `missing-surface`, `scripts/docs-check.mjs:75`).
+  Untouched brownfield cards do not generate a standing warning wall; warning
+  fatigue is how real drift gets ignored. Migration still happens on next touch.
+
+## The writing standard
+
+New reference: **`references/doc-writing-standard.md`**, applied by the
+authoring pipeline in `component-builder` and `/document-component`.
+
+**Governing rule: describe the thing and how to use it, never how it was
+made.**
+
+**Register:** plain reference — neutral and declarative for descriptions,
+imperative for guidance; the register Polaris and Carbon use. This is *not* the
+conversational guide voice of `references/guide-voice.md`, which remains the
+register for skill conversation, not doc content.
+
+Per-block rules, with before/after from the real
+`throughline-sample/design-system/docs/components/Button.doc.json`:
+
+- **`description`** — 2–3 sentences: what it is, what it's for, and the one
+  thing that most changes how you use it. Never variant/size counts (the
+  specimen and legend already show them), never token binding, never a slot
+  inventory.
+  > **Before:** "A clickable control that triggers an action — submitting a
+  > form, confirming a decision, or opening a dialog. It comes in six emphasis
+  > variants across three sizes, supports optional leading and trailing icons
+  > and a loading state, and binds every color, spacing, radius, and type value
+  > to the system's semantic tokens."
+  > **After:** "A clickable control that starts an action: saving a form,
+  > confirming a choice, opening a dialog. Its six emphasis levels signal how
+  > important an action is."
+- **`whenToUse` / `whenNotToUse`** — situations, never an echo of `summary`;
+  `whenNotToUse` always names the alternative.
+  > **Before:** summary "Triggers an action or event." → whenToUse[0] "Trigger
+  > an action or event — submit, confirm, open a dialog"
+  > **After:** "Something happens on the current page — save, confirm, open a
+  > dialog"
+- **`variants` / `states`** — lead with meaning; visual treatment is optional
+  and never the whole entry.
+  > **Before:** "Highest-emphasis, solid brand fill — the one primary action in
+  > a view." → **After:** "The one main action in a view."
+  > **Before:** "Non-interactive and not focusable; reduced opacity." →
+  > **After:** "Can't be clicked or tabbed to."
+- **`dos` / `donts`** — imperative, one action per entry, ≤ 14 words, full
+  stop. Don'ts open with *Don't / Never / Avoid* and name the alternative.
+  > **Before:** "Don't use a button for navigation — use a Link" →
+  > **After:** "Don't use a button to navigate. Use a Link."
+- **`accessibility.notes`** — what the reader must do, not what the framework
+  emits.
+  > **Cut:** "Renders a native `<button>`, so `role=\"button\"` is implicit."
+  > **Before:** "An icon-only button needs an aria-label" → **After:** "An
+  > icon-only button needs an `aria-label` so screen readers can announce it."
+
+**The vocabulary line, precisely:** technical terms that are the real names of
+things stay — `aria-label`, `role`, `Enter`, `Space` are what a reader would
+search for. What is banned from user-facing prose is the system's own machinery
+vocabulary: tokens, variables, bindings, fingerprints, provenance, projections,
+surfaces (in the machinery sense). `tokensUsed` keeps its token names — it is a
+structured field, machine-useful, and never rendered as prose.
+
+**Global rules:** write full sentences (no em-dash label-fragments bolting a
+clause onto a fragment); **one set of strings** for humans and AI — no dual
+copy; the digest (`llms.txt` / `index.json`) inherits the same text.
+
+`references/component-doc-archetypes.md` gets a light compliance pass so the
+seeds follow the standard — most already do; the accessibility entries carry the
+most jargon.
+
+## The lint — `scripts/docs-lint.mjs`
+
+Zero-dependency, **warnings only, always exits 0**, takes a `.doc.json` file
+path. Checks only what is mechanically reliable:
+
+| Check | Rule |
+|---|---|
+| Machinery vocabulary | banned-word list in user-facing strings (all prose fields; `tokensUsed`, `name`, `status`, `provenance` exempt) |
+| Summary echo | flag when > 60% of the **summary's** content words (stopwords removed, naive plural/verb-s stemming) appear in `whenToUse[0]`. On the worked example this yields 100% — *triggers*, *action*, *event* all appear in "Trigger an action or event — submit, confirm, open a dialog" |
+| Run-on sentence | any sentence > 35 words |
+| Summary length | `summary` > 12 words |
+| Description length | `description` outside 15–70 words |
+| Guidance length | any `dos` / `donts` entry > 14 words |
+| Don't shape | a `donts` entry not opening with *Don't / Never / Avoid* |
+| Terminal stop | a `dos` / `donts` entry not ending with a full stop (catches "Don't use a button for navigation — use a Link") |
+| Treatment lead | any of {fill, filled, solid, stroke, border, bordered, outline, shadow, opacity, elevation} in the first 4 words of a variant/state meaning (catches "Highest-emphasis, solid brand fill — …") |
+| Empty meanings | a variant or state meaning under 3 words |
+
+Deliberately **not** linted: verb-presence. It is not reliably detectable in
+plain JS without an NLP dependency, and a rule that fires wrongly is worse than
+no rule — it stays a prose rule, caught by the authoring pipeline and the user
+approval step.
+
+**Output contract:** always exits 0; prints one warning per line as
+`<file>: <block-path>: <rule>: <message>`; a `--json` flag emits
+`{warnings: [{path, rule, message}]}` for programmatic use. This is a
+deliberate departure from `docs-check.mjs`'s exit-code contract — lint warnings
+are advisory by design.
+
+**Sequencing:** draft record → write the file to disk → `docs-lint <file>` →
+the agent fixes warnings → show the user the draft. The lint shapes the output
+before approval rather than nagging afterward. Also exposed standalone as the
+`docs:lint` npm script, wired into the user's repo the same way `docs:check`
+and `docs:digest` are (`scripts/README.md`).
+
+## Migration
+
+**Rebuild on next touch only.** New cards use the new layout and voice
+immediately; an existing card is rebuilt whenever its component is next
+documented or rebuilt. No unprompted writes to anyone's Figma file; a file may
+hold mixed old and new cards for a while, and `docs:check` reports the old ones
+as `layout-upgrade-available` (informational), not as drift.
+
+`imported` / `user` provenance blocks are **never rewritten** — that is the
+record model working correctly, which means a voice sweep genuinely cannot fix
+hand-written copy that reads badly. The lint warns on those blocks and the user
+decides per item; a conscious choice, never a silent overwrite.
+
+## Files
+
+**New**
+
+| File | What |
+|---|---|
+| `references/doc-writing-standard.md` | the copy rules |
+| `references/doc-card-builder.md` | **generated** — the inlined `renderDocCard` snippet |
+| `scripts/lib/doc-card-plan.mjs` + `.test.mjs` | the pure layout planner |
+| `scripts/build-doc-card-builder.mjs` + `.test.mjs` | generator with `--check` |
+| `scripts/docs-lint.mjs` + `.test.mjs` | the copy lint |
+
+**Changed**
+
+- `references/figma-component-standards.md` — the doc-card body section becomes
+  the three-band architecture and points at the builder; the *layout* audit
+  items collapse to "the builder ran and returned the expected summary"; the
+  token-binding read-back (audit item 3) stays intact.
+- `skills/component-builder/SKILL.md` — the *Doc card body* bullet (line 276)
+  points at the builder; the authoring pipeline references the writing standard
+  and runs the lint before showing the user the draft.
+- `commands/document-component.md` — the same two changes.
+- `references/component-doc-archetypes.md` — light copy pass.
+- `references/component-doc-schema.md` — document the `renderer` field on the
+  `docCard` surface entry.
+- `references/manifest-schema.md` — the `meta[name].doc.surfaces` shape
+  (`references/manifest-schema.md:253-256`) gains the additive `renderer`
+  field.
+- `scripts/docs-check.mjs` + `.test.mjs` — the `layout-upgrade-available`
+  classification.
+- `scripts/README.md` — rows for the new scripts.
+- `.github/workflows/ci.yml` + `release.yml` — builder `--check` alongside the
+  adapter check.
+- `adapters/` — regenerated via `scripts/adapters/generate.mjs`, never
+  hand-edited.
+
+**Free wins:** Storybook MDX, the Figma component `description` field, and the
+AI digest are all projections of the record, so the voice rewrite reaches them
+with no additional work. Only the Figma card needs layout work.
+
+## Phasing
+
+Implementation lands as **two plans**:
+
+1. **Layout** — planner + builder + renderer stamp + the `docs:check`
+   classification. Highest risk; gates the dogfood.
+2. **Voice** — writing standard + archetype pass + lint + authoring-pipeline
+   wiring.
+
+They share only the additive `renderer` manifest field and are independently
+shippable.
+
+## Risks
+
+1. **Ragged row bottoms.** Blocks hug their own content, so a long Overview
+   beside a two-item list leaves uneven bottoms. Rows top-align and it stops
+   there — equalizing heights is where the design would start getting fussy for
+   little gain.
+2. **Long lists inflate a block.** Ten do's make a tall column. Not solved
+   structurally; the writing standard caps entry length and the lint surfaces
+   bloat.
+3. **Bad hand-written copy survives** (see *Migration*) — by design; lint
+   warns, user decides per item.
+4. **The dogfood is the acceptance test** (below); until it runs, the builder's
+   Figma-side behavior is validated only by the planner's unit tests.
+
+## Success criteria
+
+1. Building or re-documenting a component produces a card in the three-band
+   layout with every usage block one column unit wide, at any specimen width.
+2. The planner's unit tests lock block selection, row assignment, per-axis
+   definition blocks, column-unit computation, and card-width rounding;
+   `build-doc-card-builder.mjs --check` passes in CI.
+3. Re-rendering rebuilds only the `Usage` frame; header and specimen node IDs
+   are unchanged.
+4. `docs-lint` flags the mechanically detectable subset of this spec's
+   before-examples (vocabulary, echo, terminal-stop, treatment-lead, and length
+   rules) and none of the after-examples. The framework-trivia and
+   jargon-phrasing examples (the implicit `role="button"` note,
+   "Non-interactive and not focusable") are prose-standard catches, verified at
+   the user-approval gate — the same reasoning as the verb-presence exemption.
+5. `docs:check` reports an old-layout card as `layout-upgrade-available`
+   without failing, and a re-rendered card stamps `renderer: "2"`.
+6. **Dogfood on `throughline-sample`:** re-documenting Button, Input, and Card
+   rebuilds their cards in the new layout and voice, the renderer stamp flips
+   to `"2"`, `docs:check` goes quiet, and the specimen's downstream instances
+   stay attached.

--- a/docs/superpowers/specs/2026-08-09-doc-card-layout-and-voice-design.md
+++ b/docs/superpowers/specs/2026-08-09-doc-card-layout-and-voice-design.md
@@ -209,9 +209,11 @@ input.** Six contractual behaviors:
    recreating a component set detaches every downstream instance
    (`skills/component-builder/SKILL.md:347-351`), so the rebuild never crosses
    into the specimen band.
-2. **One component per card (amendment, post-dogfood).** Before the idempotency
-   guard runs, the builder checks for a foreign band — any child named
-   `Usage — *` that isn't the card's own `Usage` frame. A band like
+2. **One component per card (amendment, post-dogfood).** Before the specimen
+   lookup and the idempotency guard run, the builder checks for a foreign
+   band — any direct child whose name starts with `Usage` but isn't exactly
+   `Usage` (deliberately broad: any unexpected Usage-prefixed band fails
+   loudly, not just the "Usage — Component Name" shape). A band like
    "Usage — Select Menu Item" means the card documents more than one
    component; rendering here would append a band the builder doesn't own and
    silently accumulate. The builder throws instead, naming the offending band,
@@ -501,7 +503,7 @@ shippable.
    "Non-interactive and not focusable") are prose-standard catches, verified at
    the user-approval gate — the same reasoning as the verb-presence exemption.
 5. `docs:check` reports an old-layout card as `layout-upgrade-available`
-   without failing, and a re-rendered card stamps `renderer: "2"`.
+   without failing, and a re-rendered card stamps `renderer: "3"`.
 6. **Dogfood on `throughline-sample`:** re-documenting Button, Input, and Card
    rebuilds their cards in the new layout and voice, the renderer stamp flips
    to `"2"`, `docs:check` goes quiet, and the specimen's downstream instances

--- a/docs/superpowers/specs/2026-08-09-doc-card-layout-and-voice-design.md
+++ b/docs/superpowers/specs/2026-08-09-doc-card-layout-and-voice-design.md
@@ -87,7 +87,10 @@ Three stacked bands, top to bottom:
 1. **Header** — name, `summary` as a lede, status chip, last-updated. Unchanged
    from today's card except the lede is clamped to one column unit.
 2. **Specimen** — the ComponentSet under a "Variants & states" eyebrow label.
-   Structurally unchanged.
+   Structurally unchanged. **Amendment (post-dogfood):** the specimen contract
+   the builder measures against is the card's `COMPONENT_SET` node — not a
+   band named "Specimen". No real card has ever used a named-band lookup, so
+   that path never executed; it has been removed rather than left as dead code.
 3. **Usage** — new. The documentation body, built from the rules below.
 
 ### The column unit
@@ -128,6 +131,21 @@ A wider matrix buys more columns rather than longer lines; a narrow specimen
 one modular rhythm instead of being raggedly sized. `specimenWidth` is measured
 in Figma at run time and passed to the planner as an input.
 
+**Amendment (post-dogfood): columns are also capped by content.** The formula
+above under-specified `columns` — deriving it from specimen width alone let a
+wide specimen with sparse Usage content mint dead columns (Input's real card:
+5 columns of mostly-empty grid). The full clamp, computed after rows are built:
+
+```
+columns = clamp(maxBlocksPerRow, 3, ceil(specimenWidth / columnUnit))
+cardWidth = columns × columnUnit
+```
+
+where `maxBlocksPerRow` is the largest number of blocks in any of the card's
+(non-empty) rows. The grid never exceeds what the content can fill, and never
+drops below the 3-unit floor. This changes rendered layout, so
+`DOC_CARD_RENDERER_VERSION` bumps to `"3"` (see *Renderer version stamp*).
+
 The planner's `cardWidth` is the **content-grid** width. At render time the
 builder derives the `Usage` frame's outer width as
 `cardWidth + 2·padding + (columns − 1)·blockGap`, reading the resolved px of
@@ -135,6 +153,13 @@ the bound spacing tokens via `resolveForConsumer`, and widens the card
 (its own padding included) when it is fixed-width and narrower. Without this,
 padding and gutters eat the content box and the last column always wraps. The
 card itself must be a VERTICAL auto-layout frame — the builder throws otherwise.
+
+**Amendment (post-dogfood): the `Usage` frame sets `clipsContent = false`.**
+Figma defaults every new frame to `clipsContent = true`; a layout frame with
+clipping on silently crops content that grows past its planned bounds. Audit
+item 6 in `references/figma-component-standards.md` already requires this for
+layout frames — the builder now asserts it explicitly rather than relying on
+the ambient default staying safe.
 
 ### Four block types — a closed set
 
@@ -172,10 +197,11 @@ separates rows.
 **`renderDocCard({ card, record, vars, bodyTextStyle })`** — one canonical
 function, run verbatim inside `figma_execute`. The generated snippet inlines
 **both** `planDocCard` and the renderer; `renderDocCard` measures
-`specimenWidth` itself from the named specimen frame inside `card`, calls the
+`specimenWidth` itself from the card's `COMPONENT_SET` node (the specimen
+contract — see the amendment under *Specimen*, above), calls the
 inlined `planDocCard(record, specimenWidth, bodyTextStyle) → plan` (the plan
 contains `columnUnit`), then renders the plan. **`columnUnit` is never a caller
-input.** Five contractual behaviors:
+input.** Six contractual behaviors:
 
 1. **Idempotent, and scoped.** Finds the frame named `Usage` inside the card,
    removes it, rebuilds it. **Header and specimen are never touched.** This
@@ -183,11 +209,18 @@ input.** Five contractual behaviors:
    recreating a component set detaches every downstream instance
    (`skills/component-builder/SKILL.md:347-351`), so the rebuild never crosses
    into the specimen band.
-2. **Fonts loaded up front.** Every font style is `loadFontAsync`'d before the
+2. **One component per card (amendment, post-dogfood).** Before the idempotency
+   guard runs, the builder checks for a foreign band — any child named
+   `Usage — *` that isn't the card's own `Usage` frame. A band like
+   "Usage — Select Menu Item" means the card documents more than one
+   component; rendering here would append a band the builder doesn't own and
+   silently accumulate. The builder throws instead, naming the offending band,
+   and asks for the card to be split so each component owns its own card.
+3. **Fonts loaded up front.** Every font style is `loadFontAsync`'d before the
    first text node exists, and callers pass an explicit `timeout` — the default
    ~5s budget is already documented as too short for multi-card font-loading
    writes (`references/figma-component-standards.md:349-350`).
-3. **Binds or throws — with one chrome carve-out.** The caller resolves variable
+4. **Binds or throws — with one chrome carve-out.** The caller resolves variable
    IDs via `figma_get_variables` and passes them as `vars`; the builder uses
    `setBoundVariable` throughout. **Colors and semantic content type styles
    (body text, definition terms) bind-or-throw**: a missing variable or style
@@ -198,11 +231,13 @@ input.** Five contractual behaviors:
    `Body/Default` — `fontSize × 0.65` rounded (minimum 8), weight Bold,
    uppercase, letter-spacing +8%. These constants live in the renderer template
    and are locked by the `--check` like everything else generated. Chrome
-   derivation is documented alongside the column-unit exception.
-4. **Deterministic node names**: `Usage`, `Usage Row 1..3`, `Block: Overview`,
+   derivation is documented alongside the column-unit exception. The `Usage`
+   frame itself sets `clipsContent = false` (amendment, post-dogfood — see the
+   *Card width* section, above).
+5. **Deterministic node names**: `Usage`, `Usage Row 1..3`, `Block: Overview`,
    `Block: Do`, `Block: Don't`, `Doc Fingerprint`, etc. — same discipline as the
    existing `Status` / `Status Label` / `Last Updated` contract.
-5. **Returns a structured summary**: blocks created, rows rendered, computed
+6. **Returns a structured summary**: blocks created, rows rendered, computed
    card width, the canonical fingerprint, and the **rendered-content hash**. The
    executor verifies against this return value instead of squinting at a
    screenshot, and **the skill stamps the manifest from the return value** —
@@ -237,10 +272,10 @@ Content fingerprints cannot drive layout migration: a card built with the old
 layout from an unchanged record has a matching fingerprint and would look clean
 forever. So:
 
-- The builder stamps **`renderer: "2"`** into the manifest's
+- The builder stamps **`renderer: "3"`** into the manifest's
   `surfaces.docCard` entry (additive optional field; documented in
   `references/component-doc-schema.md`; no schemaVersion bump — absence simply
-  means "built before v2").
+  means "built before the current version").
 - The current version has **one source of truth**: an exported constant
   `DOC_CARD_RENDERER_VERSION` in `scripts/lib/doc-card-plan.mjs`.
   `docs-check.mjs` imports it; the build script embeds it into the generated
@@ -251,6 +286,12 @@ forever. So:
   `edited` / `missing-record` / `missing-surface`, `scripts/docs-check.mjs:75`).
   Untouched brownfield cards do not generate a standing warning wall; warning
   fatigue is how real drift gets ignored. Migration still happens on next touch.
+
+**Amendment (post-dogfood): version bumped `"2"` → `"3"`.** The column-count
+formula changed (see the amendment under *Card width*, above) — this alters
+rendered layout for existing cards, so cards stamped `renderer: "2"` correctly
+re-flag `layout-upgrade-available` and pick up the new column math on next
+touch.
 
 ## The writing standard
 
@@ -364,6 +405,19 @@ as `layout-upgrade-available` (informational), not as drift.
 record model working correctly, which means a voice sweep genuinely cannot fix
 hand-written copy that reads badly. The lint warns on those blocks and the user
 decides per item; a conscious choice, never a silent overwrite.
+
+**Amendment (post-dogfood): a freshness gate in `/document-component`.**
+`storybook-chromatic-builder` copies the doc scripts (`build-docs-digest.mjs`,
+`docs-check.mjs`, `lib/doc-record.mjs`, `lib/doc-card-plan.mjs`) into a repo
+**once**, at setup — nothing refreshed them afterward, so a repo whose copy
+predates a plugin update ran `docs:check` against stale rules and reported a
+meaningless "no drift" (this cost a real dogfooder real time). Before trusting
+`docs:check`, `/document-component`'s drift-reconcile step now compares the
+repo's `DOC_CARD_RENDERER_VERSION` against the plugin's; if the repo file is
+missing or behind, it says so and offers to refresh the copied scripts from
+the plugin before re-running the check. The one-time copy in
+`storybook-chromatic-builder` remains setup, not a forever-fork — freshness is
+enforced downstream, on every documentation pass.
 
 ## Files
 

--- a/references/component-doc-schema.md
+++ b/references/component-doc-schema.md
@@ -105,7 +105,7 @@ The manifest stores pointers + per-surface fingerprints, never content:
     "fingerprint": "<canonical fingerprint at last render>",
     "surfaces": {
       "figmaDescription": { "src": "<fp>", "render": "<hash of description text>" },
-      "docCard":          { "src": "<fp>", "render": "<hash of card content>", "renderer": "2" },
+      "docCard":          { "src": "<fp>", "render": "<hash of card content>", "renderer": "3" },
       "storybookMdx":     { "src": "<fp>", "render": "<hash of mdx file>", "file": "packages/ui/src/Button/Button.mdx" }
     }
   }
@@ -118,7 +118,7 @@ The manifest stores pointers + per-surface fingerprints, never content:
 - `file` — repo-relative path for code surfaces so `docs:check` can re-read them.
 - `renderer` — (docCard only) the layout version of the builder that last
   rendered the card: `DOC_CARD_RENDERER_VERSION` in `scripts/lib/doc-card-plan.mjs`,
-  currently `"2"`. Additive and optional — absence means the card predates the
+  currently `"3"`. Additive and optional — absence means the card predates the
   versioned builder. Stamped from the builder's returned summary, never by
   re-reading the card.
 

--- a/references/component-doc-schema.md
+++ b/references/component-doc-schema.md
@@ -105,7 +105,7 @@ The manifest stores pointers + per-surface fingerprints, never content:
     "fingerprint": "<canonical fingerprint at last render>",
     "surfaces": {
       "figmaDescription": { "src": "<fp>", "render": "<hash of description text>" },
-      "docCard":          { "src": "<fp>", "render": "<hash of card content>" },
+      "docCard":          { "src": "<fp>", "render": "<hash of card content>", "renderer": "2" },
       "storybookMdx":     { "src": "<fp>", "render": "<hash of mdx file>", "file": "packages/ui/src/Button/Button.mdx" }
     }
   }
@@ -116,6 +116,11 @@ The manifest stores pointers + per-surface fingerprints, never content:
 - `render` — a hash of the surface's rendered content at render time (detects
   **edited**, for surfaces the tooling can re-read).
 - `file` — repo-relative path for code surfaces so `docs:check` can re-read them.
+- `renderer` — (docCard only) the layout version of the builder that last
+  rendered the card: `DOC_CARD_RENDERER_VERSION` in `scripts/lib/doc-card-plan.mjs`,
+  currently `"2"`. Additive and optional — absence means the card predates the
+  versioned builder. Stamped from the builder's returned summary, never by
+  re-reading the card.
 
 ## Drift + reconciliation contract
 
@@ -123,6 +128,11 @@ The manifest stores pointers + per-surface fingerprints, never content:
 - **canonical-changed** — the `.doc.json` fingerprint ≠ `doc.fingerprint`.
 - **stale** — `surface.src` ≠ current canonical fingerprint.
 - **edited** — a re-readable surface's current content hash ≠ `surface.render`.
+- **layout-upgrade-available** — informational, never failing, docCard only:
+  `surfaces.docCard.renderer` is missing or lower than the current
+  `DOC_CARD_RENDERER_VERSION`. The card's content is not in drift — its layout
+  predates the current builder. Re-render on next touch (no unprompted Figma
+  writes; untouched brownfield cards must not generate a standing warning wall).
 - **missing-surface** — a repo surface that declares a `file` which is now gone.
   Failing, and distinct from `edit-unverified`: the surface *was* re-readable and
   its rendered output has been deleted, not merely unreadable this run.

--- a/references/doc-card-builder.md
+++ b/references/doc-card-builder.md
@@ -1,0 +1,371 @@
+# Doc-card Usage-band builder (GENERATED)
+
+> **GENERATED FILE — do not edit by hand.** Sources: `scripts/lib/doc-card-plan.mjs`
+> (the pure planner, unit-tested in Node) + `scripts/lib/doc-card-render.figma.js`
+> (the Figma renderer). Regenerate with `node scripts/build-doc-card-builder.mjs`;
+> CI gates freshness with `--check`.
+
+The canonical `figma_execute` snippet that renders a component doc card's
+`Usage` band from its `.doc.json` record. Every card is identical by
+construction — never hand-build the usage body. The snippet rebuilds ONLY the
+frame named `Usage`; the header and specimen bands are never touched.
+
+## How to call it
+
+1. Load the record and compute its canonical fingerprint in Node
+   (`canonicalFingerprint` in `scripts/lib/doc-record.mjs`).
+2. Resolve the nine required semantic variables via `figma_get_variables`,
+   then in the script fetch each as a Variable object with
+   `figma.variables.getVariableByIdAsync(id)`:
+   `textDefault`, `textMuted` (text colors), `tonePositive`, `toneNegative`
+   (Do/Don't eyebrow colors — success/danger roles), `border` (row dividers),
+   `spacePadding`, `spaceRowGap`, `spaceBlockGap`, `spaceItemGap` (spacing
+   roles: band padding, row gap, block gutter, within-block gap).
+3. Find the body text style: `(await figma.getLocalTextStylesAsync())
+   .find((s) => s.name === 'Body/Default')`. Missing variables or style =
+   the builder throws (bind-or-throw — the gap is in the token set; fix it
+   there, never hardcode around it).
+4. Prepend the two slots, then the snippet below, then the call:
+
+```js
+const RECORD = /* the parsed .doc.json object */;
+const CANONICAL_FP = '/* canonicalFingerprint(RECORD), 16 hex chars */';
+// … the generated snippet …
+const card = await figma.getNodeByIdAsync(cardNodeId);
+const summary = await renderDocCard({ card, record: RECORD, vars, bodyTextStyle });
+```
+
+5. Pass an explicit `timeout` (30000 is right for one card; the ~30s
+   `figma_execute` ceiling fits a single card comfortably — render cards one
+   call at a time, never batched).
+6. Verify from the returned summary — `rowsRendered`, `blocksCreated`,
+   `cardWidth` — not from a screenshot, then stamp the manifest from it:
+   `surfaces.docCard = { src: summary.fingerprint, render: summary.renderHash,
+   renderer: summary.rendererVersion }`. Never re-read the card to stamp.
+
+## The snippet
+
+```js
+// Pure layout planner for the component doc card's Usage band.
+// ZERO imports, `export const`/`export function` only — this module is inlined
+// verbatim into the generated Figma snippet (references/doc-card-builder.md) by
+// build-doc-card-builder.mjs, so it must run in both Node and the Figma plugin
+// sandbox. build-doc-card-builder.mjs enforces the no-imports rule.
+//
+// Layout contract: docs/superpowers/specs/2026-08-09-doc-card-layout-and-voice-design.md
+
+// Single source of truth for the doc-card layout version. Imported by
+// docs-check.mjs and embedded (via inlining) into the generated builder snippet.
+const DOC_CARD_RENDERER_VERSION = '2';
+
+// columnUnit = clamp(round(bodyFontSize × 30), 280, 480) px.
+// 30 ≈ 60ch × ~0.5em average glyph width for UI text faces. Layout chrome, not
+// a design value — the one documented exception to the no-hardcoded-px rule.
+function columnUnit(bodyFontSize) {
+  return Math.min(480, Math.max(280, Math.round(bodyFontSize * 30)));
+}
+
+// cardWidth = max(specimenWidth, 3 units) rounded UP to a whole unit.
+function cardColumns(specimenWidth, unit) {
+  return Math.max(3, Math.ceil(specimenWidth / unit));
+}
+
+function listBlock(eyebrow, items) {
+  if (!Array.isArray(items) || items.length === 0) return null;
+  return { type: 'list', name: `Block: ${eyebrow}`, eyebrow, items };
+}
+
+function definitionBlock(eyebrow, meanings) {
+  const terms = Object.keys(meanings || {}).map((k) => ({ term: k, meaning: meanings[k] }));
+  if (terms.length === 0) return null;
+  return { type: 'definition', name: `Block: ${eyebrow}`, eyebrow, terms };
+}
+
+// The whole layout decision, as data. Rows keep canonical numbering (an absent
+// row's number is skipped, never renumbered) so node names stay stable across
+// sparse records. bodyTextStyle: only .fontSize is read — passing a full Figma
+// TextStyle object is fine.
+function planDocCard(record, specimenWidth, bodyTextStyle) {
+  const unit = columnUnit(bodyTextStyle.fontSize);
+  const columns = cardColumns(specimenWidth, unit);
+
+  const row1 = [];
+  if (typeof record.description === 'string' && record.description.trim() !== '') {
+    row1.push({ type: 'prose', name: 'Block: Overview', eyebrow: 'Overview', text: record.description });
+  }
+  const whenTo = listBlock('When to use', record.whenToUse);
+  if (whenTo) row1.push(whenTo);
+  const whenNot = listBlock('When not to use', record.whenNotToUse);
+  if (whenNot) row1.push(whenNot);
+
+  const row2 = [];
+  if (Array.isArray(record.dos) && record.dos.length) {
+    row2.push({ type: 'list-tone', name: 'Block: Do', eyebrow: '✓ Do', tone: 'positive', items: record.dos });
+  }
+  if (Array.isArray(record.donts) && record.donts.length) {
+    row2.push({ type: 'list-tone', name: "Block: Don't", eyebrow: "✕ Don't", tone: 'negative', items: record.donts });
+  }
+
+  const row3 = [];
+  for (const axis of Object.keys(record.variants || {})) {
+    const block = definitionBlock(`What each ${axis} means`, record.variants[axis]);
+    if (block) row3.push(block);
+  }
+  const stateBlock = definitionBlock('What each state means', record.states);
+  if (stateBlock) row3.push(stateBlock);
+  const a11y = record.accessibility || {};
+  // role is not rendered on the card — it lives in the description field / MDX.
+  const a11yBlock = listBlock('Accessibility', [...(a11y.keyboard || []), ...(a11y.notes || [])]);
+  if (a11yBlock) row3.push(a11yBlock);
+
+  const rows = [
+    { name: 'Usage Row 1', blocks: row1 },
+    { name: 'Usage Row 2', blocks: row2 },
+    { name: 'Usage Row 3', blocks: row3 },
+  ].filter((r) => r.blocks.length > 0);
+
+  return {
+    rendererVersion: DOC_CARD_RENDERER_VERSION,
+    columnUnit: unit,
+    columns,
+    cardWidth: columns * unit,
+    termColumn: Math.round(unit * 0.3),
+    rows,
+  };
+}
+
+// Figma plugin-API renderer for the doc-card Usage band. This file is NOT a
+// Node module — build-doc-card-builder.mjs concatenates it after the inlined
+// planner (doc-card-plan.mjs) into references/doc-card-builder.md, and the
+// result runs inside figma_execute (dynamic-page mode). Constraints honored
+// here (see references/figma-scripting.md): async APIs only, style/font set
+// BEFORE .characters, fonts loaded up front, resize() sizing modes re-asserted,
+// bound paints seeded light-gray (never pure black).
+//
+// In-scope globals when assembled: planDocCard, DOC_CARD_RENDERER_VERSION
+// (inlined planner) and the caller-filled slots RECORD, CANONICAL_FP.
+
+// 32-bit FNV-1a — the render hash. Only ever compared against itself (the
+// manifest's surfaces.docCard.render), so it does not need to match the
+// sha256-based canonical fingerprint, which cannot run in the Figma sandbox.
+function fnv1a(str) {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h.toString(16).padStart(8, '0');
+}
+
+const REQUIRED_VARS = [
+  'textDefault', 'textMuted', 'tonePositive', 'toneNegative', 'border',
+  'spacePadding', 'spaceRowGap', 'spaceBlockGap', 'spaceItemGap',
+];
+
+// Bound paint, seeded with a light-gray approximation — a failed/late bind must
+// never render pure black (reads as accidental dark mode).
+function boundPaint(variable) {
+  return figma.variables.setBoundVariableForPaint(
+    { type: 'SOLID', color: { r: 0.85, g: 0.85, b: 0.87 } }, 'color', variable,
+  );
+}
+
+async function renderDocCard({ card, record, vars, bodyTextStyle }) {
+  // Bind-or-throw: a missing variable or style is a gap in the token set —
+  // never fall back to a hex/px.
+  for (const key of REQUIRED_VARS) {
+    if (!vars || !vars[key]) {
+      throw new Error('renderDocCard: missing required variable "' + key
+        + '" — resolve it via figma_get_variables / getVariableByIdAsync and pass the Variable object in vars');
+    }
+  }
+  if (!bodyTextStyle) {
+    throw new Error('renderDocCard: bodyTextStyle is required — find the "Body/Default" text style via getLocalTextStylesAsync');
+  }
+
+  // Three-band cards are VERTICAL auto-layout frames. Appending into anything
+  // else preserves absolute position and mis-places the band — throw instead.
+  if (card.layoutMode !== 'VERTICAL') {
+    throw new Error('renderDocCard: the doc card must be a VERTICAL auto-layout frame (three-band card); got layoutMode=' + card.layoutMode);
+  }
+
+  // Fonts, up front — before any text node exists. Eyebrow chrome is Bold of
+  // the body family; fall back to the body style's own font if no Bold exists.
+  const bodyFont = bodyTextStyle.fontName;
+  await figma.loadFontAsync(bodyFont);
+  let eyebrowFont = { family: bodyFont.family, style: 'Bold' };
+  try { await figma.loadFontAsync(eyebrowFont); } catch (e) { eyebrowFont = bodyFont; }
+
+  // Measure the specimen: the band named "Specimen", or (older cards) the
+  // component set inside the card.
+  const specimen = card.findChild((n) => n.name === 'Specimen')
+    || card.findOne((n) => n.type === 'COMPONENT_SET');
+  if (!specimen) {
+    throw new Error('renderDocCard: no "Specimen" frame or COMPONENT_SET found inside the card');
+  }
+
+  const plan = planDocCard(record, specimen.width, { fontSize: bodyTextStyle.fontSize });
+
+  // Eyebrow chrome (derived, not bound — layout chrome like the column unit):
+  // fontSize × 0.65 rounded, min 8; Bold; uppercase; letter-spacing +8%.
+  const eyebrowSize = Math.max(8, Math.round(bodyTextStyle.fontSize * 0.65));
+
+  // Idempotent + scoped: rebuild ONLY the Usage frame. Header and specimen are
+  // never touched — recreating a component set detaches downstream instances.
+  const existing = card.findChild((n) => n.name === 'Usage');
+  if (existing) existing.remove();
+
+  const eyebrowText = (chars, colorVar) => {
+    const t = figma.createText();
+    t.fontName = eyebrowFont;          // loaded above — set BEFORE .characters
+    t.fontSize = eyebrowSize;
+    t.letterSpacing = { value: 8, unit: 'PERCENT' };
+    t.textCase = 'UPPER';
+    t.characters = chars;
+    t.fills = [boundPaint(colorVar)];
+    return t;
+  };
+
+  const bodyText = async (chars, colorVar) => {
+    const t = figma.createText();
+    await t.setTextStyleIdAsync(bodyTextStyle.id);  // style BEFORE characters
+    t.characters = chars;
+    t.fills = [boundPaint(colorVar)];
+    return t;
+  };
+
+  // Appends `t` to `parent` as a full-width, height-hugging text node.
+  const fillWidth = (parent, t) => {
+    parent.appendChild(t);
+    t.textAutoResize = 'HEIGHT';
+    t.layoutSizingHorizontal = 'FILL';
+  };
+
+  // Resolved px of the spacing tokens (mode-aware, resolved against the card).
+  // The planner's cardWidth is the CONTENT-GRID width (columns × columnUnit);
+  // the frame's outer width adds the band padding and the inter-block gutters
+  // so the planned column count actually fits on one line.
+  const padPx = vars.spacePadding.resolveForConsumer(card).value;
+  const blockGapPx = vars.spaceBlockGap.resolveForConsumer(card).value;
+  const usageWidth = plan.cardWidth + 2 * padPx + (plan.columns - 1) * blockGapPx;
+
+  const usage = figma.createFrame();
+  usage.name = 'Usage';
+  usage.layoutMode = 'VERTICAL';
+  usage.fills = [];
+  card.appendChild(usage);
+  usage.resize(usageWidth, usage.height);
+  usage.counterAxisSizingMode = 'FIXED';  // VERTICAL frame: counter = width
+  usage.primaryAxisSizingMode = 'AUTO';   // height hugs — re-asserted after resize()
+  usage.setBoundVariable('paddingLeft', vars.spacePadding);
+  usage.setBoundVariable('paddingRight', vars.spacePadding);
+  usage.setBoundVariable('paddingTop', vars.spacePadding);
+  usage.setBoundVariable('paddingBottom', vars.spacePadding);
+  usage.setBoundVariable('itemSpacing', vars.spaceRowGap);
+
+  // Widen the card to fit (its own padding included). Card is VERTICAL (guarded
+  // above): counter axis = width, so a hugging card needs no resize; a fixed
+  // card is widened and its height sizing re-asserted after resize().
+  const cardOuter = usageWidth + card.paddingLeft + card.paddingRight;
+  if (card.counterAxisSizingMode !== 'AUTO' && card.width < cardOuter) {
+    card.resize(cardOuter, card.height);
+    card.primaryAxisSizingMode = 'AUTO';
+  }
+
+  const blocksCreated = [];
+  let first = true;
+  for (const row of plan.rows) {
+    if (!first) {
+      const divider = figma.createFrame();
+      divider.name = 'Row Divider';
+      divider.fills = [boundPaint(vars.border)];
+      usage.appendChild(divider);
+      divider.layoutSizingHorizontal = 'FILL';
+      divider.resize(divider.width, 1);
+    }
+    first = false;
+
+    const rowFrame = figma.createFrame();
+    rowFrame.name = row.name;
+    rowFrame.layoutMode = 'HORIZONTAL';
+    rowFrame.layoutWrap = 'WRAP';
+    rowFrame.fills = [];
+    rowFrame.counterAxisAlignItems = 'MIN';  // top-aligned…
+    rowFrame.primaryAxisAlignItems = 'MIN';  // …left-packed; never center/space-between
+    usage.appendChild(rowFrame);
+    rowFrame.layoutSizingHorizontal = 'FILL';
+    rowFrame.layoutSizingVertical = 'HUG';
+    rowFrame.setBoundVariable('itemSpacing', vars.spaceBlockGap);
+    rowFrame.setBoundVariable('counterAxisSpacing', vars.spaceRowGap);
+
+    for (const block of row.blocks) {
+      const bf = figma.createFrame();
+      bf.name = block.name;
+      bf.layoutMode = 'VERTICAL';
+      bf.fills = [];
+      rowFrame.appendChild(bf);
+      bf.resize(plan.columnUnit, bf.height);   // every block is exactly one unit wide
+      bf.counterAxisSizingMode = 'FIXED';
+      bf.primaryAxisSizingMode = 'AUTO';
+      bf.setBoundVariable('itemSpacing', vars.spaceItemGap);
+
+      const eyebrowColor = block.type === 'list-tone'
+        ? (block.tone === 'positive' ? vars.tonePositive : vars.toneNegative)
+        : vars.textMuted;
+      const eb = eyebrowText(block.eyebrow, eyebrowColor);
+      bf.appendChild(eb);
+      eb.textAutoResize = 'HEIGHT';
+      eb.layoutSizingHorizontal = 'FILL';
+
+      if (block.type === 'prose') {
+        fillWidth(bf, await bodyText(block.text, vars.textDefault));
+      } else if (block.type === 'list' || block.type === 'list-tone') {
+        for (const item of block.items) {
+          fillWidth(bf, await bodyText('• ' + item, vars.textDefault));
+        }
+      } else if (block.type === 'definition') {
+        for (const pair of block.terms) {
+          const pf = figma.createFrame();
+          pf.name = 'Definition: ' + pair.term;
+          pf.layoutMode = 'HORIZONTAL';
+          pf.fills = [];
+          bf.appendChild(pf);
+          pf.layoutSizingHorizontal = 'FILL';
+          pf.layoutSizingVertical = 'HUG';
+          pf.setBoundVariable('itemSpacing', vars.spaceItemGap);
+          const term = await bodyText(pair.term, vars.textDefault);
+          pf.appendChild(term);
+          term.textAutoResize = 'HEIGHT';        // long terms wrap, never truncate
+          term.resize(plan.termColumn, term.height);
+          term.layoutSizingHorizontal = 'FIXED'; // fixed term column: 30% of the unit
+          const meaning = await bodyText(pair.meaning, vars.textMuted);
+          pf.appendChild(meaning);
+          meaning.textAutoResize = 'HEIGHT';
+          meaning.layoutSizingHorizontal = 'FILL';
+        }
+      }
+      blocksCreated.push(block.name);
+    }
+  }
+
+  // Metadata node — hidden, machine-read by the drift check's Figma-side pass.
+  const fp = eyebrowText(CANONICAL_FP, vars.textMuted);
+  fp.name = 'Doc Fingerprint';
+  fp.visible = false;
+  usage.appendChild(fp);
+
+  return {
+    rendererVersion: DOC_CARD_RENDERER_VERSION,
+    columnUnit: plan.columnUnit,
+    columns: plan.columns,
+    cardWidth: plan.cardWidth,
+    rowsRendered: plan.rows.length,
+    blocksCreated,
+    fingerprint: CANONICAL_FP,
+    renderHash: fnv1a(JSON.stringify(plan)),
+  };
+}
+```
+
+Layout contract and rationale:
+`docs/superpowers/specs/2026-08-09-doc-card-layout-and-voice-design.md`.

--- a/references/doc-card-builder.md
+++ b/references/doc-card-builder.md
@@ -280,8 +280,8 @@ async function renderDocCard({ card, record, vars, bodyTextStyle }) {
       divider.name = 'Row Divider';
       divider.fills = [boundPaint(vars.border)];
       usage.appendChild(divider);
-      divider.layoutSizingHorizontal = 'FILL';
       divider.resize(divider.width, 1);
+      divider.layoutSizingHorizontal = 'FILL';
     }
     first = false;
 

--- a/references/doc-card-builder.md
+++ b/references/doc-card-builder.md
@@ -200,12 +200,12 @@ async function renderDocCard({ card, record, vars, bodyTextStyle }) {
   let eyebrowFont = { family: bodyFont.family, style: 'Bold' };
   try { await figma.loadFontAsync(eyebrowFont); } catch (e) { eyebrowFont = bodyFont; }
 
-  // Measure the specimen: the band named "Specimen", or (older cards) the
-  // component set inside the card.
-  const specimen = card.findChild((n) => n.name === 'Specimen')
-    || card.findOne((n) => n.type === 'COMPONENT_SET');
+  // Measure the specimen: the card's COMPONENT_SET is the specimen contract —
+  // its width drives the column calculation. (No named "Specimen" band lookup:
+  // no real card has ever used one, so that path never executed.)
+  const specimen = card.findOne((n) => n.type === 'COMPONENT_SET');
   if (!specimen) {
-    throw new Error('renderDocCard: no "Specimen" frame or COMPONENT_SET found inside the card');
+    throw new Error('renderDocCard: no COMPONENT_SET found inside the card — the specimen band must contain the component set');
   }
 
   const plan = planDocCard(record, specimen.width, { fontSize: bodyTextStyle.fontSize });
@@ -213,6 +213,15 @@ async function renderDocCard({ card, record, vars, bodyTextStyle }) {
   // Eyebrow chrome (derived, not bound — layout chrome like the column unit):
   // fontSize × 0.65 rounded, min 8; Bold; uppercase; letter-spacing +8%.
   const eyebrowSize = Math.max(8, Math.round(bodyTextStyle.fontSize * 0.65));
+
+  // One component per doc card: a band like "Usage — Select Menu Item" means this
+  // card documents multiple components. Rendering here would append a band we
+  // don't own and silently accumulate — refuse and ask for the card to be split.
+  const foreign = card.findChild((n) => n.name !== 'Usage' && n.name.startsWith('Usage'));
+  if (foreign) {
+    throw new Error('renderDocCard: card contains band "' + foreign.name
+      + '" — one component per doc card; split this card so each component owns its own card before re-rendering');
+  }
 
   // Idempotent + scoped: rebuild ONLY the Usage frame. Header and specimen are
   // never touched — recreating a component set detaches downstream instances.
@@ -257,6 +266,7 @@ async function renderDocCard({ card, record, vars, bodyTextStyle }) {
   usage.name = 'Usage';
   usage.layoutMode = 'VERTICAL';
   usage.fills = [];
+  usage.clipsContent = false;
   card.appendChild(usage);
   usage.resize(usageWidth, usage.height);
   usage.counterAxisSizingMode = 'FIXED';  // VERTICAL frame: counter = width

--- a/references/doc-card-builder.md
+++ b/references/doc-card-builder.md
@@ -56,7 +56,7 @@ const summary = await renderDocCard({ card, record: RECORD, vars, bodyTextStyle 
 
 // Single source of truth for the doc-card layout version. Imported by
 // docs-check.mjs and embedded (via inlining) into the generated builder snippet.
-const DOC_CARD_RENDERER_VERSION = '2';
+const DOC_CARD_RENDERER_VERSION = '3';
 
 // columnUnit = clamp(round(bodyFontSize × 30), 280, 480) px.
 // 30 ≈ 60ch × ~0.5em average glyph width for UI text faces. Layout chrome, not
@@ -65,9 +65,11 @@ function columnUnit(bodyFontSize) {
   return Math.min(480, Math.max(280, Math.round(bodyFontSize * 30)));
 }
 
-// cardWidth = max(specimenWidth, 3 units) rounded UP to a whole unit.
-function cardColumns(specimenWidth, unit) {
-  return Math.max(3, Math.ceil(specimenWidth / unit));
+// columns = clamp(max blocks in any row, 3, ceil(specimenWidth / unit)) —
+// the grid never exceeds what the content can fill (a wide specimen must not
+// mint dead columns), and never drops below the 3-unit floor.
+function cardColumns(specimenWidth, unit, maxBlocksPerRow) {
+  return Math.max(3, Math.min(Math.ceil(specimenWidth / unit), maxBlocksPerRow));
 }
 
 function listBlock(eyebrow, items) {
@@ -87,7 +89,6 @@ function definitionBlock(eyebrow, meanings) {
 // TextStyle object is fine.
 function planDocCard(record, specimenWidth, bodyTextStyle) {
   const unit = columnUnit(bodyTextStyle.fontSize);
-  const columns = cardColumns(specimenWidth, unit);
 
   const row1 = [];
   if (typeof record.description === 'string' && record.description.trim() !== '') {
@@ -123,6 +124,9 @@ function planDocCard(record, specimenWidth, bodyTextStyle) {
     { name: 'Usage Row 2', blocks: row2 },
     { name: 'Usage Row 3', blocks: row3 },
   ].filter((r) => r.blocks.length > 0);
+
+  const maxBlocksPerRow = rows.reduce((m, r) => Math.max(m, r.blocks.length), 0);
+  const columns = cardColumns(specimenWidth, unit, maxBlocksPerRow);
 
   return {
     rendererVersion: DOC_CARD_RENDERER_VERSION,

--- a/references/doc-card-builder.md
+++ b/references/doc-card-builder.md
@@ -200,6 +200,17 @@ async function renderDocCard({ card, record, vars, bodyTextStyle }) {
   let eyebrowFont = { family: bodyFont.family, style: 'Bold' };
   try { await figma.loadFontAsync(eyebrowFont); } catch (e) { eyebrowFont = bodyFont; }
 
+  // One component per doc card: a band like "Usage — Select Menu Item" means this
+  // card documents multiple components. Rendering here would append a band we
+  // don't own and silently accumulate — refuse and ask for the card to be split.
+  // Checked before the specimen lookup so a multi-component card always gets
+  // this error, never a possible "no COMPONENT_SET found" from the lookup below.
+  const foreign = card.findChild((n) => n.name !== 'Usage' && n.name.startsWith('Usage'));
+  if (foreign) {
+    throw new Error('renderDocCard: card contains band "' + foreign.name
+      + '" — one component per doc card; split this card so each component owns its own card before re-rendering');
+  }
+
   // Measure the specimen: the card's COMPONENT_SET is the specimen contract —
   // its width drives the column calculation. (No named "Specimen" band lookup:
   // no real card has ever used one, so that path never executed.)
@@ -213,15 +224,6 @@ async function renderDocCard({ card, record, vars, bodyTextStyle }) {
   // Eyebrow chrome (derived, not bound — layout chrome like the column unit):
   // fontSize × 0.65 rounded, min 8; Bold; uppercase; letter-spacing +8%.
   const eyebrowSize = Math.max(8, Math.round(bodyTextStyle.fontSize * 0.65));
-
-  // One component per doc card: a band like "Usage — Select Menu Item" means this
-  // card documents multiple components. Rendering here would append a band we
-  // don't own and silently accumulate — refuse and ask for the card to be split.
-  const foreign = card.findChild((n) => n.name !== 'Usage' && n.name.startsWith('Usage'));
-  if (foreign) {
-    throw new Error('renderDocCard: card contains band "' + foreign.name
-      + '" — one component per doc card; split this card so each component owns its own card before re-rendering');
-  }
 
   // Idempotent + scoped: rebuild ONLY the Usage frame. Header and specimen are
   // never touched — recreating a component set detaches downstream instances.

--- a/references/figma-component-standards.md
+++ b/references/figma-component-standards.md
@@ -282,9 +282,10 @@ frames. Applies to `component-builder`, `icon-system-builder`, and
 ### Every component sits on its own documentation card
 
 Wrap each generated component in a "doc card" — a **vertical, three-band
-auto-layout frame**: a **header** band, a **specimen** band (a frame named
-`Specimen` holding the component set), and a **`Usage`** band holding the
-documentation body. Never leave components floating on bare canvas.
+auto-layout frame**: a **header** band, a **specimen** band (holding the
+component set — the builder's specimen contract is the card's `COMPONENT_SET`,
+not a band name), and a **`Usage`** band holding the documentation body. Never
+leave components floating on bare canvas.
 
 **The `Usage` band is never hand-built.** It is rendered by the canonical
 builder snippet in `${CLAUDE_PLUGIN_ROOT}/references/doc-card-builder.md`

--- a/references/figma-component-standards.md
+++ b/references/figma-component-standards.md
@@ -281,9 +281,23 @@ frames. Applies to `component-builder`, `icon-system-builder`, and
 
 ### Every component sits on its own documentation card
 
-Wrap each generated component in a "doc card" — a frame that holds the component
-plus a small header. Never leave components floating on bare canvas. The card
-shows:
+Wrap each generated component in a "doc card" — a **vertical, three-band
+auto-layout frame**: a **header** band, a **specimen** band (a frame named
+`Specimen` holding the component set), and a **`Usage`** band holding the
+documentation body. Never leave components floating on bare canvas.
+
+**The `Usage` band is never hand-built.** It is rendered by the canonical
+builder snippet in `${CLAUDE_PLUGIN_ROOT}/references/doc-card-builder.md`
+(generated — that file carries the full call contract: the record/fingerprint
+slots, the nine required semantic variables, the `Body/Default` text style, and
+the returned summary you verify and stamp the manifest from). The builder
+computes the card's width from the specimen and the body type — a column-unit
+grid whose text fills its block, not the card — and rebuilds only the `Usage`
+frame, leaving header and specimen untouched. The header's short-description
+text node is clamped to one column unit wide (`summary.columnUnit` from the
+builder's return), so it never stretches across a wide matrix.
+
+The header shows:
 
 - **Component name** (the deterministic name, matching code).
 - **Short description** (what it is / when to use it).
@@ -410,6 +424,10 @@ The doc card is a **vertical, top-to-bottom auto-layout** frame
 overlapping text is almost always absolutely-positioned or mis-sized nodes, and
 proper auto layout eliminates it.
 
+The `Usage` band's internal layout (rows, wrapping, block widths) is entirely
+the builder's job — these auto-layout rules apply to the header band and any
+hand-built chrome, not to nodes inside `Usage`.
+
 ### Arrange cards in a parent container (fixes overlapping artboards)
 
 Never drop cards onto blank canvas at coordinates that can collide. Place all doc
@@ -486,6 +504,11 @@ For each generated artboard / doc card / icon grid, read the nodes back (via
 3. **Variables bound** — every fill, stroke, text color, corner radius,
    `itemSpacing`, and padding resolves to a **bound variable** (`boundVariables`
    present), not a raw hex/px. No hardcoded values anywhere in the doc-card chrome.
+   **Two documented exceptions inside the `Usage` band** (layout chrome, not
+   design values, both produced by the builder): the computed column-unit width
+   on blocks, and the derived eyebrow type (size/case/tracking/weight). All
+   other `Usage` properties — padding, gaps, text colors, dividers — must still
+   resolve to bound variables.
    **Check container and component-set background fills specifically** — a paint bind
    that didn't stick renders the placeholder color instead (a pure-black placeholder
    reads as accidental dark mode), so read back `fills[0].boundVariables.color` on
@@ -522,9 +545,17 @@ For each generated artboard / doc card / icon grid, read the nodes back (via
    be retrofitted to the current recipe (see "State handling").
 10. **Visual** — the screenshot (from the validation loop) shows no overlaps,
    misalignment, lopsided hug/fill sizing, or clipped strokes/focus rings.
+11. **Usage band rendered by the builder** — the card's `Usage` frame was
+   created by `renderDocCard`
+   (`${CLAUDE_PLUGIN_ROOT}/references/doc-card-builder.md`) in this session, and
+   the returned summary matches the record: `rowsRendered` and `blocksCreated`
+   line up with the record's populated blocks, `cardWidth` is a whole multiple
+   of `columnUnit` (minimum 3), and the frame contains the deterministic names
+   (`Usage`, `Usage Row 1..3`, `Block: …`, `Doc Fingerprint`). Verify from the
+   summary, not a screenshot. A hand-assembled usage body is a fail.
 
 If any item fails, **fix and re-audit** — don't hand off a partial pass. Iterate
-with the same ~3-pass budget as the visual loop. Only when all ten pass is the
+with the same ~3-pass budget as the visual loop. Only when all eleven pass is the
 build done.
 
 ## Naming

--- a/references/manifest-schema.md
+++ b/references/manifest-schema.md
@@ -259,7 +259,7 @@ bailing or running silently.
   hash of the surface's rendered content (detects edits, for re-readable surfaces),
   `renderer` (docCard only) is the layout version of the builder that last
   rendered the card (`DOC_CARD_RENDERER_VERSION`); missing/lower is reported by
-  `docs:check` as the informational `layout-upgrade-available`, never as drift.
+  `docs:check` as the informational `layout-upgrade-available`, never as drift,
   and `file` is the repo-relative path of a code surface. Written by
   `component-builder` (Figma + card surfaces) and `storybook-chromatic-builder`
   (code surfaces); read by the `docs:check` gate. See

--- a/references/manifest-schema.md
+++ b/references/manifest-schema.md
@@ -253,10 +253,13 @@ bailing or running silently.
 - `meta[name].doc` — documentation pointer + per-surface fingerprints for the
   component (v1: components only). **Pointers and hashes, never content** — the
   content lives in `design-system/docs/components/<name>.doc.json`. Shape:
-  `{ path, fingerprint, surfaces: { <surfaceName>: { src, render, file? } } }`,
+  `{ path, fingerprint, surfaces: { <surfaceName>: { src, render, file?, renderer? } } }`,
   where `fingerprint` is the canonical fingerprint at last render, `src` is the
   canonical fingerprint a surface was rendered from (detects stale), `render` is a
   hash of the surface's rendered content (detects edits, for re-readable surfaces),
+  `renderer` (docCard only) is the layout version of the builder that last
+  rendered the card (`DOC_CARD_RENDERER_VERSION`); missing/lower is reported by
+  `docs:check` as the informational `layout-upgrade-available`, never as drift.
   and `file` is the repo-relative path of a code surface. Written by
   `component-builder` (Figma + card surfaces) and `storybook-chromatic-builder`
   (code surfaces); read by the `docs:check` gate. See

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,6 +14,8 @@ tested here; copied verbatim by `token-crosswalk-builder` into the user's
 | `crosswalk.schema.json` | The finalized JSON Schema for `crosswalk.json` (contract + editor support). | copied beside `crosswalk.json` |
 | `build-docs-digest.mjs` | Aggregate every `design-system/docs/components/*.doc.json` into `design-system/docs/index.json` + `llms.txt` for AI/human consumers. | `docs:digest` |
 | `docs-check.mjs` | Drift gate — verifies each component's doc surfaces still match its canonical record (via `lib/doc-record.mjs` fingerprints). Exits 1 on drift. | `docs:check` |
+| `lib/doc-card-plan.mjs` | Pure layout planner for the doc card's `Usage` band + `DOC_CARD_RENDERER_VERSION` (single source of the layout version). Inlined into `references/doc-card-builder.md`; imported by `docs-check.mjs`. | inlined into the generated builder |
+| `build-doc-card-builder.mjs` | Generate `references/doc-card-builder.md` from the planner + the Figma renderer template (`lib/doc-card-render.figma.js`). `--check` gates CI. | plugin-internal (not installed) |
 
 The crosswalk contract is documented in
 `${CLAUDE_PLUGIN_ROOT}/references/crosswalk-schema.md`.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,7 +14,7 @@ tested here; copied verbatim by `token-crosswalk-builder` into the user's
 | `crosswalk.schema.json` | The finalized JSON Schema for `crosswalk.json` (contract + editor support). | copied beside `crosswalk.json` |
 | `build-docs-digest.mjs` | Aggregate every `design-system/docs/components/*.doc.json` into `design-system/docs/index.json` + `llms.txt` for AI/human consumers. | `docs:digest` |
 | `docs-check.mjs` | Drift gate — verifies each component's doc surfaces still match its canonical record (via `lib/doc-record.mjs` fingerprints). Exits 1 on drift. | `docs:check` |
-| `lib/doc-card-plan.mjs` | Pure layout planner for the doc card's `Usage` band + `DOC_CARD_RENDERER_VERSION` (single source of the layout version). Inlined into `references/doc-card-builder.md`; imported by `docs-check.mjs`. | inlined into the generated builder |
+| `lib/doc-card-plan.mjs` | Pure layout planner for the doc card's `Usage` band + `DOC_CARD_RENDERER_VERSION` (single source of the layout version). Inlined into `references/doc-card-builder.md`; imported by `docs-check.mjs`. | copied alongside docs-check.mjs; also inlined into the generated builder |
 | `build-doc-card-builder.mjs` | Generate `references/doc-card-builder.md` from the planner + the Figma renderer template (`lib/doc-card-render.figma.js`). `--check` gates CI. | plugin-internal (not installed) |
 
 The crosswalk contract is documented in

--- a/scripts/build-doc-card-builder.mjs
+++ b/scripts/build-doc-card-builder.mjs
@@ -1,0 +1,103 @@
+// Generates references/doc-card-builder.md — the canonical figma_execute
+// snippet that renders a doc card's Usage band — by inlining the pure planner
+// (lib/doc-card-plan.mjs) above the Figma renderer template
+// (lib/doc-card-render.figma.js). Mirrors the adapters generate.mjs idiom:
+// run bare to write, run with --check to gate CI. Zero dependencies.
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const PLANNER = join(REPO_ROOT, 'scripts', 'lib', 'doc-card-plan.mjs');
+const RENDERER = join(REPO_ROOT, 'scripts', 'lib', 'doc-card-render.figma.js');
+const OUT = join(REPO_ROOT, 'references', 'doc-card-builder.md');
+
+const HEADER = [
+  '# Doc-card Usage-band builder (GENERATED)',
+  '',
+  '> **GENERATED FILE — do not edit by hand.** Sources: `scripts/lib/doc-card-plan.mjs`',
+  '> (the pure planner, unit-tested in Node) + `scripts/lib/doc-card-render.figma.js`',
+  '> (the Figma renderer). Regenerate with `node scripts/build-doc-card-builder.mjs`;',
+  '> CI gates freshness with `--check`.',
+  '',
+  'The canonical `figma_execute` snippet that renders a component doc card\'s',
+  '`Usage` band from its `.doc.json` record. Every card is identical by',
+  'construction — never hand-build the usage body. The snippet rebuilds ONLY the',
+  'frame named `Usage`; the header and specimen bands are never touched.',
+  '',
+  '## How to call it',
+  '',
+  '1. Load the record and compute its canonical fingerprint in Node',
+  '   (`canonicalFingerprint` in `scripts/lib/doc-record.mjs`).',
+  '2. Resolve the nine required semantic variables via `figma_get_variables`,',
+  '   then in the script fetch each as a Variable object with',
+  '   `figma.variables.getVariableByIdAsync(id)`:',
+  '   `textDefault`, `textMuted` (text colors), `tonePositive`, `toneNegative`',
+  '   (Do/Don\'t eyebrow colors — success/danger roles), `border` (row dividers),',
+  '   `spacePadding`, `spaceRowGap`, `spaceBlockGap`, `spaceItemGap` (spacing',
+  '   roles: band padding, row gap, block gutter, within-block gap).',
+  '3. Find the body text style: `(await figma.getLocalTextStylesAsync())',
+  '   .find((s) => s.name === \'Body/Default\')`. Missing variables or style =',
+  '   the builder throws (bind-or-throw — the gap is in the token set; fix it',
+  '   there, never hardcode around it).',
+  '4. Prepend the two slots, then the snippet below, then the call:',
+  '',
+  '```js',
+  'const RECORD = /* the parsed .doc.json object */;',
+  'const CANONICAL_FP = \'/* canonicalFingerprint(RECORD), 16 hex chars */\';',
+  '// … the generated snippet …',
+  'const card = await figma.getNodeByIdAsync(cardNodeId);',
+  'const summary = await renderDocCard({ card, record: RECORD, vars, bodyTextStyle });',
+  '```',
+  '',
+  '5. Pass an explicit `timeout` (30000 is right for one card; the ~30s',
+  '   `figma_execute` ceiling fits a single card comfortably — render cards one',
+  '   call at a time, never batched).',
+  '6. Verify from the returned summary — `rowsRendered`, `blocksCreated`,',
+  '   `cardWidth` — not from a screenshot, then stamp the manifest from it:',
+  '   `surfaces.docCard = { src: summary.fingerprint, render: summary.renderHash,',
+  '   renderer: summary.rendererVersion }`. Never re-read the card to stamp.',
+  '',
+  '## The snippet',
+  '',
+  '```js',
+].join('\n');
+
+const FOOTER = [
+  '```',
+  '',
+  'Layout contract and rationale:',
+  '`docs/superpowers/specs/2026-08-09-doc-card-layout-and-voice-design.md`.',
+  '',
+].join('\n');
+
+export function buildDocCardBuilder({ plannerSource, rendererSource }) {
+  const inlined = plannerSource
+    .replace(/^export const /gm, 'const ')
+    .replace(/^export function /gm, 'function ');
+  for (const [name, src] of [['doc-card-plan.mjs', inlined], ['doc-card-render.figma.js', rendererSource]]) {
+    if (/^\s*(import|export)\b/m.test(src)) {
+      throw new Error(`${name} must stay import-free (only top-level \`export const\`/\`export function\` allowed in the planner) — it is inlined into the Figma snippet where no module system exists`);
+    }
+  }
+  return `${HEADER}\n${inlined}\n${rendererSource}${FOOTER}`;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const result = buildDocCardBuilder({
+    plannerSource: readFileSync(PLANNER, 'utf8'),
+    rendererSource: readFileSync(RENDERER, 'utf8'),
+  });
+  if (process.argv.includes('--check')) {
+    let onDisk = null;
+    try { onDisk = readFileSync(OUT, 'utf8'); } catch (e) { /* missing counts as drift */ }
+    if (onDisk !== result) {
+      console.error('✗ references/doc-card-builder.md out of date; run: node scripts/build-doc-card-builder.mjs');
+      process.exit(1);
+    }
+    console.log('✓ doc-card builder in sync');
+  } else {
+    writeFileSync(OUT, result);
+    console.log('✓ wrote references/doc-card-builder.md');
+  }
+}

--- a/scripts/build-doc-card-builder.test.mjs
+++ b/scripts/build-doc-card-builder.test.mjs
@@ -1,0 +1,48 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildDocCardBuilder } from './build-doc-card-builder.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const realPlanner = () => readFileSync(join(HERE, 'lib', 'doc-card-plan.mjs'), 'utf8');
+const realRenderer = () => readFileSync(join(HERE, 'lib', 'doc-card-render.figma.js'), 'utf8');
+
+test('build: inlines the planner with export keywords stripped, no module syntax survives', () => {
+  const md = buildDocCardBuilder({ plannerSource: realPlanner(), rendererSource: realRenderer() });
+  assert.match(md, /function planDocCard\(/);
+  assert.match(md, /const DOC_CARD_RENDERER_VERSION = '2'/);
+  assert.match(md, /async function renderDocCard\(/);
+  const snippet = md.slice(md.indexOf('```js'), md.lastIndexOf('```'));
+  assert.ok(!/^\s*(import|export)\b/m.test(snippet), 'snippet must contain no import/export lines');
+});
+
+test('build: refuses a planner that has imports (the inlinability guard)', () => {
+  assert.throws(
+    () => buildDocCardBuilder({
+      plannerSource: "import { x } from 'node:fs';\nexport function planDocCard() {}\n",
+      rendererSource: realRenderer(),
+    }),
+    /import-free/,
+  );
+});
+
+test('build: the generated markdown carries the do-not-edit warning and the slot instructions', () => {
+  const md = buildDocCardBuilder({ plannerSource: realPlanner(), rendererSource: realRenderer() });
+  assert.match(md, /GENERATED FILE — do not edit by hand/);
+  assert.match(md, /const RECORD =/);
+  assert.match(md, /const CANONICAL_FP =/);
+  assert.match(md, /spaceItemGap/); // the vars contract is documented
+});
+
+test('build: output is deterministic', () => {
+  const args = { plannerSource: realPlanner(), rendererSource: realRenderer() };
+  assert.equal(buildDocCardBuilder(args), buildDocCardBuilder(args));
+});
+
+test('generated reference on disk is in sync with the sources', () => {
+  const expected = buildDocCardBuilder({ plannerSource: realPlanner(), rendererSource: realRenderer() });
+  const onDisk = readFileSync(join(HERE, '..', 'references', 'doc-card-builder.md'), 'utf8');
+  assert.equal(onDisk, expected, 'run: node scripts/build-doc-card-builder.mjs');
+});

--- a/scripts/build-doc-card-builder.test.mjs
+++ b/scripts/build-doc-card-builder.test.mjs
@@ -12,7 +12,7 @@ const realRenderer = () => readFileSync(join(HERE, 'lib', 'doc-card-render.figma
 test('build: inlines the planner with export keywords stripped, no module syntax survives', () => {
   const md = buildDocCardBuilder({ plannerSource: realPlanner(), rendererSource: realRenderer() });
   assert.match(md, /function planDocCard\(/);
-  assert.match(md, /const DOC_CARD_RENDERER_VERSION = '2'/);
+  assert.match(md, /const DOC_CARD_RENDERER_VERSION = '3'/);
   assert.match(md, /async function renderDocCard\(/);
   const snippet = md.slice(md.indexOf('```js'), md.lastIndexOf('```'));
   assert.ok(!/^\s*(import|export)\b/m.test(snippet), 'snippet must contain no import/export lines');

--- a/scripts/docs-check.mjs
+++ b/scripts/docs-check.mjs
@@ -3,10 +3,13 @@
 // design-system.json, and reports drift. Zero dependencies.
 //
 // Drift classes: canonical-changed | stale | edited | missing-surface | edit-unverified
+//                | layout-upgrade-available
 // (edit-unverified = a surface the CLI cannot read, e.g. Figma — informational;
 //  it is checked live by the Figma-connected skill instead.
 //  missing-surface = a repo surface that declares a file which is now gone — failing;
-//  distinct from edit-unverified, which has no file to read in the first place.)
+//  distinct from edit-unverified, which has no file to read in the first place.
+//  layout-upgrade-available = informational, docCard only: the card's layout
+//  predates DOC_CARD_RENDERER_VERSION — re-render on next touch, never a failure.)
 //
 // Usage: node docs-check.mjs [--root <dir>]   (default root: cwd)
 import { readFileSync, existsSync } from 'node:fs';
@@ -14,11 +17,12 @@ import { join } from 'node:path';
 import { parseArgs } from 'node:util';
 import { pathToFileURL } from 'node:url';
 import { loadRecord, canonicalFingerprint, fingerprint } from './lib/doc-record.mjs';
+import { DOC_CARD_RENDERER_VERSION } from './lib/doc-card-plan.mjs';
 
 // Surfaces whose rendered content the CLI can re-read from the repo.
 const REPO_SURFACES = new Set(['storybookMdx']);
 
-export function classifySurface({ currentCanonical, surface, currentRenderHash, fileMissing = false }) {
+export function classifySurface({ currentCanonical, surface, currentRenderHash, fileMissing = false, expectedRenderer = null }) {
   const flags = [];
   if (surface.src !== currentCanonical) flags.push('stale');
   if (fileMissing) {
@@ -27,6 +31,10 @@ export function classifySurface({ currentCanonical, surface, currentRenderHash, 
     flags.push('edit-unverified');
   } else if (surface.render !== currentRenderHash) {
     flags.push('edited');
+  }
+  if (expectedRenderer !== null
+      && (!surface.renderer || Number(surface.renderer) < Number(expectedRenderer))) {
+    flags.push('layout-upgrade-available');
   }
   return flags;
 }
@@ -57,7 +65,10 @@ export function checkComponent({ name, meta, root }) {
         fileMissing = true;
       }
     }
-    const flags = classifySurface({ currentCanonical, surface, currentRenderHash, fileMissing });
+    const flags = classifySurface({
+      currentCanonical, surface, currentRenderHash, fileMissing,
+      expectedRenderer: surfaceName === 'docCard' ? DOC_CARD_RENDERER_VERSION : null,
+    });
     if (flags.length) out.push({ name, surface: surfaceName, flags });
   }
   return out;
@@ -89,7 +100,10 @@ function main() {
   const info = results.filter((r) => !r.flags.some((f) => FAILING.has(f)));
 
   for (const r of drift) console.error(`  ✗ ${r.name} · ${r.surface}: ${r.flags.join(', ')}`);
-  for (const r of info) console.log(`  ~ ${r.name} · ${r.surface}: ${r.flags.join(', ')} (check in a Figma session)`);
+  for (const r of info) {
+    const note = r.flags.includes('edit-unverified') ? ' (check in a Figma session)' : '';
+    console.log(`  ~ ${r.name} · ${r.surface}: ${r.flags.join(', ')}${note}`);
+  }
 
   if (drift.length) {
     console.error(`✗ docs:check — ${drift.length} drifted surface(s); reconcile with /document-component`);

--- a/scripts/docs-check.test.mjs
+++ b/scripts/docs-check.test.mjs
@@ -108,3 +108,54 @@ test('checkAll: flags missing-surface (failing) when a rendered repo file is del
   // Must NOT be silently downgraded to the passing edit-unverified class.
   assert.ok(!mdx.flags.includes('edit-unverified'));
 });
+
+test('classifySurface: layout-upgrade-available when docCard renderer is missing', () => {
+  assert.deepEqual(
+    classifySurface({ currentCanonical: 'a', surface: { src: 'a', render: 'r' }, currentRenderHash: 'r', expectedRenderer: '2' }),
+    ['layout-upgrade-available'],
+  );
+});
+
+test('classifySurface: layout-upgrade-available when renderer is lower; silent when equal or higher', () => {
+  const base = { currentCanonical: 'a', currentRenderHash: 'r' };
+  assert.deepEqual(
+    classifySurface({ ...base, surface: { src: 'a', render: 'r', renderer: '1' }, expectedRenderer: '2' }),
+    ['layout-upgrade-available'],
+  );
+  assert.deepEqual(
+    classifySurface({ ...base, surface: { src: 'a', render: 'r', renderer: '2' }, expectedRenderer: '2' }),
+    [],
+  );
+  assert.deepEqual(
+    classifySurface({ ...base, surface: { src: 'a', render: 'r', renderer: '3' }, expectedRenderer: '2' }),
+    [],
+  );
+});
+
+test('classifySurface: no renderer check when expectedRenderer is null (non-docCard surfaces)', () => {
+  assert.deepEqual(
+    classifySurface({ currentCanonical: 'a', surface: { src: 'a', render: 'r' }, currentRenderHash: 'r' }),
+    [],
+  );
+});
+
+test('checkAll: an old-layout docCard is informational, never in the failing set', () => {
+  const { root, manifest, fp } = fixture();
+  manifest.components.meta.Button.doc.surfaces.docCard = { src: fp, render: 'whatever' };
+  const results = checkAll(manifest, root);
+  const docCard = results.find((r) => r.surface === 'docCard');
+  assert.ok(docCard, 'docCard surface should be reported');
+  assert.ok(docCard.flags.includes('layout-upgrade-available'));
+  // Every docCard flag must be informational — none from the failing set.
+  const failing = new Set(['canonical-changed', 'stale', 'edited', 'missing-record', 'missing-surface']);
+  assert.ok(docCard.flags.every((f) => !failing.has(f)), `unexpected failing flag in ${docCard.flags.join(',')}`);
+});
+
+test('checkAll: a stamped docCard (renderer "2") reports no layout upgrade', () => {
+  const { root, manifest, fp } = fixture();
+  manifest.components.meta.Button.doc.surfaces.docCard = { src: fp, render: 'whatever', renderer: '2' };
+  const results = checkAll(manifest, root);
+  const docCard = results.find((r) => r.surface === 'docCard');
+  // Still edit-unverified (the CLI can't read Figma), but no layout flag.
+  assert.ok(!docCard || !docCard.flags.includes('layout-upgrade-available'));
+});

--- a/scripts/docs-check.test.mjs
+++ b/scripts/docs-check.test.mjs
@@ -151,9 +151,9 @@ test('checkAll: an old-layout docCard is informational, never in the failing set
   assert.ok(docCard.flags.every((f) => !failing.has(f)), `unexpected failing flag in ${docCard.flags.join(',')}`);
 });
 
-test('checkAll: a stamped docCard (renderer "2") reports no layout upgrade', () => {
+test('checkAll: a stamped docCard (renderer "3") reports no layout upgrade', () => {
   const { root, manifest, fp } = fixture();
-  manifest.components.meta.Button.doc.surfaces.docCard = { src: fp, render: 'whatever', renderer: '2' };
+  manifest.components.meta.Button.doc.surfaces.docCard = { src: fp, render: 'whatever', renderer: '3' };
   const results = checkAll(manifest, root);
   const docCard = results.find((r) => r.surface === 'docCard');
   // Still edit-unverified (the CLI can't read Figma), but no layout flag.

--- a/scripts/lib/doc-card-plan.mjs
+++ b/scripts/lib/doc-card-plan.mjs
@@ -8,7 +8,7 @@
 
 // Single source of truth for the doc-card layout version. Imported by
 // docs-check.mjs and embedded (via inlining) into the generated builder snippet.
-export const DOC_CARD_RENDERER_VERSION = '2';
+export const DOC_CARD_RENDERER_VERSION = '3';
 
 // columnUnit = clamp(round(bodyFontSize × 30), 280, 480) px.
 // 30 ≈ 60ch × ~0.5em average glyph width for UI text faces. Layout chrome, not
@@ -17,9 +17,11 @@ export function columnUnit(bodyFontSize) {
   return Math.min(480, Math.max(280, Math.round(bodyFontSize * 30)));
 }
 
-// cardWidth = max(specimenWidth, 3 units) rounded UP to a whole unit.
-export function cardColumns(specimenWidth, unit) {
-  return Math.max(3, Math.ceil(specimenWidth / unit));
+// columns = clamp(max blocks in any row, 3, ceil(specimenWidth / unit)) —
+// the grid never exceeds what the content can fill (a wide specimen must not
+// mint dead columns), and never drops below the 3-unit floor.
+export function cardColumns(specimenWidth, unit, maxBlocksPerRow) {
+  return Math.max(3, Math.min(Math.ceil(specimenWidth / unit), maxBlocksPerRow));
 }
 
 function listBlock(eyebrow, items) {
@@ -39,7 +41,6 @@ function definitionBlock(eyebrow, meanings) {
 // TextStyle object is fine.
 export function planDocCard(record, specimenWidth, bodyTextStyle) {
   const unit = columnUnit(bodyTextStyle.fontSize);
-  const columns = cardColumns(specimenWidth, unit);
 
   const row1 = [];
   if (typeof record.description === 'string' && record.description.trim() !== '') {
@@ -75,6 +76,9 @@ export function planDocCard(record, specimenWidth, bodyTextStyle) {
     { name: 'Usage Row 2', blocks: row2 },
     { name: 'Usage Row 3', blocks: row3 },
   ].filter((r) => r.blocks.length > 0);
+
+  const maxBlocksPerRow = rows.reduce((m, r) => Math.max(m, r.blocks.length), 0);
+  const columns = cardColumns(specimenWidth, unit, maxBlocksPerRow);
 
   return {
     rendererVersion: DOC_CARD_RENDERER_VERSION,

--- a/scripts/lib/doc-card-plan.mjs
+++ b/scripts/lib/doc-card-plan.mjs
@@ -21,3 +21,67 @@ export function columnUnit(bodyFontSize) {
 export function cardColumns(specimenWidth, unit) {
   return Math.max(3, Math.ceil(specimenWidth / unit));
 }
+
+function listBlock(eyebrow, items) {
+  if (!Array.isArray(items) || items.length === 0) return null;
+  return { type: 'list', name: `Block: ${eyebrow}`, eyebrow, items };
+}
+
+function definitionBlock(eyebrow, meanings) {
+  const terms = Object.keys(meanings || {}).map((k) => ({ term: k, meaning: meanings[k] }));
+  if (terms.length === 0) return null;
+  return { type: 'definition', name: `Block: ${eyebrow}`, eyebrow, terms };
+}
+
+// The whole layout decision, as data. Rows keep canonical numbering (an absent
+// row's number is skipped, never renumbered) so node names stay stable across
+// sparse records. bodyTextStyle: only .fontSize is read — passing a full Figma
+// TextStyle object is fine.
+export function planDocCard(record, specimenWidth, bodyTextStyle) {
+  const unit = columnUnit(bodyTextStyle.fontSize);
+  const columns = cardColumns(specimenWidth, unit);
+
+  const row1 = [];
+  if (typeof record.description === 'string' && record.description.trim() !== '') {
+    row1.push({ type: 'prose', name: 'Block: Overview', eyebrow: 'Overview', text: record.description });
+  }
+  const whenTo = listBlock('When to use', record.whenToUse);
+  if (whenTo) row1.push(whenTo);
+  const whenNot = listBlock('When not to use', record.whenNotToUse);
+  if (whenNot) row1.push(whenNot);
+
+  const row2 = [];
+  if (Array.isArray(record.dos) && record.dos.length) {
+    row2.push({ type: 'list-tone', name: 'Block: Do', eyebrow: '✓ Do', tone: 'positive', items: record.dos });
+  }
+  if (Array.isArray(record.donts) && record.donts.length) {
+    row2.push({ type: 'list-tone', name: "Block: Don't", eyebrow: "✕ Don't", tone: 'negative', items: record.donts });
+  }
+
+  const row3 = [];
+  for (const axis of Object.keys(record.variants || {})) {
+    const block = definitionBlock(`What each ${axis} means`, record.variants[axis]);
+    if (block) row3.push(block);
+  }
+  const stateBlock = definitionBlock('What each state means', record.states);
+  if (stateBlock) row3.push(stateBlock);
+  const a11y = record.accessibility || {};
+  // role is not rendered on the card — it lives in the description field / MDX.
+  const a11yBlock = listBlock('Accessibility', [...(a11y.keyboard || []), ...(a11y.notes || [])]);
+  if (a11yBlock) row3.push(a11yBlock);
+
+  const rows = [
+    { name: 'Usage Row 1', blocks: row1 },
+    { name: 'Usage Row 2', blocks: row2 },
+    { name: 'Usage Row 3', blocks: row3 },
+  ].filter((r) => r.blocks.length > 0);
+
+  return {
+    rendererVersion: DOC_CARD_RENDERER_VERSION,
+    columnUnit: unit,
+    columns,
+    cardWidth: columns * unit,
+    termColumn: Math.round(unit * 0.3),
+    rows,
+  };
+}

--- a/scripts/lib/doc-card-plan.mjs
+++ b/scripts/lib/doc-card-plan.mjs
@@ -1,0 +1,23 @@
+// Pure layout planner for the component doc card's Usage band.
+// ZERO imports, `export const`/`export function` only — this module is inlined
+// verbatim into the generated Figma snippet (references/doc-card-builder.md) by
+// build-doc-card-builder.mjs, so it must run in both Node and the Figma plugin
+// sandbox. build-doc-card-builder.mjs enforces the no-imports rule.
+//
+// Layout contract: docs/superpowers/specs/2026-08-09-doc-card-layout-and-voice-design.md
+
+// Single source of truth for the doc-card layout version. Imported by
+// docs-check.mjs and embedded (via inlining) into the generated builder snippet.
+export const DOC_CARD_RENDERER_VERSION = '2';
+
+// columnUnit = clamp(round(bodyFontSize × 30), 280, 480) px.
+// 30 ≈ 60ch × ~0.5em average glyph width for UI text faces. Layout chrome, not
+// a design value — the one documented exception to the no-hardcoded-px rule.
+export function columnUnit(bodyFontSize) {
+  return Math.min(480, Math.max(280, Math.round(bodyFontSize * 30)));
+}
+
+// cardWidth = max(specimenWidth, 3 units) rounded UP to a whole unit.
+export function cardColumns(specimenWidth, unit) {
+  return Math.max(3, Math.ceil(specimenWidth / unit));
+}

--- a/scripts/lib/doc-card-plan.test.mjs
+++ b/scripts/lib/doc-card-plan.test.mjs
@@ -2,8 +2,8 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { DOC_CARD_RENDERER_VERSION, columnUnit, cardColumns, planDocCard } from './doc-card-plan.mjs';
 
-test('DOC_CARD_RENDERER_VERSION is the string "2"', () => {
-  assert.equal(DOC_CARD_RENDERER_VERSION, '2');
+test('DOC_CARD_RENDERER_VERSION is the string "3"', () => {
+  assert.equal(DOC_CARD_RENDERER_VERSION, '3');
 });
 
 test('columnUnit: clamp(round(fontSize × 30), 280, 480)', () => {
@@ -14,11 +14,13 @@ test('columnUnit: clamp(round(fontSize × 30), 280, 480)', () => {
   assert.equal(columnUnit(13.5), 405); // rounds: 13.5 × 30 = 405
 });
 
-test('cardColumns: max(3, ceil(specimenWidth / unit)) — width rounds UP to whole units', () => {
-  assert.equal(cardColumns(1500, 420), 4); // ceil(3.57) = 4
-  assert.equal(cardColumns(1260, 420), 3); // exact multiple stays 3
-  assert.equal(cardColumns(200, 480), 3);  // narrow specimen: 3-unit floor
-  assert.equal(cardColumns(0, 480), 3);    // degenerate specimen still floors at 3
+test('cardColumns: clamp(maxBlocksPerRow, 3, ceil(specimenWidth / unit)) — content-capped, width-ceilinged, 3-unit floored', () => {
+  assert.equal(cardColumns(1500, 420, 10), 4); // ceil(3.57) = 4, uncapped by content
+  assert.equal(cardColumns(1260, 420, 10), 3); // exact multiple stays 3
+  assert.equal(cardColumns(2010, 480, 3), 3);  // Input's dogfood case: was 5 (dead columns) — content caps it at 3
+  assert.equal(cardColumns(1440, 480, 4), 3);  // Button's case: specimen ceiling still binds; 4th block wraps
+  assert.equal(cardColumns(200, 480, 1), 3);   // narrow specimen, sparse content: 3-unit floor
+  assert.equal(cardColumns(2010, 480, 0), 3);  // degenerate content count still floors at 3
 });
 
 const FULL_RECORD = {
@@ -43,7 +45,7 @@ const FULL_RECORD = {
 
 test('planDocCard: full record → three rows with the canonical block layout', () => {
   const plan = planDocCard(FULL_RECORD, 1500, { fontSize: 14 });
-  assert.equal(plan.rendererVersion, '2');
+  assert.equal(plan.rendererVersion, '3');
   assert.equal(plan.columnUnit, 420);
   assert.equal(plan.columns, 4);          // ceil(1500 / 420)
   assert.equal(plan.cardWidth, 1680);     // 4 × 420
@@ -101,6 +103,26 @@ test('planDocCard: row names keep canonical numbers when an earlier row is absen
   // No description/whenToUse (row 1 empty), no dos/donts (row 2 empty) — the
   // states row is still named Usage Row 3, never renumbered.
   assert.deepEqual(plan.rows.map((r) => r.name), ['Usage Row 3']);
+});
+
+test('planDocCard: columns are capped by content, not just specimen width — a wide specimen with sparse rows does not mint dead columns', () => {
+  // Row 1 has 3 blocks (the widest row); row 2 has 2; row 3 has 1 — max is 3.
+  // A 2010px specimen would ceil to 5 columns on width alone; content caps it.
+  const plan = planDocCard(
+    {
+      name: 'Input',
+      summary: 's',
+      description: 'A single-line field for entering text.',
+      whenToUse: ['Collecting a short piece of free text.'],
+      whenNotToUse: ['Choosing from a fixed set. Use a Select instead.'],
+      dos: ['Label every input.'],
+      donts: ["Don't rely on placeholder text as the only label."],
+      states: { focused: 'The input has keyboard focus.' },
+    },
+    2010, { fontSize: 16 },
+  );
+  assert.equal(plan.columns, 3);
+  assert.equal(plan.cardWidth, 1440);
 });
 
 test('planDocCard: empty arrays and empty objects are skipped like absent fields', () => {

--- a/scripts/lib/doc-card-plan.test.mjs
+++ b/scripts/lib/doc-card-plan.test.mjs
@@ -20,6 +20,7 @@ test('cardColumns: clamp(maxBlocksPerRow, 3, ceil(specimenWidth / unit)) — con
   assert.equal(cardColumns(2010, 480, 3), 3);  // Input's dogfood case: was 5 (dead columns) — content caps it at 3
   assert.equal(cardColumns(1440, 480, 4), 3);  // Button's case: specimen ceiling still binds; 4th block wraps
   assert.equal(cardColumns(200, 480, 1), 3);   // narrow specimen, sparse content: 3-unit floor
+  assert.equal(cardColumns(0, 480, 2), 3);     // degenerate specimen width still floors at 3
   assert.equal(cardColumns(2010, 480, 0), 3);  // degenerate content count still floors at 3
 });
 

--- a/scripts/lib/doc-card-plan.test.mjs
+++ b/scripts/lib/doc-card-plan.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { DOC_CARD_RENDERER_VERSION, columnUnit, cardColumns } from './doc-card-plan.mjs';
+import { DOC_CARD_RENDERER_VERSION, columnUnit, cardColumns, planDocCard } from './doc-card-plan.mjs';
 
 test('DOC_CARD_RENDERER_VERSION is the string "2"', () => {
   assert.equal(DOC_CARD_RENDERER_VERSION, '2');
@@ -19,4 +19,95 @@ test('cardColumns: max(3, ceil(specimenWidth / unit)) — width rounds UP to who
   assert.equal(cardColumns(1260, 420), 3); // exact multiple stays 3
   assert.equal(cardColumns(200, 480), 3);  // narrow specimen: 3-unit floor
   assert.equal(cardColumns(0, 480), 3);    // degenerate specimen still floors at 3
+});
+
+const FULL_RECORD = {
+  name: 'Button',
+  summary: 'Triggers an action or event.',
+  description: 'A clickable control that starts an action.',
+  whenToUse: ['Something happens on the current page'],
+  whenNotToUse: ['Moving to another page or URL. Use a Link instead.'],
+  variants: {
+    variant: { default: 'The one main action in a view.', secondary: 'Sits alongside a main action.' },
+    size: { sm: 'Dense layouts and toolbars.', md: 'The default size.' },
+  },
+  states: { hover: 'The pointer is over the button.', disabled: "Can't be clicked or tabbed to." },
+  dos: ['Start the label with a verb.'],
+  donts: ["Don't use a button to navigate. Use a Link."],
+  accessibility: {
+    role: 'button',
+    keyboard: ['Enter and Space activate it.'],
+    notes: ['An icon-only button needs an aria-label so screen readers can announce it.'],
+  },
+};
+
+test('planDocCard: full record → three rows with the canonical block layout', () => {
+  const plan = planDocCard(FULL_RECORD, 1500, { fontSize: 14 });
+  assert.equal(plan.rendererVersion, '2');
+  assert.equal(plan.columnUnit, 420);
+  assert.equal(plan.columns, 4);          // ceil(1500 / 420)
+  assert.equal(plan.cardWidth, 1680);     // 4 × 420
+  assert.equal(plan.termColumn, 126);     // round(420 × 0.3)
+  assert.deepEqual(plan.rows.map((r) => r.name), ['Usage Row 1', 'Usage Row 2', 'Usage Row 3']);
+  assert.deepEqual(plan.rows[0].blocks.map((b) => b.name),
+    ['Block: Overview', 'Block: When to use', 'Block: When not to use']);
+  assert.deepEqual(plan.rows[1].blocks.map((b) => [b.name, b.tone]),
+    [['Block: Do', 'positive'], ["Block: Don't", 'negative']]);
+  assert.deepEqual(plan.rows[2].blocks.map((b) => b.name), [
+    'Block: What each variant means',   // one definition block per variants axis, in key order
+    'Block: What each size means',
+    'Block: What each state means',
+    'Block: Accessibility',
+  ]);
+});
+
+test('planDocCard: definition terms preserve key order; accessibility = keyboard then notes, role dropped', () => {
+  const plan = planDocCard(FULL_RECORD, 1500, { fontSize: 14 });
+  const variantBlock = plan.rows[2].blocks[0];
+  assert.equal(variantBlock.type, 'definition');
+  assert.deepEqual(variantBlock.terms, [
+    { term: 'default', meaning: 'The one main action in a view.' },
+    { term: 'secondary', meaning: 'Sits alongside a main action.' },
+  ]);
+  const a11y = plan.rows[2].blocks[3];
+  assert.equal(a11y.type, 'list');
+  assert.deepEqual(a11y.items, [
+    'Enter and Space activate it.',
+    'An icon-only button needs an aria-label so screen readers can announce it.',
+  ]);
+});
+
+test('planDocCard: tone blocks carry the glyph eyebrows, plain deterministic names', () => {
+  const plan = planDocCard(FULL_RECORD, 1500, { fontSize: 14 });
+  assert.deepEqual(plan.rows[1].blocks.map((b) => b.eyebrow), ['✓ Do', "✕ Don't"]);
+});
+
+test('planDocCard: sparse record → only Usage Row 1 with Overview; empty rows collapse', () => {
+  const plan = planDocCard(
+    { name: 'Badge', summary: 's', description: 'A small label.' }, 200, { fontSize: 16 },
+  );
+  assert.equal(plan.columnUnit, 480);
+  assert.equal(plan.columns, 3);         // 3-unit floor
+  assert.equal(plan.cardWidth, 1440);
+  assert.deepEqual(plan.rows.map((r) => r.name), ['Usage Row 1']);
+  assert.deepEqual(plan.rows[0].blocks.map((b) => b.name), ['Block: Overview']);
+});
+
+test('planDocCard: row names keep canonical numbers when an earlier row is absent', () => {
+  const plan = planDocCard(
+    { name: 'X', summary: 's', description: '', states: { hover: 'Pointer over it.' } },
+    200, { fontSize: 16 },
+  );
+  // No description/whenToUse (row 1 empty), no dos/donts (row 2 empty) — the
+  // states row is still named Usage Row 3, never renumbered.
+  assert.deepEqual(plan.rows.map((r) => r.name), ['Usage Row 3']);
+});
+
+test('planDocCard: empty arrays and empty objects are skipped like absent fields', () => {
+  const plan = planDocCard(
+    { name: 'X', summary: 's', description: 'd', whenToUse: [], variants: {}, dos: [] },
+    200, { fontSize: 16 },
+  );
+  assert.deepEqual(plan.rows.map((r) => r.name), ['Usage Row 1']);
+  assert.deepEqual(plan.rows[0].blocks.map((b) => b.name), ['Block: Overview']);
 });

--- a/scripts/lib/doc-card-plan.test.mjs
+++ b/scripts/lib/doc-card-plan.test.mjs
@@ -1,0 +1,22 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { DOC_CARD_RENDERER_VERSION, columnUnit, cardColumns } from './doc-card-plan.mjs';
+
+test('DOC_CARD_RENDERER_VERSION is the string "2"', () => {
+  assert.equal(DOC_CARD_RENDERER_VERSION, '2');
+});
+
+test('columnUnit: clamp(round(fontSize × 30), 280, 480)', () => {
+  assert.equal(columnUnit(14), 420);  // 14 × 30 = 420, inside the clamp
+  assert.equal(columnUnit(16), 480);  // 16 × 30 = 480, exactly the ceiling
+  assert.equal(columnUnit(9), 280);   // 270 clamps up to the floor
+  assert.equal(columnUnit(20), 480);  // 600 clamps down to the ceiling
+  assert.equal(columnUnit(13.5), 405); // rounds: 13.5 × 30 = 405
+});
+
+test('cardColumns: max(3, ceil(specimenWidth / unit)) — width rounds UP to whole units', () => {
+  assert.equal(cardColumns(1500, 420), 4); // ceil(3.57) = 4
+  assert.equal(cardColumns(1260, 420), 3); // exact multiple stays 3
+  assert.equal(cardColumns(200, 480), 3);  // narrow specimen: 3-unit floor
+  assert.equal(cardColumns(0, 480), 3);    // degenerate specimen still floors at 3
+});

--- a/scripts/lib/doc-card-render.figma.js
+++ b/scripts/lib/doc-card-render.figma.js
@@ -47,6 +47,12 @@ async function renderDocCard({ card, record, vars, bodyTextStyle }) {
     throw new Error('renderDocCard: bodyTextStyle is required — find the "Body/Default" text style via getLocalTextStylesAsync');
   }
 
+  // Three-band cards are VERTICAL auto-layout frames. Appending into anything
+  // else preserves absolute position and mis-places the band — throw instead.
+  if (card.layoutMode !== 'VERTICAL') {
+    throw new Error('renderDocCard: the doc card must be a VERTICAL auto-layout frame (three-band card); got layoutMode=' + card.layoutMode);
+  }
+
   // Fonts, up front — before any text node exists. Eyebrow chrome is Bold of
   // the body family; fall back to the body style's own font if no Bold exists.
   const bodyFont = bodyTextStyle.fontName;
@@ -99,12 +105,20 @@ async function renderDocCard({ card, record, vars, bodyTextStyle }) {
     t.layoutSizingHorizontal = 'FILL';
   };
 
+  // Resolved px of the spacing tokens (mode-aware, resolved against the card).
+  // The planner's cardWidth is the CONTENT-GRID width (columns × columnUnit);
+  // the frame's outer width adds the band padding and the inter-block gutters
+  // so the planned column count actually fits on one line.
+  const padPx = vars.spacePadding.resolveForConsumer(card).value;
+  const blockGapPx = vars.spaceBlockGap.resolveForConsumer(card).value;
+  const usageWidth = plan.cardWidth + 2 * padPx + (plan.columns - 1) * blockGapPx;
+
   const usage = figma.createFrame();
   usage.name = 'Usage';
   usage.layoutMode = 'VERTICAL';
   usage.fills = [];
   card.appendChild(usage);
-  usage.resize(plan.cardWidth, usage.height);
+  usage.resize(usageWidth, usage.height);
   usage.counterAxisSizingMode = 'FIXED';  // VERTICAL frame: counter = width
   usage.primaryAxisSizingMode = 'AUTO';   // height hugs — re-asserted after resize()
   usage.setBoundVariable('paddingLeft', vars.spacePadding);
@@ -113,11 +127,13 @@ async function renderDocCard({ card, record, vars, bodyTextStyle }) {
   usage.setBoundVariable('paddingBottom', vars.spacePadding);
   usage.setBoundVariable('itemSpacing', vars.spaceRowGap);
 
-  // If the card is narrower than the computed width and not hugging, widen it —
-  // this touches only the card's own size, never its children.
-  if (card.width < plan.cardWidth && !(card.layoutMode === 'VERTICAL' && card.counterAxisSizingMode === 'AUTO')) {
-    card.resize(plan.cardWidth, card.height);
-    if (card.layoutMode === 'VERTICAL') card.primaryAxisSizingMode = 'AUTO';
+  // Widen the card to fit (its own padding included). Card is VERTICAL (guarded
+  // above): counter axis = width, so a hugging card needs no resize; a fixed
+  // card is widened and its height sizing re-asserted after resize().
+  const cardOuter = usageWidth + card.paddingLeft + card.paddingRight;
+  if (card.counterAxisSizingMode !== 'AUTO' && card.width < cardOuter) {
+    card.resize(cardOuter, card.height);
+    card.primaryAxisSizingMode = 'AUTO';
   }
 
   const blocksCreated = [];

--- a/scripts/lib/doc-card-render.figma.js
+++ b/scripts/lib/doc-card-render.figma.js
@@ -1,0 +1,215 @@
+// Figma plugin-API renderer for the doc-card Usage band. This file is NOT a
+// Node module — build-doc-card-builder.mjs concatenates it after the inlined
+// planner (doc-card-plan.mjs) into references/doc-card-builder.md, and the
+// result runs inside figma_execute (dynamic-page mode). Constraints honored
+// here (see references/figma-scripting.md): async APIs only, style/font set
+// BEFORE .characters, fonts loaded up front, resize() sizing modes re-asserted,
+// bound paints seeded light-gray (never pure black).
+//
+// In-scope globals when assembled: planDocCard, DOC_CARD_RENDERER_VERSION
+// (inlined planner) and the caller-filled slots RECORD, CANONICAL_FP.
+
+// 32-bit FNV-1a — the render hash. Only ever compared against itself (the
+// manifest's surfaces.docCard.render), so it does not need to match the
+// sha256-based canonical fingerprint, which cannot run in the Figma sandbox.
+function fnv1a(str) {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h.toString(16).padStart(8, '0');
+}
+
+const REQUIRED_VARS = [
+  'textDefault', 'textMuted', 'tonePositive', 'toneNegative', 'border',
+  'spacePadding', 'spaceRowGap', 'spaceBlockGap', 'spaceItemGap',
+];
+
+// Bound paint, seeded with a light-gray approximation — a failed/late bind must
+// never render pure black (reads as accidental dark mode).
+function boundPaint(variable) {
+  return figma.variables.setBoundVariableForPaint(
+    { type: 'SOLID', color: { r: 0.85, g: 0.85, b: 0.87 } }, 'color', variable,
+  );
+}
+
+async function renderDocCard({ card, record, vars, bodyTextStyle }) {
+  // Bind-or-throw: a missing variable or style is a gap in the token set —
+  // never fall back to a hex/px.
+  for (const key of REQUIRED_VARS) {
+    if (!vars || !vars[key]) {
+      throw new Error('renderDocCard: missing required variable "' + key
+        + '" — resolve it via figma_get_variables / getVariableByIdAsync and pass the Variable object in vars');
+    }
+  }
+  if (!bodyTextStyle) {
+    throw new Error('renderDocCard: bodyTextStyle is required — find the "Body/Default" text style via getLocalTextStylesAsync');
+  }
+
+  // Fonts, up front — before any text node exists. Eyebrow chrome is Bold of
+  // the body family; fall back to the body style's own font if no Bold exists.
+  const bodyFont = bodyTextStyle.fontName;
+  await figma.loadFontAsync(bodyFont);
+  let eyebrowFont = { family: bodyFont.family, style: 'Bold' };
+  try { await figma.loadFontAsync(eyebrowFont); } catch (e) { eyebrowFont = bodyFont; }
+
+  // Measure the specimen: the band named "Specimen", or (older cards) the
+  // component set inside the card.
+  const specimen = card.findChild((n) => n.name === 'Specimen')
+    || card.findOne((n) => n.type === 'COMPONENT_SET');
+  if (!specimen) {
+    throw new Error('renderDocCard: no "Specimen" frame or COMPONENT_SET found inside the card');
+  }
+
+  const plan = planDocCard(record, specimen.width, { fontSize: bodyTextStyle.fontSize });
+
+  // Eyebrow chrome (derived, not bound — layout chrome like the column unit):
+  // fontSize × 0.65 rounded, min 8; Bold; uppercase; letter-spacing +8%.
+  const eyebrowSize = Math.max(8, Math.round(bodyTextStyle.fontSize * 0.65));
+
+  // Idempotent + scoped: rebuild ONLY the Usage frame. Header and specimen are
+  // never touched — recreating a component set detaches downstream instances.
+  const existing = card.findChild((n) => n.name === 'Usage');
+  if (existing) existing.remove();
+
+  const eyebrowText = (chars, colorVar) => {
+    const t = figma.createText();
+    t.fontName = eyebrowFont;          // loaded above — set BEFORE .characters
+    t.fontSize = eyebrowSize;
+    t.letterSpacing = { value: 8, unit: 'PERCENT' };
+    t.textCase = 'UPPER';
+    t.characters = chars;
+    t.fills = [boundPaint(colorVar)];
+    return t;
+  };
+
+  const bodyText = async (chars, colorVar) => {
+    const t = figma.createText();
+    await t.setTextStyleIdAsync(bodyTextStyle.id);  // style BEFORE characters
+    t.characters = chars;
+    t.fills = [boundPaint(colorVar)];
+    return t;
+  };
+
+  // Appends `t` to `parent` as a full-width, height-hugging text node.
+  const fillWidth = (parent, t) => {
+    parent.appendChild(t);
+    t.textAutoResize = 'HEIGHT';
+    t.layoutSizingHorizontal = 'FILL';
+  };
+
+  const usage = figma.createFrame();
+  usage.name = 'Usage';
+  usage.layoutMode = 'VERTICAL';
+  usage.fills = [];
+  card.appendChild(usage);
+  usage.resize(plan.cardWidth, usage.height);
+  usage.counterAxisSizingMode = 'FIXED';  // VERTICAL frame: counter = width
+  usage.primaryAxisSizingMode = 'AUTO';   // height hugs — re-asserted after resize()
+  usage.setBoundVariable('paddingLeft', vars.spacePadding);
+  usage.setBoundVariable('paddingRight', vars.spacePadding);
+  usage.setBoundVariable('paddingTop', vars.spacePadding);
+  usage.setBoundVariable('paddingBottom', vars.spacePadding);
+  usage.setBoundVariable('itemSpacing', vars.spaceRowGap);
+
+  // If the card is narrower than the computed width and not hugging, widen it —
+  // this touches only the card's own size, never its children.
+  if (card.width < plan.cardWidth && !(card.layoutMode === 'VERTICAL' && card.counterAxisSizingMode === 'AUTO')) {
+    card.resize(plan.cardWidth, card.height);
+    if (card.layoutMode === 'VERTICAL') card.primaryAxisSizingMode = 'AUTO';
+  }
+
+  const blocksCreated = [];
+  let first = true;
+  for (const row of plan.rows) {
+    if (!first) {
+      const divider = figma.createFrame();
+      divider.name = 'Row Divider';
+      divider.fills = [boundPaint(vars.border)];
+      usage.appendChild(divider);
+      divider.layoutSizingHorizontal = 'FILL';
+      divider.resize(divider.width, 1);
+    }
+    first = false;
+
+    const rowFrame = figma.createFrame();
+    rowFrame.name = row.name;
+    rowFrame.layoutMode = 'HORIZONTAL';
+    rowFrame.layoutWrap = 'WRAP';
+    rowFrame.fills = [];
+    rowFrame.counterAxisAlignItems = 'MIN';  // top-aligned…
+    rowFrame.primaryAxisAlignItems = 'MIN';  // …left-packed; never center/space-between
+    usage.appendChild(rowFrame);
+    rowFrame.layoutSizingHorizontal = 'FILL';
+    rowFrame.layoutSizingVertical = 'HUG';
+    rowFrame.setBoundVariable('itemSpacing', vars.spaceBlockGap);
+    rowFrame.setBoundVariable('counterAxisSpacing', vars.spaceRowGap);
+
+    for (const block of row.blocks) {
+      const bf = figma.createFrame();
+      bf.name = block.name;
+      bf.layoutMode = 'VERTICAL';
+      bf.fills = [];
+      rowFrame.appendChild(bf);
+      bf.resize(plan.columnUnit, bf.height);   // every block is exactly one unit wide
+      bf.counterAxisSizingMode = 'FIXED';
+      bf.primaryAxisSizingMode = 'AUTO';
+      bf.setBoundVariable('itemSpacing', vars.spaceItemGap);
+
+      const eyebrowColor = block.type === 'list-tone'
+        ? (block.tone === 'positive' ? vars.tonePositive : vars.toneNegative)
+        : vars.textMuted;
+      const eb = eyebrowText(block.eyebrow, eyebrowColor);
+      bf.appendChild(eb);
+      eb.textAutoResize = 'HEIGHT';
+      eb.layoutSizingHorizontal = 'FILL';
+
+      if (block.type === 'prose') {
+        fillWidth(bf, await bodyText(block.text, vars.textDefault));
+      } else if (block.type === 'list' || block.type === 'list-tone') {
+        for (const item of block.items) {
+          fillWidth(bf, await bodyText('• ' + item, vars.textDefault));
+        }
+      } else if (block.type === 'definition') {
+        for (const pair of block.terms) {
+          const pf = figma.createFrame();
+          pf.name = 'Definition: ' + pair.term;
+          pf.layoutMode = 'HORIZONTAL';
+          pf.fills = [];
+          bf.appendChild(pf);
+          pf.layoutSizingHorizontal = 'FILL';
+          pf.layoutSizingVertical = 'HUG';
+          pf.setBoundVariable('itemSpacing', vars.spaceItemGap);
+          const term = await bodyText(pair.term, vars.textDefault);
+          pf.appendChild(term);
+          term.textAutoResize = 'HEIGHT';        // long terms wrap, never truncate
+          term.resize(plan.termColumn, term.height);
+          term.layoutSizingHorizontal = 'FIXED'; // fixed term column: 30% of the unit
+          const meaning = await bodyText(pair.meaning, vars.textMuted);
+          pf.appendChild(meaning);
+          meaning.textAutoResize = 'HEIGHT';
+          meaning.layoutSizingHorizontal = 'FILL';
+        }
+      }
+      blocksCreated.push(block.name);
+    }
+  }
+
+  // Metadata node — hidden, machine-read by the drift check's Figma-side pass.
+  const fp = eyebrowText(CANONICAL_FP, vars.textMuted);
+  fp.name = 'Doc Fingerprint';
+  fp.visible = false;
+  usage.appendChild(fp);
+
+  return {
+    rendererVersion: DOC_CARD_RENDERER_VERSION,
+    columnUnit: plan.columnUnit,
+    columns: plan.columns,
+    cardWidth: plan.cardWidth,
+    rowsRendered: plan.rows.length,
+    blocksCreated,
+    fingerprint: CANONICAL_FP,
+    renderHash: fnv1a(JSON.stringify(plan)),
+  };
+}

--- a/scripts/lib/doc-card-render.figma.js
+++ b/scripts/lib/doc-card-render.figma.js
@@ -60,12 +60,12 @@ async function renderDocCard({ card, record, vars, bodyTextStyle }) {
   let eyebrowFont = { family: bodyFont.family, style: 'Bold' };
   try { await figma.loadFontAsync(eyebrowFont); } catch (e) { eyebrowFont = bodyFont; }
 
-  // Measure the specimen: the band named "Specimen", or (older cards) the
-  // component set inside the card.
-  const specimen = card.findChild((n) => n.name === 'Specimen')
-    || card.findOne((n) => n.type === 'COMPONENT_SET');
+  // Measure the specimen: the card's COMPONENT_SET is the specimen contract —
+  // its width drives the column calculation. (No named "Specimen" band lookup:
+  // no real card has ever used one, so that path never executed.)
+  const specimen = card.findOne((n) => n.type === 'COMPONENT_SET');
   if (!specimen) {
-    throw new Error('renderDocCard: no "Specimen" frame or COMPONENT_SET found inside the card');
+    throw new Error('renderDocCard: no COMPONENT_SET found inside the card — the specimen band must contain the component set');
   }
 
   const plan = planDocCard(record, specimen.width, { fontSize: bodyTextStyle.fontSize });
@@ -73,6 +73,15 @@ async function renderDocCard({ card, record, vars, bodyTextStyle }) {
   // Eyebrow chrome (derived, not bound — layout chrome like the column unit):
   // fontSize × 0.65 rounded, min 8; Bold; uppercase; letter-spacing +8%.
   const eyebrowSize = Math.max(8, Math.round(bodyTextStyle.fontSize * 0.65));
+
+  // One component per doc card: a band like "Usage — Select Menu Item" means this
+  // card documents multiple components. Rendering here would append a band we
+  // don't own and silently accumulate — refuse and ask for the card to be split.
+  const foreign = card.findChild((n) => n.name !== 'Usage' && n.name.startsWith('Usage'));
+  if (foreign) {
+    throw new Error('renderDocCard: card contains band "' + foreign.name
+      + '" — one component per doc card; split this card so each component owns its own card before re-rendering');
+  }
 
   // Idempotent + scoped: rebuild ONLY the Usage frame. Header and specimen are
   // never touched — recreating a component set detaches downstream instances.
@@ -117,6 +126,7 @@ async function renderDocCard({ card, record, vars, bodyTextStyle }) {
   usage.name = 'Usage';
   usage.layoutMode = 'VERTICAL';
   usage.fills = [];
+  usage.clipsContent = false;
   card.appendChild(usage);
   usage.resize(usageWidth, usage.height);
   usage.counterAxisSizingMode = 'FIXED';  // VERTICAL frame: counter = width

--- a/scripts/lib/doc-card-render.figma.js
+++ b/scripts/lib/doc-card-render.figma.js
@@ -60,6 +60,17 @@ async function renderDocCard({ card, record, vars, bodyTextStyle }) {
   let eyebrowFont = { family: bodyFont.family, style: 'Bold' };
   try { await figma.loadFontAsync(eyebrowFont); } catch (e) { eyebrowFont = bodyFont; }
 
+  // One component per doc card: a band like "Usage — Select Menu Item" means this
+  // card documents multiple components. Rendering here would append a band we
+  // don't own and silently accumulate — refuse and ask for the card to be split.
+  // Checked before the specimen lookup so a multi-component card always gets
+  // this error, never a possible "no COMPONENT_SET found" from the lookup below.
+  const foreign = card.findChild((n) => n.name !== 'Usage' && n.name.startsWith('Usage'));
+  if (foreign) {
+    throw new Error('renderDocCard: card contains band "' + foreign.name
+      + '" — one component per doc card; split this card so each component owns its own card before re-rendering');
+  }
+
   // Measure the specimen: the card's COMPONENT_SET is the specimen contract —
   // its width drives the column calculation. (No named "Specimen" band lookup:
   // no real card has ever used one, so that path never executed.)
@@ -73,15 +84,6 @@ async function renderDocCard({ card, record, vars, bodyTextStyle }) {
   // Eyebrow chrome (derived, not bound — layout chrome like the column unit):
   // fontSize × 0.65 rounded, min 8; Bold; uppercase; letter-spacing +8%.
   const eyebrowSize = Math.max(8, Math.round(bodyTextStyle.fontSize * 0.65));
-
-  // One component per doc card: a band like "Usage — Select Menu Item" means this
-  // card documents multiple components. Rendering here would append a band we
-  // don't own and silently accumulate — refuse and ask for the card to be split.
-  const foreign = card.findChild((n) => n.name !== 'Usage' && n.name.startsWith('Usage'));
-  if (foreign) {
-    throw new Error('renderDocCard: card contains band "' + foreign.name
-      + '" — one component per doc card; split this card so each component owns its own card before re-rendering');
-  }
 
   // Idempotent + scoped: rebuild ONLY the Usage frame. Header and specimen are
   // never touched — recreating a component set detaches downstream instances.

--- a/scripts/lib/doc-card-render.figma.js
+++ b/scripts/lib/doc-card-render.figma.js
@@ -144,8 +144,8 @@ async function renderDocCard({ card, record, vars, bodyTextStyle }) {
       divider.name = 'Row Divider';
       divider.fills = [boundPaint(vars.border)];
       usage.appendChild(divider);
-      divider.layoutSizingHorizontal = 'FILL';
       divider.resize(divider.width, 1);
+      divider.layoutSizingHorizontal = 'FILL';
     }
     first = false;
 

--- a/skills/component-builder/SKILL.md
+++ b/skills/component-builder/SKILL.md
@@ -273,19 +273,24 @@ stamp `provenance` per block):**
   when-to-use/not, do's/don'ts, and the a11y summary — and append a fingerprint
   marker line `<!-- tl:doc <fp> -->` (this is the surface Dev Mode and Code Connect
   read).
-- **Doc card body.** Extend the existing doc card (name/short-desc/status/date, per
-  `${CLAUDE_PLUGIN_ROOT}/references/figma-component-standards.md`) with a usage body:
-  when-to-use, do's/don'ts, an a11y line, and a variant/state legend — all
-  token-bound (no hardcoded hex/px). Add a metadata text node named
-  `Doc Fingerprint` holding `<fp>`.
+- **Doc card body.** Render the card's `Usage` band with the canonical builder
+  snippet in `${CLAUDE_PLUGIN_ROOT}/references/doc-card-builder.md` (via
+  `figma_execute` with an explicit `timeout`, one card per call): fill the
+  RECORD/CANONICAL_FP slots, resolve the nine required semantic variables and
+  the `Body/Default` text style per that file's call contract, run it, and
+  verify the returned summary (`rowsRendered`, `blocksCreated`, `cardWidth`) —
+  not a screenshot. The builder creates the `Doc Fingerprint` node itself and
+  is the only thing that may build the usage body — never hand-assemble it.
 - Compute `<fp>` as the canonical fingerprint defined in the schema reference
   (sha256 of the projected record without `provenance`, first 16 hex chars).
 
 **Update the manifest (fields this skill owns):** set
 `components.meta[<Name>].doc` to `{ path, fingerprint: <fp>, surfaces: {
 figmaDescription: { src: <fp>, render: <hash of the description text> }, docCard: {
-src: <fp>, render: <hash of the card body content> } } }`. The code surfaces
-(`storybookMdx`) are added later by `storybook-chromatic-builder`.
+src: <fp>, render: <summary.renderHash>, renderer: <summary.rendererVersion> } } }`
+— the docCard entry is stamped from the builder's returned summary, never by
+re-reading the card. The code surfaces (`storybookMdx`) are added later by
+`storybook-chromatic-builder`.
 
 Run the standard doc-card visual-validation + post-build audit
 (`${CLAUDE_PLUGIN_ROOT}/references/figma-component-standards.md`) after enriching

--- a/skills/storybook-chromatic-builder/SKILL.md
+++ b/skills/storybook-chromatic-builder/SKILL.md
@@ -33,8 +33,9 @@ real design tokens (import the generated CSS/theme). Checkpoint: confirm
 Storybook runs and shows the token-themed canvas.
 
 Install the documentation scripts alongside the token scripts (copy from the
-plugin's `scripts/` — `build-docs-digest.mjs`, `docs-check.mjs`, and
-`lib/doc-record.mjs` — into the repo and register npm scripts):
+plugin's `scripts/` — `build-docs-digest.mjs`, `docs-check.mjs`,
+`lib/doc-record.mjs`, and `lib/doc-card-plan.mjs` — into the repo and register
+npm scripts):
 
 - `"docs:digest": "node scripts/build-docs-digest.mjs"`
 - `"docs:check": "node scripts/docs-check.mjs"`

--- a/skills/storybook-chromatic-builder/SKILL.md
+++ b/skills/storybook-chromatic-builder/SKILL.md
@@ -41,7 +41,9 @@ npm scripts):
 - `"docs:check": "node scripts/docs-check.mjs"`
 
 These are the documentation analog of `tokens:validate`; see
-`${CLAUDE_PLUGIN_ROOT}/scripts/README.md`.
+`${CLAUDE_PLUGIN_ROOT}/scripts/README.md`. This copy is setup, not a forever-fork:
+`/document-component` re-checks these files' freshness on every run and refreshes
+them from the plugin when it has moved on.
 
 **pnpm build-script allowlist (first-run gotcha).** On pnpm workspaces, the
 `@storybook/react-vite` install pulls `esbuild`, whose postinstall is blocked by


### PR DESCRIPTION
## Summary

Plan 1 of the [doc-card layout & voice spec](docs/superpowers/specs/2026-08-09-doc-card-layout-and-voice-design.md): the doc card's `Usage` band is now rendered by a canonical, generated `figma_execute` snippet instead of being improvised per run.

- **Pure layout planner** (`scripts/lib/doc-card-plan.mjs`, zero imports, unit-tested): column unit computed from the body text style (`clamp(round(fontSize×30), 280, 480)`), card width in whole column units (min 3), three wrapping rows over four closed block types, canonical row numbering.
- **Figma renderer template** (`scripts/lib/doc-card-render.figma.js`): bind-or-throw on 9 semantic variables + `Body/Default`, rebuilds only the `Usage` frame (header/specimen untouched), derives the frame's outer width from resolved spacing tokens at run time, returns a verifiable summary.
- **Generated reference** `references/doc-card-builder.md` built by `scripts/build-doc-card-builder.mjs`; `--check` gates CI and release alongside the adapter check.
- **Renderer version stamp**: builder stamps `renderer: "2"` into `surfaces.docCard`; `docs:check` reports missing/lower stamps as the informational `layout-upgrade-available` — never a failure, so untouched brownfield cards don't warn. `lib/doc-card-plan.mjs` ships in the installer copy list beside `docs-check.mjs`.
- **Prose wiring**: three-band card architecture in the standards doc, audit item 11 (builder-rendered Usage band, verified from the summary not a screenshot), skill/command updates, regenerated adapters, CHANGELOG.

The spec and implementation plan are included as the first two commits. Spec amendment in-branch: outer-width derivation (the plan's original width math double-counted padding/gutters — caught in review, adjudicated, fixed).

## Test plan

- 160/160 `node --test` (19 new: planner math, row assembly, docs:check classification, build/inlining guards, on-disk sync)
- `build-doc-card-builder.mjs --check`, `adapters/generate.mjs --check`, both plugin validators green
- Live-Figma dogfood (re-documenting Button/Input/Card in throughline-sample) is the acceptance test and happens post-merge per the spec; watch items there: `counterAxisSpacing` bindability, per-card `figma_execute` timeout, row-divider rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013K6HRnMCUxbyA3FHvr2AQf