### PR TITLE
feat: doc-writing standard + copy lint — voice phase (plan 2/2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ to [Semantic Versioning](https://semver.org).
   the plain reference register for all doc-record prose — per-block rules for
   `description`, `whenToUse`/`whenNotToUse`, `variants`/`states`,
   `dos`/`donts`, and `accessibility.notes`, plus the banned machinery
-  vocabulary (tokens, bindings, fingerprints, provenance, projections,
+  vocabulary (tokens, variables, bindings, fingerprints, provenance, projections,
   surfaces). `scripts/docs-lint.mjs` checks the mechanically reliable subset
   of the standard — warnings only, always exits 0 on a parseable record — and
   installs as `docs:lint` alongside `docs:digest`/`docs:check`. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ to [Semantic Versioning](https://semver.org).
 ## [Unreleased]
 
 ### Added
+- **Doc-writing standard and lint.** `references/doc-writing-standard.md` sets
+  the plain reference register for all doc-record prose — per-block rules for
+  `description`, `whenToUse`/`whenNotToUse`, `variants`/`states`,
+  `dos`/`donts`, and `accessibility.notes`, plus the banned machinery
+  vocabulary (tokens, bindings, fingerprints, provenance, projections,
+  surfaces). `scripts/docs-lint.mjs` checks the mechanically reliable subset
+  of the standard — warnings only, always exits 0 on a parseable record — and
+  installs as `docs:lint` alongside `docs:digest`/`docs:check`. The
+  `component-doc-archetypes.md` seed content was brought into compliance with
+  the standard. The `component-builder` authoring pipeline and
+  `/document-component` now run the lint after the record is written and
+  before the user-approval gate, fixing what it can and surfacing warnings on
+  `imported`/`user`-provenance blocks for the user to decide per item rather
+  than rewriting them silently.
+
 - **Deterministic doc-card builder (layout phase).** The doc card's `Usage` band
   is now rendered by a canonical, generated `figma_execute` snippet
   (`references/doc-card-builder.md`) built from a pure, unit-tested layout

--- a/adapters/codex/prompts/component-builder.md
+++ b/adapters/codex/prompts/component-builder.md
@@ -262,9 +262,10 @@ reference register, not this skill's guide voice.
    `node .throughline/scripts/docs-lint.mjs design-system/docs/components/<Name>.doc.json`,
    and fix the warnings it raises — for `imported`/`user` blocks, surface the
    warning to the user and let them decide per item, never silently rewrite.
-   **Show the whole drafted record and get explicit approval** — layers 1–4
-   only fill blocks the ingest step did not, and an `imported`/`user` block is
-   never overwritten.
+   **Show the whole drafted record and get explicit approval before
+   projecting it anywhere** (Figma description, doc card, manifest) — layers
+   1–4 only fill blocks the ingest step did not, and an `imported`/`user`
+   block is never overwritten.
 
 **Write the record and project it:**
 

--- a/adapters/codex/prompts/component-builder.md
+++ b/adapters/codex/prompts/component-builder.md
@@ -236,7 +236,9 @@ Read `.throughline/references/component-doc-schema.md` for the exact JSON
 schema, the fingerprint algorithm, and the projection contract.
 
 **Run the generation pipeline (each layer only fills what it legitimately knows;
-stamp `provenance` per block):**
+stamp `provenance` per block):** all authored prose follows
+`.throughline/references/doc-writing-standard.md` — its plain
+reference register, not this skill's guide voice.
 
 0. **Ingest existing docs — brownfield only, runs first.** If docs already exist
    for this component (code JSDoc/MDX/README, or a populated Figma component
@@ -255,9 +257,14 @@ stamp `provenance` per block):**
    accessibility idiom to the target framework (the same field you read for variant
    vocabulary). Provenance `framework`.
 4. **Interview for the non-inferable.** Ask the user for brand/product-specific
-   do's & don'ts and intent. Provenance `user`. **Show the whole drafted record and
-   get explicit approval before writing anything** — layers 1–4 only fill blocks the
-   ingest step did not, and an `imported`/`user` block is never overwritten.
+   do's & don'ts and intent. Provenance `user`. Write the draft to
+   `design-system/docs/components/<Name>.doc.json`, run
+   `node .throughline/scripts/docs-lint.mjs design-system/docs/components/<Name>.doc.json`,
+   and fix the warnings it raises — for `imported`/`user` blocks, surface the
+   warning to the user and let them decide per item, never silently rewrite.
+   **Show the whole drafted record and get explicit approval** — layers 1–4
+   only fill blocks the ingest step did not, and an `imported`/`user` block is
+   never overwritten.
 
 **Write the record and project it:**
 

--- a/adapters/codex/prompts/document-component.md
+++ b/adapters/codex/prompts/document-component.md
@@ -13,8 +13,9 @@ Ask which component to document (e.g. "Button"), then:
    written, run `node .throughline/scripts/docs-lint.mjs
    design-system/docs/components/<Name>.doc.json` and fix its warnings — for
    `imported`/`user` blocks, surface the warning and let the user decide per
-   item — before the user approves the drafted record; `imported`/`user`
-   blocks are never overwritten.
+   item. The user approves the drafted record before anything is projected
+   (Figma description, doc card, manifest); `imported`/`user` blocks are
+   never overwritten.
 2. **Project it.** Write `design-system/docs/components/<Name>.doc.json`, set the
    Figma component `description`, rebuild the doc card's `Usage` band with the
    canonical builder (`.throughline/references/doc-card-builder.md` —

--- a/adapters/codex/prompts/document-component.md
+++ b/adapters/codex/prompts/document-component.md
@@ -8,8 +8,13 @@ Ask which component to document (e.g. "Button"), then:
    the `component-builder` prompt's *Author the documentation record* step —
    ingest any existing docs first (brownfield), then infer → enrich (from
    `.throughline/references/component-doc-archetypes.md`) → specialize →
-   interview. The user approves the drafted record; `imported`/`user` blocks are
-   never overwritten.
+   interview. Authored prose follows
+   `.throughline/references/doc-writing-standard.md`. Once the record is
+   written, run `node .throughline/scripts/docs-lint.mjs
+   design-system/docs/components/<Name>.doc.json` and fix its warnings — for
+   `imported`/`user` blocks, surface the warning and let the user decide per
+   item — before the user approves the drafted record; `imported`/`user`
+   blocks are never overwritten.
 2. **Project it.** Write `design-system/docs/components/<Name>.doc.json`, set the
    Figma component `description`, rebuild the doc card's `Usage` band with the
    canonical builder (`.throughline/references/doc-card-builder.md` —
@@ -23,8 +28,8 @@ Ask which component to document (e.g. "Button"), then:
    missing, or its version is lower, `docs:check` is reading stale rules and its
    "no drift" is meaningless — say so plainly, and offer to refresh the repo's
    doc scripts from the plugin copy (`build-docs-digest.mjs`, `docs-check.mjs`,
-   `lib/doc-record.mjs`, `lib/doc-card-plan.mjs` — the same files
-   `storybook-chromatic-builder` installed at setup). Run `docs:check` (with the
+   `lib/doc-record.mjs`, `lib/doc-card-plan.mjs`, `docs-lint.mjs` — the same
+   files `storybook-chromatic-builder` installed at setup). Run `docs:check` (with the
    refreshed scripts, if any). For each drifted surface, offer a per-item
    choice — **re-render** (canonical wins) or **pull-back**
    (fold the surface edit into the record) — and land the result as a reviewable

--- a/adapters/codex/prompts/storybook-chromatic-builder.md
+++ b/adapters/codex/prompts/storybook-chromatic-builder.md
@@ -29,11 +29,12 @@ Storybook runs and shows the token-themed canvas.
 
 Install the documentation scripts alongside the token scripts (copy from the
 plugin's `scripts/` — `build-docs-digest.mjs`, `docs-check.mjs`,
-`lib/doc-record.mjs`, and `lib/doc-card-plan.mjs` — into the repo and register
-npm scripts):
+`lib/doc-record.mjs`, `lib/doc-card-plan.mjs`, and `docs-lint.mjs` — into the
+repo and register npm scripts):
 
 - `"docs:digest": "node scripts/build-docs-digest.mjs"`
 - `"docs:check": "node scripts/docs-check.mjs"`
+- `"docs:lint": "node scripts/docs-lint.mjs"`
 
 These are the documentation analog of `tokens:validate`; see
 `.throughline/scripts/README.md`. This copy is setup, not a forever-fork:

--- a/adapters/cursor/.cursor/commands/document-component.md
+++ b/adapters/cursor/.cursor/commands/document-component.md
@@ -8,8 +8,13 @@ Ask which component to document (e.g. "Button"), then:
    the `component-builder` rule's *Author the documentation record* step —
    ingest any existing docs first (brownfield), then infer → enrich (from
    `.throughline/references/component-doc-archetypes.md`) → specialize →
-   interview. The user approves the drafted record; `imported`/`user` blocks are
-   never overwritten.
+   interview. Authored prose follows
+   `.throughline/references/doc-writing-standard.md`. Once the record is
+   written, run `node .throughline/scripts/docs-lint.mjs
+   design-system/docs/components/<Name>.doc.json` and fix its warnings — for
+   `imported`/`user` blocks, surface the warning and let the user decide per
+   item — before the user approves the drafted record; `imported`/`user`
+   blocks are never overwritten.
 2. **Project it.** Write `design-system/docs/components/<Name>.doc.json`, set the
    Figma component `description`, rebuild the doc card's `Usage` band with the
    canonical builder (`.throughline/references/doc-card-builder.md` —
@@ -23,8 +28,8 @@ Ask which component to document (e.g. "Button"), then:
    missing, or its version is lower, `docs:check` is reading stale rules and its
    "no drift" is meaningless — say so plainly, and offer to refresh the repo's
    doc scripts from the plugin copy (`build-docs-digest.mjs`, `docs-check.mjs`,
-   `lib/doc-record.mjs`, `lib/doc-card-plan.mjs` — the same files
-   `storybook-chromatic-builder` installed at setup). Run `docs:check` (with the
+   `lib/doc-record.mjs`, `lib/doc-card-plan.mjs`, `docs-lint.mjs` — the same
+   files `storybook-chromatic-builder` installed at setup). Run `docs:check` (with the
    refreshed scripts, if any). For each drifted surface, offer a per-item
    choice — **re-render** (canonical wins) or **pull-back**
    (fold the surface edit into the record) — and land the result as a reviewable

--- a/adapters/cursor/.cursor/commands/document-component.md
+++ b/adapters/cursor/.cursor/commands/document-component.md
@@ -13,8 +13,9 @@ Ask which component to document (e.g. "Button"), then:
    written, run `node .throughline/scripts/docs-lint.mjs
    design-system/docs/components/<Name>.doc.json` and fix its warnings — for
    `imported`/`user` blocks, surface the warning and let the user decide per
-   item — before the user approves the drafted record; `imported`/`user`
-   blocks are never overwritten.
+   item. The user approves the drafted record before anything is projected
+   (Figma description, doc card, manifest); `imported`/`user` blocks are
+   never overwritten.
 2. **Project it.** Write `design-system/docs/components/<Name>.doc.json`, set the
    Figma component `description`, rebuild the doc card's `Usage` band with the
    canonical builder (`.throughline/references/doc-card-builder.md` —

--- a/adapters/cursor/.cursor/rules/component-builder.mdc
+++ b/adapters/cursor/.cursor/rules/component-builder.mdc
@@ -240,7 +240,9 @@ Read `.throughline/references/component-doc-schema.md` for the exact JSON
 schema, the fingerprint algorithm, and the projection contract.
 
 **Run the generation pipeline (each layer only fills what it legitimately knows;
-stamp `provenance` per block):**
+stamp `provenance` per block):** all authored prose follows
+`.throughline/references/doc-writing-standard.md` — its plain
+reference register, not this skill's guide voice.
 
 0. **Ingest existing docs — brownfield only, runs first.** If docs already exist
    for this component (code JSDoc/MDX/README, or a populated Figma component
@@ -259,9 +261,14 @@ stamp `provenance` per block):**
    accessibility idiom to the target framework (the same field you read for variant
    vocabulary). Provenance `framework`.
 4. **Interview for the non-inferable.** Ask the user for brand/product-specific
-   do's & don'ts and intent. Provenance `user`. **Show the whole drafted record and
-   get explicit approval before writing anything** — layers 1–4 only fill blocks the
-   ingest step did not, and an `imported`/`user` block is never overwritten.
+   do's & don'ts and intent. Provenance `user`. Write the draft to
+   `design-system/docs/components/<Name>.doc.json`, run
+   `node .throughline/scripts/docs-lint.mjs design-system/docs/components/<Name>.doc.json`,
+   and fix the warnings it raises — for `imported`/`user` blocks, surface the
+   warning to the user and let them decide per item, never silently rewrite.
+   **Show the whole drafted record and get explicit approval** — layers 1–4
+   only fill blocks the ingest step did not, and an `imported`/`user` block is
+   never overwritten.
 
 **Write the record and project it:**
 

--- a/adapters/cursor/.cursor/rules/component-builder.mdc
+++ b/adapters/cursor/.cursor/rules/component-builder.mdc
@@ -266,9 +266,10 @@ reference register, not this skill's guide voice.
    `node .throughline/scripts/docs-lint.mjs design-system/docs/components/<Name>.doc.json`,
    and fix the warnings it raises — for `imported`/`user` blocks, surface the
    warning to the user and let them decide per item, never silently rewrite.
-   **Show the whole drafted record and get explicit approval** — layers 1–4
-   only fill blocks the ingest step did not, and an `imported`/`user` block is
-   never overwritten.
+   **Show the whole drafted record and get explicit approval before
+   projecting it anywhere** (Figma description, doc card, manifest) — layers
+   1–4 only fill blocks the ingest step did not, and an `imported`/`user`
+   block is never overwritten.
 
 **Write the record and project it:**
 

--- a/adapters/cursor/.cursor/rules/storybook-chromatic-builder.mdc
+++ b/adapters/cursor/.cursor/rules/storybook-chromatic-builder.mdc
@@ -33,11 +33,12 @@ Storybook runs and shows the token-themed canvas.
 
 Install the documentation scripts alongside the token scripts (copy from the
 plugin's `scripts/` — `build-docs-digest.mjs`, `docs-check.mjs`,
-`lib/doc-record.mjs`, and `lib/doc-card-plan.mjs` — into the repo and register
-npm scripts):
+`lib/doc-record.mjs`, `lib/doc-card-plan.mjs`, and `docs-lint.mjs` — into the
+repo and register npm scripts):
 
 - `"docs:digest": "node scripts/build-docs-digest.mjs"`
 - `"docs:check": "node scripts/docs-check.mjs"`
+- `"docs:lint": "node scripts/docs-lint.mjs"`
 
 These are the documentation analog of `tokens:validate`; see
 `.throughline/scripts/README.md`. This copy is setup, not a forever-fork:

--- a/adapters/generic/commands/document-component.md
+++ b/adapters/generic/commands/document-component.md
@@ -13,8 +13,9 @@ Ask which component to document (e.g. "Button"), then:
    written, run `node .throughline/scripts/docs-lint.mjs
    design-system/docs/components/<Name>.doc.json` and fix its warnings — for
    `imported`/`user` blocks, surface the warning and let the user decide per
-   item — before the user approves the drafted record; `imported`/`user`
-   blocks are never overwritten.
+   item. The user approves the drafted record before anything is projected
+   (Figma description, doc card, manifest); `imported`/`user` blocks are
+   never overwritten.
 2. **Project it.** Write `design-system/docs/components/<Name>.doc.json`, set the
    Figma component `description`, rebuild the doc card's `Usage` band with the
    canonical builder (`.throughline/references/doc-card-builder.md` —

--- a/adapters/generic/commands/document-component.md
+++ b/adapters/generic/commands/document-component.md
@@ -8,8 +8,13 @@ Ask which component to document (e.g. "Button"), then:
    the `component-builder` skill's *Author the documentation record* step —
    ingest any existing docs first (brownfield), then infer → enrich (from
    `.throughline/references/component-doc-archetypes.md`) → specialize →
-   interview. The user approves the drafted record; `imported`/`user` blocks are
-   never overwritten.
+   interview. Authored prose follows
+   `.throughline/references/doc-writing-standard.md`. Once the record is
+   written, run `node .throughline/scripts/docs-lint.mjs
+   design-system/docs/components/<Name>.doc.json` and fix its warnings — for
+   `imported`/`user` blocks, surface the warning and let the user decide per
+   item — before the user approves the drafted record; `imported`/`user`
+   blocks are never overwritten.
 2. **Project it.** Write `design-system/docs/components/<Name>.doc.json`, set the
    Figma component `description`, rebuild the doc card's `Usage` band with the
    canonical builder (`.throughline/references/doc-card-builder.md` —
@@ -23,8 +28,8 @@ Ask which component to document (e.g. "Button"), then:
    missing, or its version is lower, `docs:check` is reading stale rules and its
    "no drift" is meaningless — say so plainly, and offer to refresh the repo's
    doc scripts from the plugin copy (`build-docs-digest.mjs`, `docs-check.mjs`,
-   `lib/doc-record.mjs`, `lib/doc-card-plan.mjs` — the same files
-   `storybook-chromatic-builder` installed at setup). Run `docs:check` (with the
+   `lib/doc-record.mjs`, `lib/doc-card-plan.mjs`, `docs-lint.mjs` — the same
+   files `storybook-chromatic-builder` installed at setup). Run `docs:check` (with the
    refreshed scripts, if any). For each drifted surface, offer a per-item
    choice — **re-render** (canonical wins) or **pull-back**
    (fold the surface edit into the record) — and land the result as a reviewable

--- a/adapters/generic/skills/component-builder/SKILL.md
+++ b/adapters/generic/skills/component-builder/SKILL.md
@@ -262,9 +262,10 @@ reference register, not this skill's guide voice.
    `node .throughline/scripts/docs-lint.mjs design-system/docs/components/<Name>.doc.json`,
    and fix the warnings it raises — for `imported`/`user` blocks, surface the
    warning to the user and let them decide per item, never silently rewrite.
-   **Show the whole drafted record and get explicit approval** — layers 1–4
-   only fill blocks the ingest step did not, and an `imported`/`user` block is
-   never overwritten.
+   **Show the whole drafted record and get explicit approval before
+   projecting it anywhere** (Figma description, doc card, manifest) — layers
+   1–4 only fill blocks the ingest step did not, and an `imported`/`user`
+   block is never overwritten.
 
 **Write the record and project it:**
 

--- a/adapters/generic/skills/component-builder/SKILL.md
+++ b/adapters/generic/skills/component-builder/SKILL.md
@@ -236,7 +236,9 @@ Read `.throughline/references/component-doc-schema.md` for the exact JSON
 schema, the fingerprint algorithm, and the projection contract.
 
 **Run the generation pipeline (each layer only fills what it legitimately knows;
-stamp `provenance` per block):**
+stamp `provenance` per block):** all authored prose follows
+`.throughline/references/doc-writing-standard.md` — its plain
+reference register, not this skill's guide voice.
 
 0. **Ingest existing docs — brownfield only, runs first.** If docs already exist
    for this component (code JSDoc/MDX/README, or a populated Figma component
@@ -255,9 +257,14 @@ stamp `provenance` per block):**
    accessibility idiom to the target framework (the same field you read for variant
    vocabulary). Provenance `framework`.
 4. **Interview for the non-inferable.** Ask the user for brand/product-specific
-   do's & don'ts and intent. Provenance `user`. **Show the whole drafted record and
-   get explicit approval before writing anything** — layers 1–4 only fill blocks the
-   ingest step did not, and an `imported`/`user` block is never overwritten.
+   do's & don'ts and intent. Provenance `user`. Write the draft to
+   `design-system/docs/components/<Name>.doc.json`, run
+   `node .throughline/scripts/docs-lint.mjs design-system/docs/components/<Name>.doc.json`,
+   and fix the warnings it raises — for `imported`/`user` blocks, surface the
+   warning to the user and let them decide per item, never silently rewrite.
+   **Show the whole drafted record and get explicit approval** — layers 1–4
+   only fill blocks the ingest step did not, and an `imported`/`user` block is
+   never overwritten.
 
 **Write the record and project it:**
 

--- a/adapters/generic/skills/storybook-chromatic-builder/SKILL.md
+++ b/adapters/generic/skills/storybook-chromatic-builder/SKILL.md
@@ -29,11 +29,12 @@ Storybook runs and shows the token-themed canvas.
 
 Install the documentation scripts alongside the token scripts (copy from the
 plugin's `scripts/` — `build-docs-digest.mjs`, `docs-check.mjs`,
-`lib/doc-record.mjs`, and `lib/doc-card-plan.mjs` — into the repo and register
-npm scripts):
+`lib/doc-record.mjs`, `lib/doc-card-plan.mjs`, and `docs-lint.mjs` — into the
+repo and register npm scripts):
 
 - `"docs:digest": "node scripts/build-docs-digest.mjs"`
 - `"docs:check": "node scripts/docs-check.mjs"`
+- `"docs:lint": "node scripts/docs-lint.mjs"`
 
 These are the documentation analog of `tokens:validate`; see
 `.throughline/scripts/README.md`. This copy is setup, not a forever-fork:

--- a/commands/document-component.md
+++ b/commands/document-component.md
@@ -12,8 +12,13 @@ Ask which component to document (e.g. "Button"), then:
    the `component-builder` skill's *Author the documentation record* step —
    ingest any existing docs first (brownfield), then infer → enrich (from
    `${CLAUDE_PLUGIN_ROOT}/references/component-doc-archetypes.md`) → specialize →
-   interview. The user approves the drafted record; `imported`/`user` blocks are
-   never overwritten.
+   interview. Authored prose follows
+   `${CLAUDE_PLUGIN_ROOT}/references/doc-writing-standard.md`. Once the record is
+   written, run `node ${CLAUDE_PLUGIN_ROOT}/scripts/docs-lint.mjs
+   design-system/docs/components/<Name>.doc.json` and fix its warnings — for
+   `imported`/`user` blocks, surface the warning and let the user decide per
+   item — before the user approves the drafted record; `imported`/`user`
+   blocks are never overwritten.
 2. **Project it.** Write `design-system/docs/components/<Name>.doc.json`, set the
    Figma component `description`, rebuild the doc card's `Usage` band with the
    canonical builder (`${CLAUDE_PLUGIN_ROOT}/references/doc-card-builder.md` —
@@ -27,8 +32,8 @@ Ask which component to document (e.g. "Button"), then:
    missing, or its version is lower, `docs:check` is reading stale rules and its
    "no drift" is meaningless — say so plainly, and offer to refresh the repo's
    doc scripts from the plugin copy (`build-docs-digest.mjs`, `docs-check.mjs`,
-   `lib/doc-record.mjs`, `lib/doc-card-plan.mjs` — the same files
-   `storybook-chromatic-builder` installed at setup). Run `docs:check` (with the
+   `lib/doc-record.mjs`, `lib/doc-card-plan.mjs`, `docs-lint.mjs` — the same
+   files `storybook-chromatic-builder` installed at setup). Run `docs:check` (with the
    refreshed scripts, if any). For each drifted surface, offer a per-item
    choice — **re-render** (canonical wins) or **pull-back**
    (fold the surface edit into the record) — and land the result as a reviewable

--- a/commands/document-component.md
+++ b/commands/document-component.md
@@ -17,8 +17,9 @@ Ask which component to document (e.g. "Button"), then:
    written, run `node ${CLAUDE_PLUGIN_ROOT}/scripts/docs-lint.mjs
    design-system/docs/components/<Name>.doc.json` and fix its warnings — for
    `imported`/`user` blocks, surface the warning and let the user decide per
-   item — before the user approves the drafted record; `imported`/`user`
-   blocks are never overwritten.
+   item. The user approves the drafted record before anything is projected
+   (Figma description, doc card, manifest); `imported`/`user` blocks are
+   never overwritten.
 2. **Project it.** Write `design-system/docs/components/<Name>.doc.json`, set the
    Figma component `description`, rebuild the doc card's `Usage` band with the
    canonical builder (`${CLAUDE_PLUGIN_ROOT}/references/doc-card-builder.md` —

--- a/docs/superpowers/plans/2026-08-11-doc-card-voice.md
+++ b/docs/superpowers/plans/2026-08-11-doc-card-voice.md
@@ -1,0 +1,505 @@
+# Doc-Card Voice (Plan 2 of 2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the documentation writing standard, the mechanical copy lint (`docs-lint.mjs`), the archetype compliance pass, and the authoring-pipeline wiring — plan 2 of `docs/superpowers/specs/2026-08-09-doc-card-layout-and-voice-design.md` (see its Phasing section; plan 1, the layout phase, is merged).
+
+**Architecture:** One new reference (`doc-writing-standard.md`) states the copy rules; one new zero-dependency script (`docs-lint.mjs`) mechanically checks the ten reliable rules, warnings-only; the archetype seeds are brought into compliance; and the authoring pipeline in `component-builder` / `/document-component` runs the lint on the drafted record **before** the user sees it. The lint is advisory by design — it never gates CI and always exits 0 on a parseable record.
+
+**Tech Stack:** Zero-dependency Node ESM (`node:test` + `node:assert/strict`, bare `node --test`); markdown references; generated adapters via `scripts/adapters/generate.mjs`.
+
+## Global Constraints
+
+- Zero runtime dependencies; scripts run on bare Node (`node:` builtins only).
+- Tests: `node:test` + `node:assert/strict`, files named `*.test.mjs` beside the script, run by `npm test`.
+- `docs-lint.mjs` output contract (spec, *The lint*): warnings only; **exit 0 for any parseable record regardless of findings**; one warning per line as `<file>: <block-path>: <rule>: <message>`; `--json` emits `{"warnings":[{"path","rule","message"}]}`. Exit `2` only for unusable invocation (missing arg, unreadable file, invalid JSON) — the repo's documented "bad CLI arguments" idiom (`scripts/README.md`).
+- The ten lint rules and their thresholds are **pinned by the spec table** (`docs/superpowers/specs/2026-08-09-doc-card-layout-and-voice-design.md`, *The lint*): machinery vocabulary; summary echo (> 60% of the **summary's** content words, stopwords removed, naive plural/verb-s stemming, found in `whenToUse[0]`); run-on sentence (> 35 words); summary length (> 12 words); description length (outside 15–70 words); guidance length (> 14 words); don't shape (must open *Don't / Do not / Never / Avoid*); terminal stop (dos/donts must end with `.`); treatment lead (treatment word in first 4 words of a variant/state meaning); empty meaning (< 3 words). Verb-presence is deliberately NOT linted.
+- Exempt fields (never linted): `tokensUsed`, `name`, `status`, `provenance`, `updatedAt`, `accessibility.role`.
+- **Register split** (spec, *The writing standard*): doc-record content uses plain reference register (Polaris/Carbon); skill/command conversational prose keeps `references/guide-voice.md`. Do not mix them.
+- **One set of strings** for humans and AI — no dual copy anywhere.
+- `adapters/**` are generated — edit sources, then `node scripts/adapters/generate.mjs`; CI gates with `--check`.
+- Every changed line traces to a task in this plan. Branch: `feat/doc-card-voice`.
+
+---
+
+### Task 1: `scripts/docs-lint.mjs` — the copy lint
+
+**Files:**
+- Create: `scripts/docs-lint.mjs`
+- Test: `scripts/docs-lint.test.mjs`
+
+**Interfaces:**
+- Consumes: nothing from other tasks. Reads a `.doc.json` record (schema: `references/component-doc-schema.md`).
+- Produces: CLI `node scripts/docs-lint.mjs <file> [--json]` and named export `lintRecord(record) → [{path, rule, message}]` (Task 4's prose references the CLI; tests import `lintRecord`).
+
+Before writing code, read `scripts/docs-check.mjs` for the repo's import-safe-CLI idiom (it both exports functions and runs as a CLI); use the same idiom for the entry guard.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `scripts/docs-lint.test.mjs`:
+
+```js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { lintRecord } from './docs-lint.mjs';
+
+const rules = (ws) => ws.map((w) => w.rule);
+const byRule = (ws, rule) => ws.filter((w) => w.rule === rule);
+
+test('machinery vocabulary flagged in prose, exempt fields ignored', () => {
+  const ws = lintRecord({
+    name: 'Button',
+    summary: 'Triggers an action.',
+    description: 'A clickable control that starts an action: saving a form, confirming a choice, opening a dialog. It binds every color, spacing, radius, and type value to the semantic tokens.',
+    tokensUsed: ['color.bg.primary'],
+  });
+  const hits = byRule(ws, 'machinery-vocabulary');
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].path, 'description');
+  // tokensUsed is exempt — its token names must not trip the rule
+  assert.ok(!hits.some((w) => w.path.startsWith('tokensUsed')));
+});
+
+test('summary echo: spec worked example yields 100% and warns', () => {
+  const ws = lintRecord({
+    name: 'Button',
+    summary: 'Triggers an action or event.',
+    description: 'A clickable control that starts an action: saving a form, confirming a choice, opening a dialog.',
+    whenToUse: ['Trigger an action or event — submit, confirm, open a dialog'],
+  });
+  const hits = byRule(ws, 'summary-echo');
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].path, 'whenToUse[0]');
+  assert.match(hits[0].message, /100%/);
+});
+
+test('summary echo: spec after-example does not warn', () => {
+  const ws = lintRecord({
+    name: 'Button',
+    summary: 'Triggers an action or event.',
+    description: 'A clickable control that starts an action: saving a form, confirming a choice, opening a dialog.',
+    whenToUse: ['Something happens on the current page — save, confirm, open a dialog'],
+  });
+  assert.equal(byRule(ws, 'summary-echo').length, 0);
+});
+
+test('run-on sentence over 35 words flagged', () => {
+  const long = 'This sentence keeps going and going with clause after clause after clause because nobody ever stopped it from growing far beyond what any patient reader can comfortably parse in one single breath which is exactly the failure mode';
+  const ws = lintRecord({ name: 'X', summary: 'Short.', description: long + '.' });
+  assert.equal(byRule(ws, 'run-on-sentence').length, 1);
+});
+
+test('summary length over 12 words flagged', () => {
+  const ws = lintRecord({
+    name: 'X',
+    summary: 'This summary uses far too many words to say a very simple thing indeed.',
+    description: 'A clickable control that starts an action: saving a form, confirming a choice, opening a dialog.',
+  });
+  assert.equal(byRule(ws, 'summary-length').length, 1);
+});
+
+test('description length outside 15–70 words flagged, inside passes', () => {
+  const short = lintRecord({ name: 'X', summary: 'Short.', description: 'Too short by far.' });
+  assert.equal(byRule(short, 'description-length').length, 1);
+  const ok = lintRecord({
+    name: 'X', summary: 'Short.',
+    description: 'A clickable control that starts an action: saving a form, confirming a choice, opening a dialog. Its six emphasis levels signal how important an action is.',
+  });
+  assert.equal(byRule(ok, 'description-length').length, 0);
+});
+
+test('guidance length, terminal stop, and dont shape on dos/donts', () => {
+  const ws = lintRecord({
+    name: 'X', summary: 'Short.',
+    description: 'A clickable control that starts an action: saving a form, confirming a choice, opening a dialog.',
+    dos: ['Lead with a verb'],                                     // no terminal stop
+    donts: ["Don't use a button for navigation — use a Link",      // no terminal stop
+            'Use a Link for navigation instead of this.'],          // wrong opener
+  });
+  assert.equal(byRule(ws, 'terminal-stop').length, 2);
+  const shape = byRule(ws, 'dont-shape');
+  assert.equal(shape.length, 1);
+  assert.equal(shape[0].path, 'donts[1]');
+});
+
+test('spec after-example guidance passes clean', () => {
+  const ws = lintRecord({
+    name: 'X', summary: 'Short.',
+    description: 'A clickable control that starts an action: saving a form, confirming a choice, opening a dialog.',
+    donts: ["Don't use a button to navigate. Use a Link."],
+  });
+  assert.equal(rules(ws).filter((r) => ['guidance-length', 'terminal-stop', 'dont-shape'].includes(r)).length, 0);
+});
+
+test('treatment lead flagged in first 4 words of a meaning; later mention passes', () => {
+  const ws = lintRecord({
+    name: 'X', summary: 'Short.',
+    description: 'A clickable control that starts an action: saving a form, confirming a choice, opening a dialog.',
+    variants: { type: {
+      primary: 'Highest-emphasis, solid brand fill — the one primary action in a view.',
+      secondary: 'A supporting action, rendered with a subtle border treatment.',
+    } },
+    states: { disabled: "Can't be clicked or tabbed to." },
+  });
+  const hits = byRule(ws, 'treatment-lead');
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].path, 'variants.type.primary');
+});
+
+test('empty meaning under 3 words flagged', () => {
+  const ws = lintRecord({
+    name: 'X', summary: 'Short.',
+    description: 'A clickable control that starts an action: saving a form, confirming a choice, opening a dialog.',
+    states: { hover: 'Pointer feedback.' },
+  });
+  const hits = byRule(ws, 'empty-meaning');
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].path, 'states.hover');
+});
+
+test('a record following the standard produces zero warnings', () => {
+  const ws = lintRecord({
+    name: 'Button',
+    summary: 'Triggers an action or event.',
+    description: 'A clickable control that starts an action: saving a form, confirming a choice, opening a dialog. Its six emphasis levels signal how important an action is.',
+    whenToUse: ['Something happens on the current page — save, confirm, open a dialog'],
+    whenNotToUse: ['Navigating to another page. Use a Link.'],
+    variants: { type: { primary: 'The one main action in a view.' } },
+    states: { disabled: "Can't be clicked or tabbed to." },
+    dos: ['Lead with a verb.'],
+    donts: ["Don't use a button to navigate. Use a Link."],
+    accessibility: {
+      role: 'button',
+      keyboard: ['Enter or Space activates the button.'],
+      notes: ['An icon-only button needs an `aria-label` so screen readers can announce it.'],
+    },
+    tokensUsed: ['color.bg.primary'],
+    status: 'stable',
+  });
+  assert.deepEqual(ws, []);
+});
+
+test('missing optional blocks lint without crashing', () => {
+  const ws = lintRecord({ name: 'X', summary: 'Short.', description: 'A clickable control that starts an action: saving a form, confirming a choice, opening a dialog.' });
+  assert.equal(rules(ws).length, 0);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `node --test scripts/docs-lint.test.mjs`
+Expected: FAIL — cannot find module `./docs-lint.mjs`.
+
+- [ ] **Step 3: Implement `scripts/docs-lint.mjs`**
+
+```js
+#!/usr/bin/env node
+// Copy lint for component doc records (.doc.json). Warnings only — findings
+// never affect the exit code; the lint shapes a draft before user approval
+// rather than gating CI. Rules: references/doc-writing-standard.md (pinned in
+// the design spec's lint table).
+//
+// Usage: node docs-lint.mjs <path/to/Component.doc.json> [--json]
+// Output: one warning per line — `<file>: <block-path>: <rule>: <message>`;
+// --json emits {"warnings":[{path, rule, message}]}.
+// Exit: 0 for any parseable record; 2 for unusable invocation.
+
+import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+// Machinery vocabulary banned from user-facing prose — the system's own
+// build-compliance language. Real names of things (aria-label, role, Enter)
+// are not banned; readers search for those.
+const MACHINERY = [
+  'token', 'tokens', 'variable', 'variables', 'binding', 'bindings',
+  'fingerprint', 'fingerprints', 'provenance', 'projection', 'projections',
+  'surface', 'surfaces',
+];
+
+// Visual-treatment words that must not LEAD a variant/state meaning.
+const TREATMENT = [
+  'fill', 'filled', 'solid', 'stroke', 'border', 'bordered', 'outline',
+  'shadow', 'opacity', 'elevation',
+];
+
+const STOPWORDS = new Set([
+  'a', 'an', 'the', 'and', 'or', 'but', 'of', 'to', 'in', 'on', 'for',
+  'with', 'as', 'at', 'by', 'is', 'are', 'was', 'were', 'be', 'been', 'it',
+  'its', 'this', 'that', 'these', 'those', 'you', 'your', 'not', 'no', 'do',
+  'does', 'did', 'has', 'have', 'had', 'can', 'could', 'should', 'would',
+  'will', 'may', 'might', 'must', 'when', 'how', 'what', 'which', 'who',
+  'while', 'than', 'then', 'so', 'if', 'into', 'onto', 'from', 'over',
+  'under', 'up', 'down', 'out', 'about',
+]);
+
+const words = (s) => String(s).toLowerCase().match(/[a-z0-9'’-]+/g) || [];
+// Naive plural/verb-s stemming: enough to match "Triggers" to "trigger".
+const stem = (w) => (w.length > 3 && w.endsWith('s') ? w.slice(0, -1) : w);
+
+export function lintRecord(record) {
+  const warnings = [];
+  const warn = (path, rule, message) => warnings.push({ path, rule, message });
+
+  // Every user-facing prose field, as [block-path, text].
+  const prose = [];
+  if (typeof record.summary === 'string') prose.push(['summary', record.summary]);
+  if (typeof record.description === 'string') prose.push(['description', record.description]);
+  for (const key of ['whenToUse', 'whenNotToUse', 'dos', 'donts']) {
+    (Array.isArray(record[key]) ? record[key] : []).forEach((t, i) => prose.push([`${key}[${i}]`, t]));
+  }
+  const meanings = [];
+  for (const axis of Object.keys(record.variants || {})) {
+    for (const [term, meaning] of Object.entries(record.variants[axis] || {})) {
+      meanings.push([`variants.${axis}.${term}`, meaning]);
+    }
+  }
+  for (const [term, meaning] of Object.entries(record.states || {})) {
+    meanings.push([`states.${term}`, meaning]);
+  }
+  prose.push(...meanings);
+  const a11y = record.accessibility || {};
+  (Array.isArray(a11y.keyboard) ? a11y.keyboard : []).forEach((t, i) => prose.push([`accessibility.keyboard[${i}]`, t]));
+  (Array.isArray(a11y.notes) ? a11y.notes : []).forEach((t, i) => prose.push([`accessibility.notes[${i}]`, t]));
+
+  for (const [path, text] of prose) {
+    const ws = words(text);
+    const banned = MACHINERY.find((b) => ws.includes(b));
+    if (banned) {
+      warn(path, 'machinery-vocabulary',
+        `"${banned}" is the system's machinery vocabulary — describe the thing and how to use it, never how it was made`);
+    }
+    for (const sentence of String(text).split(/[.!?]+/)) {
+      const n = words(sentence).length;
+      if (n > 35) warn(path, 'run-on-sentence', `sentence has ${n} words (max 35)`);
+    }
+  }
+
+  if (typeof record.summary === 'string') {
+    const n = words(record.summary).length;
+    if (n > 12) warn('summary', 'summary-length', `${n} words (max 12)`);
+  }
+
+  if (typeof record.description === 'string') {
+    const n = words(record.description).length;
+    if (n < 15 || n > 70) warn('description', 'description-length', `${n} words (want 15–70)`);
+  }
+
+  if (typeof record.summary === 'string' && Array.isArray(record.whenToUse)
+      && typeof record.whenToUse[0] === 'string') {
+    const summaryStems = [...new Set(
+      words(record.summary).filter((w) => !STOPWORDS.has(w)).map(stem),
+    )];
+    const targetStems = new Set(words(record.whenToUse[0]).map(stem));
+    if (summaryStems.length > 0) {
+      const matched = summaryStems.filter((s) => targetStems.has(s)).length;
+      const pct = matched / summaryStems.length;
+      if (pct > 0.6) {
+        warn('whenToUse[0]', 'summary-echo',
+          `${Math.round(pct * 100)}% of the summary's content words reappear — describe a situation, not the summary again`);
+      }
+    }
+  }
+
+  for (const key of ['dos', 'donts']) {
+    (Array.isArray(record[key]) ? record[key] : []).forEach((entry, i) => {
+      const path = `${key}[${i}]`;
+      const n = words(entry).length;
+      if (n > 14) warn(path, 'guidance-length', `${n} words (max 14)`);
+      if (!/\.$/.test(String(entry).trim())) {
+        warn(path, 'terminal-stop', 'end the entry with a full stop');
+      }
+      if (key === 'donts' && !/^(don['’]?t|do not|never|avoid)\b/i.test(String(entry).trim())) {
+        warn(path, 'dont-shape', "open with Don't / Never / Avoid and name the alternative");
+      }
+    });
+  }
+
+  for (const [path, meaning] of meanings) {
+    const ws = words(meaning);
+    if (ws.length < 3) {
+      warn(path, 'empty-meaning', `${ws.length} word(s) — say what it means, not just that it exists`);
+    }
+    if (ws.slice(0, 4).some((w) => TREATMENT.includes(w))) {
+      warn(path, 'treatment-lead', 'leads with visual treatment — lead with meaning; treatment is optional detail');
+    }
+  }
+
+  return warnings;
+}
+
+const invokedAsCli = process.argv[1]
+  && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedAsCli) {
+  const args = process.argv.slice(2);
+  const asJson = args.includes('--json');
+  const file = args.find((a) => !a.startsWith('--'));
+  if (!file) {
+    console.error('usage: docs-lint.mjs <path/to/Component.doc.json> [--json]');
+    process.exit(2);
+  }
+  let record;
+  try {
+    record = JSON.parse(readFileSync(file, 'utf8'));
+  } catch (e) {
+    console.error(`docs-lint: cannot read ${file}: ${e.message}`);
+    process.exit(2);
+  }
+  const warnings = lintRecord(record);
+  if (asJson) {
+    console.log(JSON.stringify({ warnings }, null, 2));
+  } else {
+    for (const w of warnings) console.log(`${file}: ${w.path}: ${w.rule}: ${w.message}`);
+  }
+  process.exit(0);
+}
+```
+
+If `scripts/docs-check.mjs` uses a different import-safe-CLI idiom than the `pathToFileURL` guard above, match its idiom instead — consistency wins.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test scripts/docs-lint.test.mjs`
+Expected: PASS, all tests.
+
+- [ ] **Step 5: CLI smoke check**
+
+Write a temp record with one violation to `/tmp` is not allowed — use the repo-ignored path `.superpowers/lint-smoke.doc.json` (or any git-ignored scratch location), run `node scripts/docs-lint.mjs <path>` and confirm: exit code 0, one `<file>: <path>: <rule>: <message>` line; then `--json` and confirm the `{warnings:[...]}` shape; then a missing path and confirm exit 2. Delete the scratch file.
+
+- [ ] **Step 6: Full suite**
+
+Run: `npm test`
+Expected: PASS (existing tests plus the new file).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/docs-lint.mjs scripts/docs-lint.test.mjs
+git commit -m "feat(docs): docs-lint — mechanical copy lint for doc records, warnings-only"
+```
+
+---
+
+### Task 2: `references/doc-writing-standard.md` — the copy rules
+
+**Files:**
+- Create: `references/doc-writing-standard.md`
+
+**Interfaces:**
+- Consumes: rule slugs from Task 1 (`machinery-vocabulary`, `summary-echo`, `run-on-sentence`, `summary-length`, `description-length`, `guidance-length`, `dont-shape`, `terminal-stop`, `treatment-lead`, `empty-meaning`) — the standard names them so warnings are traceable to rules.
+- Produces: the reference path `references/doc-writing-standard.md`, cited by Tasks 3 and 4.
+
+- [ ] **Step 1: Write the reference**
+
+Content requirements (all from the spec's *The writing standard* section — carry its before/after examples verbatim):
+
+1. **Title + scope line**: the writing standard for all doc-record content; applied by the authoring pipeline in `component-builder` and `/document-component`; projections (Figma description, doc card, Storybook MDX, AI digest) inherit it for free.
+2. **Governing rule**, verbatim: *describe the thing and how to use it, never how it was made.*
+3. **Register**: plain reference — neutral and declarative for descriptions, imperative for guidance (the Polaris/Carbon register). Explicitly: this is NOT the conversational guide voice of `references/guide-voice.md`, which remains the register for skill conversation.
+4. **Per-block rules** with the spec's before/after pairs (Button examples) for: `description` (2–3 sentences: what it is, what it's for, the one thing that most changes how you use it; never variant/size counts, token binding, or slot inventories); `whenToUse`/`whenNotToUse` (situations, never an echo of `summary`; `whenNotToUse` always names the alternative); `variants`/`states` (lead with meaning; visual treatment optional, never the whole entry); `dos`/`donts` (imperative, one action per entry, ≤ 14 words, full stop; don'ts open with *Don't / Never / Avoid* and name the alternative); `accessibility.notes` (what the reader must do, not what the framework emits — include the spec's "Cut" example).
+5. **The vocabulary line**, verbatim from the spec: real names of things stay (`aria-label`, `role`, `Enter`, `Space`); banned from user-facing prose is the system's machinery vocabulary — tokens, variables, bindings, fingerprints, provenance, projections, surfaces (machinery sense). `tokensUsed` keeps token names — structured, machine-useful, never rendered as prose.
+6. **Global rules**: full sentences (no em-dash label-fragments); one set of strings for humans and AI — no dual copy; the digest inherits the same text.
+7. **The lint section**: `scripts/docs-lint.mjs` checks the mechanically reliable subset — list the ten rule slugs with one-line summaries and the thresholds; note the output contract (warnings only, exit 0, `--json`); note what is deliberately not linted (verb-presence) and why (an unreliable rule is worse than no rule — it stays a prose rule caught at the user-approval gate).
+8. **Sequencing**: draft record → write file → `node ${CLAUDE_PLUGIN_ROOT}/scripts/docs-lint.mjs <file>` → fix warnings → show the user. The lint shapes the draft before approval, it does not nag afterward. `imported`/`user` provenance blocks: the lint still warns, the user decides per item — never silently rewritten.
+
+Match the register and formatting of existing references (e.g. `references/component-doc-schema.md`): terse headings, tables where enumerable, no marketing prose.
+
+- [ ] **Step 2: Verify internal consistency**
+
+Check every rule slug named in the reference exactly matches a `rule` string in `scripts/docs-lint.mjs` (grep both files side by side). Check the before-examples in the reference are the ones the lint's tests assert on.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add references/doc-writing-standard.md
+git commit -m "docs: doc-writing-standard — the copy rules for doc-record content"
+```
+
+---
+
+### Task 3: Archetype compliance pass
+
+**Files:**
+- Modify: `references/component-doc-archetypes.md` (86 lines; archetypes: Button, Input/text field, Checkbox/radio/toggle, Card, Modal/dialog, Badge/chip/tag, Fallback)
+
+**Interfaces:**
+- Consumes: `references/doc-writing-standard.md` (Task 2) — read it first; it is the rubric.
+- Produces: seeds that pass the standard, so records grown from them start clean.
+
+- [ ] **Step 1: Audit every seed entry against the standard**
+
+For each archetype's seeded `dos`, `donts`, `accessibility`, `whenToUse`, `whenNotToUse` entries apply, by hand, the mechanical rules (they cannot be run by the lint — this file is not a `.doc.json`): guidance ≤ 14 words with terminal stop; don'ts open *Don't / Never / Avoid* and name the alternative; no machinery vocabulary; no treatment-leads; no framework-emission trivia in accessibility (the spec singles out accessibility entries as carrying the most jargon — e.g. any "renders a native element, so the role is implicit" style note gets cut or rewritten as what the reader must do). This is a **light** pass: rewrite non-compliant entries in place, do not restructure the file, do not add new archetypes, do not change compliant entries.
+
+- [ ] **Step 2: Self-check**
+
+Re-read the diff. Every changed line must be a compliance fix traceable to a named rule in the standard; revert any drive-by wording change that isn't.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add references/component-doc-archetypes.md
+git commit -m "docs: archetype seeds comply with the doc-writing standard"
+```
+
+---
+
+### Task 4: Pipeline wiring, install path, and changelog
+
+**Files:**
+- Modify: `skills/component-builder/SKILL.md` (the *Author the documentation record* step, layers 0–4 around lines 246–265, and the "Write the record and project it" block around 267–285)
+- Modify: `commands/document-component.md` (step 1 authoring flow ~lines 11–15; the freshness-gate file list ~lines 29–31)
+- Modify: `skills/storybook-chromatic-builder/SKILL.md` (script copy list + npm script registration, lines 35–44)
+- Modify: `scripts/README.md` (script table)
+- Modify: `CHANGELOG.md` (`[Unreleased]` section — create it if absent; never touch released headings)
+- Regenerate: `adapters/**` via `node scripts/adapters/generate.mjs`
+
+**Interfaces:**
+- Consumes: Task 1's CLI (`node ${CLAUDE_PLUGIN_ROOT}/scripts/docs-lint.mjs <file>`; installed name `docs:lint`), Task 2's reference path.
+- Produces: nothing downstream; this is the leaf task.
+
+- [ ] **Step 1: Wire `component-builder`**
+
+In the authoring-pipeline step: add one sentence establishing that all authored prose follows `${CLAUDE_PLUGIN_ROOT}/references/doc-writing-standard.md` (plain reference register — not the guide voice). After the record is written to disk and **before** the user-approval gate (the bold "Show the whole drafted record and get explicit approval" sentence), insert the lint sequencing from the spec: run `node ${CLAUDE_PLUGIN_ROOT}/scripts/docs-lint.mjs design-system/docs/components/<Name>.doc.json`, fix the warnings it raises (for `imported`/`user` blocks: surface the warning to the user and let them decide per item — never silently rewrite), then show the draft. Keep the surrounding guide voice; keep edits minimal — this is two surgical insertions, not a rewrite of the step.
+
+- [ ] **Step 2: Wire `/document-component`**
+
+Same two insertions in `commands/document-component.md` step 1 (it delegates to the component-builder pipeline — reference the standard and the lint-before-approval sequencing there too, one sentence each). Then extend the freshness-gate refresh list (~line 30) so `docs-lint.mjs` is among the files refreshed from the plugin (`build-docs-digest.mjs`, `docs-check.mjs`, `lib/doc-record.mjs`, `lib/doc-card-plan.mjs`, **`docs-lint.mjs`**).
+
+- [ ] **Step 3: Wire the install path**
+
+In `skills/storybook-chromatic-builder/SKILL.md` lines 35–41: add `docs-lint.mjs` to the copied-scripts list and register the npm script `"docs:lint": "node scripts/docs-lint.mjs"` beside `docs:digest`/`docs:check`. (Plan-1 lesson: this copy list is the ONLY install path into native repos — a script missing here does not exist downstream.)
+
+- [ ] **Step 4: `scripts/README.md` row**
+
+Add to the script table:
+`| docs-lint.mjs | Copy lint for .doc.json records — warnings only, always exit 0 on a parseable record; the mechanical subset of references/doc-writing-standard.md. | docs:lint |`
+(Adjust cell wording to match the table's voice; keep the three-column shape.)
+
+- [ ] **Step 5: Changelog**
+
+Add an `[Unreleased]` section (the previous one was consumed by the 0.15 merge — check first) with entries for: the doc-writing standard, `docs-lint.mjs` (+ `docs:lint` install), the archetype compliance pass, and the authoring-pipeline lint gate.
+
+- [ ] **Step 6: Regenerate adapters and run every gate**
+
+```bash
+node scripts/adapters/generate.mjs
+node scripts/adapters/generate.mjs --check
+node scripts/build-doc-card-builder.mjs --check
+npm test
+```
+Expected: all green; the adapter regen picks up the `document-component` and `storybook-chromatic-builder` changes.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add skills/component-builder/SKILL.md commands/document-component.md skills/storybook-chromatic-builder/SKILL.md scripts/README.md CHANGELOG.md adapters
+git commit -m "feat(docs): wire the writing standard and docs-lint into the authoring pipeline"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** writing standard → Task 2; lint (rules table, output contract, sequencing, `docs:lint` install) → Tasks 1 + 4; archetype pass → Task 3; pipeline wiring (`component-builder`, `/document-component`) → Task 4; free-win projections need no task (they render record strings). The spec's dogfood success criterion (#6) is the acceptance test AFTER this plan, run from `throughline-sample` — not a task here.
+- **Not in scope:** verb-presence linting (spec-rejected); CI gating on lint (spec-rejected); balanced columns (spec-rejected); token-sheet/icon cards.
+- **Type consistency:** rule slugs appear in three places — `docs-lint.mjs`, its tests, and `doc-writing-standard.md`; Task 2 Step 2 checks the match explicitly.
+- **Ambiguity resolved here:** "always exits 0" (spec) is scoped to parseable records; unusable invocation exits 2 per the repo's documented CLI idiom. "Don't / Never / Avoid" accepts "Do not" as the expanded form of *Don't*.

--- a/references/component-doc-archetypes.md
+++ b/references/component-doc-archetypes.md
@@ -19,7 +19,7 @@ keyboard), Material 3, Shopify Polaris (content/usage), IBM Carbon (usage).
 - **dos:** lead the label with a verb; keep one primary (highest-emphasis) button
   per view; keep labels short (≤ ~3 words).
 - **donts:** don't use a button for navigation (use a Link); don't stack multiple
-  primary buttons; don't disable without telling the user why.
+  primary buttons (keep one per view); don't disable without telling the user why.
 - **accessibility (w3c-apg):** role `button`; Enter and Space activate; an
   icon-only button needs an `aria-label`; disabled buttons are not focusable.
 
@@ -43,7 +43,7 @@ keyboard), Material 3, Shopify Polaris (content/usage), IBM Carbon (usage).
   save (prefer a toggle) vs. a form choice (prefer radio/checkbox).
 - **dos:** label the control, not just the group; make the label clickable.
 - **donts:** don't use a radio group for multi-select (use checkboxes); don't use
-  a toggle for choices that only apply after a separate Save.
+  a toggle for choices needing a separate Save (use radio/checkbox).
 - **accessibility (w3c-apg):** roles `checkbox` / `radio` / `switch`; Space
   toggles; radio groups navigate with arrow keys; state exposed via
   `aria-checked`.

--- a/references/component-doc-archetypes.md
+++ b/references/component-doc-archetypes.md
@@ -12,6 +12,8 @@ These are **seeds, not gospel** — the user's approval and the actual built
 component override them. Sources: W3C ARIA Authoring Practices Guide (roles +
 keyboard), Material 3, Shopify Polaris (content/usage), IBM Carbon (usage).
 
+Seeds are clause-style shorthand; the authoring pipeline expands them into full sentences per references/doc-writing-standard.md before they enter a record.
+
 ## Button
 
 - **whenToUse:** trigger an action or event (submit, confirm, open a dialog).
@@ -72,7 +74,7 @@ keyboard), Material 3, Shopify Polaris (content/usage), IBM Carbon (usage).
 ## Badge / chip / tag
 
 - **whenToUse:** short status, count, or category label (badge); a removable/
-  selectable token (chip).
+  selectable item (chip).
 - **whenNotToUse:** interactive primary actions (use a Button).
 - **dos:** keep text to a word or two; match badge color to its semantic meaning
   (success, warning, error).

--- a/references/component-doc-archetypes.md
+++ b/references/component-doc-archetypes.md
@@ -15,11 +15,11 @@ keyboard), Material 3, Shopify Polaris (content/usage), IBM Carbon (usage).
 ## Button
 
 - **whenToUse:** trigger an action or event (submit, confirm, open a dialog).
-- **whenNotToUse:** navigation between pages/URLs — use a Link.
+- **whenNotToUse:** navigation between pages/URLs (use a Link).
 - **dos:** lead the label with a verb; keep one primary (highest-emphasis) button
   per view; keep labels short (≤ ~3 words).
-- **donts:** don't use a button for navigation; don't stack multiple primary
-  buttons; don't disable without telling the user why.
+- **donts:** don't use a button for navigation (use a Link); don't stack multiple
+  primary buttons; don't disable without telling the user why.
 - **accessibility (w3c-apg):** role `button`; Enter and Space activate; an
   icon-only button needs an `aria-label`; disabled buttons are not focusable.
 
@@ -30,8 +30,8 @@ keyboard), Material 3, Shopify Polaris (content/usage), IBM Carbon (usage).
   text (use Textarea).
 - **dos:** always pair with a visible label; show format hints as helper text;
   reserve space for error text to avoid layout shift.
-- **donts:** don't use placeholder text as the only label; don't validate on every
-  keystroke before first blur.
+- **donts:** don't use placeholder text as the only label (pair with a visible
+  label); don't validate on every keystroke before first blur.
 - **accessibility (w3c-apg):** every input has a programmatically associated
   `<label>`; error state sets `aria-invalid` and links the message via
   `aria-describedby`.
@@ -42,8 +42,8 @@ keyboard), Material 3, Shopify Polaris (content/usage), IBM Carbon (usage).
 - **whenNotToUse:** a single either/or action that takes effect immediately with no
   save (prefer a toggle) vs. a form choice (prefer radio/checkbox).
 - **dos:** label the control, not just the group; make the label clickable.
-- **donts:** don't use a radio group for multi-select; don't use a toggle for
-  choices that only apply after a separate Save.
+- **donts:** don't use a radio group for multi-select (use checkboxes); don't use
+  a toggle for choices that only apply after a separate Save.
 - **accessibility (w3c-apg):** roles `checkbox` / `radio` / `switch`; Space
   toggles; radio groups navigate with arrow keys; state exposed via
   `aria-checked`.
@@ -51,7 +51,8 @@ keyboard), Material 3, Shopify Polaris (content/usage), IBM Carbon (usage).
 ## Card
 
 - **whenToUse:** group related content and actions about a single subject.
-- **whenNotToUse:** primary page layout scaffolding; a bare list of text.
+- **whenNotToUse:** primary page layout scaffolding (use a layout/grid component); a
+  bare list of text (use a List).
 - **dos:** make the primary action obvious; keep one main call-to-action per card.
 - **donts:** don't nest cards more than one level; don't make the whole card AND an
   inner button separately clickable in conflicting ways.
@@ -73,8 +74,9 @@ keyboard), Material 3, Shopify Polaris (content/usage), IBM Carbon (usage).
 - **whenToUse:** short status, count, or category label (badge); a removable/
   selectable token (chip).
 - **whenNotToUse:** interactive primary actions (use a Button).
-- **dos:** keep text to a word or two; bind color to a semantic tone token.
-- **donts:** don't rely on color alone to convey status — include text/icon.
+- **dos:** keep text to a word or two; match badge color to its semantic meaning
+  (success, warning, error).
+- **donts:** don't rely on color alone to convey status (include text or an icon).
 - **accessibility:** a removable chip's remove control needs an accessible name
   (e.g. "Remove <label>"); status conveyed with text, not color only (WCAG 1.4.1).
 

--- a/references/doc-writing-standard.md
+++ b/references/doc-writing-standard.md
@@ -80,15 +80,12 @@ What the reader must do, not what the framework emits.
 
 ## Vocabulary
 
-Real names of things stay — `aria-label`, `role`, `Enter`, `Space` are what a
-reader would search for.
-
-Banned from user-facing prose: the system's own machinery vocabulary —
-*token(s)*, *variable(s)*, *binding(s)*, *fingerprint(s)*, *provenance*,
-*projection(s)*, *surface(s)* (machinery sense).
-
-`tokensUsed` keeps its token names — it is a structured field, machine-useful,
-never rendered as prose.
+Technical terms that are the real names of things stay — `aria-label`, `role`,
+`Enter`, `Space` are what a reader would search for. What is banned from
+user-facing prose is the system's own machinery vocabulary: tokens,
+variables, bindings, fingerprints, provenance, projections, surfaces (in the
+machinery sense). `tokensUsed` keeps its token names — it is a structured
+field, machine-useful, and never rendered as prose.
 
 ## Global rules
 

--- a/references/doc-writing-standard.md
+++ b/references/doc-writing-standard.md
@@ -1,0 +1,137 @@
+# Doc-writing standard
+
+The writing standard for all doc-record (`.doc.json`) content. Applied by the
+authoring pipeline in `component-builder` and `/document-component`. Every
+projection — Figma component description, doc card, Storybook MDX, AI digest —
+inherits this text unchanged; none of them are written separately.
+
+**Governing rule: describe the thing and how to use it, never how it was
+made.**
+
+## Register
+
+Plain reference: neutral and declarative for descriptions, imperative for
+guidance — the register Polaris and Carbon use.
+
+This is **not** the conversational guide voice of `references/guide-voice.md`.
+Guide voice is for skill conversation — a guide talking to the person building
+the system. This standard is for doc-record content — what gets written about
+the component itself, read by whoever uses it later. Different audience,
+different register; do not blend them.
+
+## Per-block rules
+
+Before/after pairs are the real Button record
+(`throughline-sample/design-system/docs/components/Button.doc.json`).
+
+### `description`
+
+2–3 sentences: what it is, what it's for, and the one thing that most changes
+how you use it. Never variant/size counts (the specimen and legend already show
+them), never token binding, never a slot inventory.
+
+> **Before:** "A clickable control that triggers an action — submitting a
+> form, confirming a decision, or opening a dialog. It comes in six emphasis
+> variants across three sizes, supports optional leading and trailing icons
+> and a loading state, and binds every color, spacing, radius, and type value
+> to the system's semantic tokens."
+>
+> **After:** "A clickable control that starts an action: saving a form,
+> confirming a choice, opening a dialog. Its six emphasis levels signal how
+> important an action is."
+
+### `whenToUse` / `whenNotToUse`
+
+Situations, never an echo of `summary`. `whenNotToUse` always names the
+alternative.
+
+> **Before:** summary "Triggers an action or event." → whenToUse[0] "Trigger
+> an action or event — submit, confirm, open a dialog"
+>
+> **After:** "Something happens on the current page — save, confirm, open a
+> dialog"
+
+### `variants` / `states`
+
+Lead with meaning; visual treatment is optional and never the whole entry.
+
+> **Before:** "Highest-emphasis, solid brand fill — the one primary action in
+> a view." → **After:** "The one main action in a view."
+>
+> **Before:** "Non-interactive and not focusable; reduced opacity." →
+> **After:** "Can't be clicked or tabbed to."
+
+### `dos` / `donts`
+
+Imperative, one action per entry, ≤ 14 words, full stop. Don'ts open with
+*Don't / Never / Avoid* and name the alternative.
+
+> **Before:** "Don't use a button for navigation — use a Link" →
+> **After:** "Don't use a button to navigate. Use a Link."
+
+### `accessibility.notes`
+
+What the reader must do, not what the framework emits.
+
+> **Cut:** "Renders a native `<button>`, so `role=\"button\"` is implicit."
+>
+> **Before:** "An icon-only button needs an aria-label" → **After:** "An
+> icon-only button needs an `aria-label` so screen readers can announce it."
+
+## Vocabulary
+
+Real names of things stay — `aria-label`, `role`, `Enter`, `Space` are what a
+reader would search for.
+
+Banned from user-facing prose: the system's own machinery vocabulary —
+*token(s)*, *variable(s)*, *binding(s)*, *fingerprint(s)*, *provenance*,
+*projection(s)*, *surface(s)* (machinery sense).
+
+`tokensUsed` keeps its token names — it is a structured field, machine-useful,
+never rendered as prose.
+
+## Global rules
+
+- Full sentences. No em-dash label-fragments bolting a clause onto a fragment.
+- One set of strings for humans and AI — no dual copy. The digest (`llms.txt`
+  / `index.json`) inherits the same text.
+
+## The lint — `scripts/docs-lint.mjs`
+
+Checks the mechanically reliable subset of this standard. Zero-dependency,
+**warnings only, always exits 0**.
+
+| Rule | Checks | Threshold |
+|---|---|---|
+| `machinery-vocabulary` | banned-word list in user-facing prose (all prose fields; `tokensUsed`, `name`, `status`, `provenance` exempt) | — |
+| `summary-echo` | `whenToUse[0]` reusing the summary's content words (stopwords removed, naive plural/verb-s stemming) | > 60% overlap |
+| `run-on-sentence` | sentence length | > 35 words |
+| `summary-length` | `summary` length | > 12 words |
+| `description-length` | `description` length | outside 15–70 words |
+| `guidance-length` | `dos` / `donts` entry length | > 14 words |
+| `dont-shape` | a `donts` entry not opening with *Don't / Never / Avoid* | — |
+| `terminal-stop` | a `dos` / `donts` entry not ending with a full stop | — |
+| `treatment-lead` | a variant/state meaning opening with a visual-treatment word ({fill, filled, solid, stroke, border, bordered, outline, shadow, opacity, elevation}) | first 4 words |
+| `empty-meaning` | a variant or state meaning that's too short to say anything | < 3 words |
+
+**Output contract:** always exits 0; one warning per line as
+`<file>: <block-path>: <rule>: <message>`; `--json` emits
+`{"warnings": [{path, rule, message}]}`.
+
+**Deliberately not linted: verb-presence.** Not reliably detectable in plain
+JS without an NLP dependency, and a rule that fires wrongly is worse than no
+rule. It stays a prose rule, caught by the authoring pipeline and the user
+approval step.
+
+## Sequencing
+
+1. Draft the record.
+2. Write the file to disk.
+3. `node ${CLAUDE_PLUGIN_ROOT}/scripts/docs-lint.mjs <file>`
+4. Fix warnings.
+5. Show the user.
+
+The lint shapes the draft before approval — it does not nag afterward.
+
+`imported` / `user` provenance blocks are never silently rewritten. The lint
+still warns on them; the user decides per item.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,6 +14,7 @@ tested here; copied verbatim by `token-crosswalk-builder` into the user's
 | `crosswalk.schema.json` | The finalized JSON Schema for `crosswalk.json` (contract + editor support). | copied beside `crosswalk.json` |
 | `build-docs-digest.mjs` | Aggregate every `design-system/docs/components/*.doc.json` into `design-system/docs/index.json` + `llms.txt` for AI/human consumers. | `docs:digest` |
 | `docs-check.mjs` | Drift gate — verifies each component's doc surfaces still match its canonical record (via `lib/doc-record.mjs` fingerprints). Exits 1 on drift. | `docs:check` |
+| `docs-lint.mjs` | Copy lint for .doc.json records — warnings only, always exit 0 on a parseable record; the mechanical subset of `references/doc-writing-standard.md`. | `docs:lint` |
 | `lib/doc-card-plan.mjs` | Pure layout planner for the doc card's `Usage` band + `DOC_CARD_RENDERER_VERSION` (single source of the layout version). Inlined into `references/doc-card-builder.md`; imported by `docs-check.mjs`. | copied alongside docs-check.mjs; also inlined into the generated builder |
 | `build-doc-card-builder.mjs` | Generate `references/doc-card-builder.md` from the planner + the Figma renderer template (`lib/doc-card-render.figma.js`). `--check` gates CI. | plugin-internal (not installed) |
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,7 +14,7 @@ tested here; copied verbatim by `token-crosswalk-builder` into the user's
 | `crosswalk.schema.json` | The finalized JSON Schema for `crosswalk.json` (contract + editor support). | copied beside `crosswalk.json` |
 | `build-docs-digest.mjs` | Aggregate every `design-system/docs/components/*.doc.json` into `design-system/docs/index.json` + `llms.txt` for AI/human consumers. | `docs:digest` |
 | `docs-check.mjs` | Drift gate — verifies each component's doc surfaces still match its canonical record (via `lib/doc-record.mjs` fingerprints). Exits 1 on drift. | `docs:check` |
-| `docs-lint.mjs` | Copy lint for .doc.json records — warnings only, always exit 0 on a parseable record; the mechanical subset of `references/doc-writing-standard.md`. | `docs:lint` |
+| `docs-lint.mjs` | Copy lint for .doc.json records — warnings only, always exits 0 on a parseable record; the mechanical subset of `references/doc-writing-standard.md`. | `docs:lint` |
 | `lib/doc-card-plan.mjs` | Pure layout planner for the doc card's `Usage` band + `DOC_CARD_RENDERER_VERSION` (single source of the layout version). Inlined into `references/doc-card-builder.md`; imported by `docs-check.mjs`. | copied alongside docs-check.mjs; also inlined into the generated builder |
 | `build-doc-card-builder.mjs` | Generate `references/doc-card-builder.md` from the planner + the Figma renderer template (`lib/doc-card-render.figma.js`). `--check` gates CI. | plugin-internal (not installed) |
 

--- a/scripts/docs-lint.mjs
+++ b/scripts/docs-lint.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+// Copy lint for component doc records (.doc.json). Warnings only — findings
+// never affect the exit code; the lint shapes a draft before user approval
+// rather than gating CI. Rules: references/doc-writing-standard.md (pinned in
+// the design spec's lint table).
+//
+// Usage: node docs-lint.mjs <path/to/Component.doc.json> [--json]
+// Output: one warning per line — `<file>: <block-path>: <rule>: <message>`;
+// --json emits {"warnings":[{path, rule, message}]}.
+// Exit: 0 for any parseable record; 2 for unusable invocation.
+
+import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+// Machinery vocabulary banned from user-facing prose — the system's own
+// build-compliance language. Real names of things (aria-label, role, Enter)
+// are not banned; readers search for those.
+const MACHINERY = [
+  'token', 'tokens', 'variable', 'variables', 'binding', 'bindings',
+  'fingerprint', 'fingerprints', 'provenance', 'projection', 'projections',
+  'surface', 'surfaces',
+];
+
+// Visual-treatment words that must not LEAD a variant/state meaning.
+const TREATMENT = [
+  'fill', 'filled', 'solid', 'stroke', 'border', 'bordered', 'outline',
+  'shadow', 'opacity', 'elevation',
+];
+
+const STOPWORDS = new Set([
+  'a', 'an', 'the', 'and', 'or', 'but', 'of', 'to', 'in', 'on', 'for',
+  'with', 'as', 'at', 'by', 'is', 'are', 'was', 'were', 'be', 'been', 'it',
+  'its', 'this', 'that', 'these', 'those', 'you', 'your', 'not', 'no', 'do',
+  'does', 'did', 'has', 'have', 'had', 'can', 'could', 'should', 'would',
+  'will', 'may', 'might', 'must', 'when', 'how', 'what', 'which', 'who',
+  'while', 'than', 'then', 'so', 'if', 'into', 'onto', 'from', 'over',
+  'under', 'up', 'down', 'out', 'about',
+]);
+
+const words = (s) => String(s).toLowerCase().match(/[a-z0-9''-]+/g) || [];
+// Naive plural/verb-s stemming: enough to match "Triggers" to "trigger".
+const stem = (w) => (w.length > 3 && w.endsWith('s') ? w.slice(0, -1) : w);
+
+export function lintRecord(record) {
+  const warnings = [];
+  const warn = (path, rule, message) => warnings.push({ path, rule, message });
+
+  // Every user-facing prose field, as [block-path, text].
+  const prose = [];
+  if (typeof record.summary === 'string') prose.push(['summary', record.summary]);
+  if (typeof record.description === 'string') prose.push(['description', record.description]);
+  for (const key of ['whenToUse', 'whenNotToUse', 'dos', 'donts']) {
+    (Array.isArray(record[key]) ? record[key] : []).forEach((t, i) => prose.push([`${key}[${i}]`, t]));
+  }
+  const meanings = [];
+  for (const axis of Object.keys(record.variants || {})) {
+    for (const [term, meaning] of Object.entries(record.variants[axis] || {})) {
+      meanings.push([`variants.${axis}.${term}`, meaning]);
+    }
+  }
+  for (const [term, meaning] of Object.entries(record.states || {})) {
+    meanings.push([`states.${term}`, meaning]);
+  }
+  prose.push(...meanings);
+  const a11y = record.accessibility || {};
+  (Array.isArray(a11y.keyboard) ? a11y.keyboard : []).forEach((t, i) => prose.push([`accessibility.keyboard[${i}]`, t]));
+  (Array.isArray(a11y.notes) ? a11y.notes : []).forEach((t, i) => prose.push([`accessibility.notes[${i}]`, t]));
+
+  for (const [path, text] of prose) {
+    const ws = words(text);
+    const banned = MACHINERY.find((b) => ws.includes(b));
+    if (banned) {
+      warn(path, 'machinery-vocabulary',
+        `"${banned}" is the system's machinery vocabulary — describe the thing and how to use it, never how it was made`);
+    }
+    for (const sentence of String(text).split(/[.!?]+/)) {
+      const n = words(sentence).length;
+      if (n > 35) warn(path, 'run-on-sentence', `sentence has ${n} words (max 35)`);
+    }
+  }
+
+  if (typeof record.summary === 'string') {
+    const n = words(record.summary).length;
+    if (n > 12) warn('summary', 'summary-length', `${n} words (max 12)`);
+  }
+
+  if (typeof record.description === 'string') {
+    const n = words(record.description).length;
+    if (n < 15 || n > 70) warn('description', 'description-length', `${n} words (want 15–70)`);
+  }
+
+  if (typeof record.summary === 'string' && Array.isArray(record.whenToUse)
+      && typeof record.whenToUse[0] === 'string') {
+    const summaryStems = [...new Set(
+      words(record.summary).filter((w) => !STOPWORDS.has(w)).map(stem),
+    )];
+    const targetStems = new Set(words(record.whenToUse[0]).map(stem));
+    if (summaryStems.length > 0) {
+      const matched = summaryStems.filter((s) => targetStems.has(s)).length;
+      const pct = matched / summaryStems.length;
+      if (pct > 0.6) {
+        warn('whenToUse[0]', 'summary-echo',
+          `${Math.round(pct * 100)}% of the summary's content words reappear — describe a situation, not the summary again`);
+      }
+    }
+  }
+
+  for (const key of ['dos', 'donts']) {
+    (Array.isArray(record[key]) ? record[key] : []).forEach((entry, i) => {
+      const path = `${key}[${i}]`;
+      const n = words(entry).length;
+      if (n > 14) warn(path, 'guidance-length', `${n} words (max 14)`);
+      if (!/\.$/.test(String(entry).trim())) {
+        warn(path, 'terminal-stop', 'end the entry with a full stop');
+      }
+      if (key === 'donts' && !/^(don['']?t|do not|never|avoid)\b/i.test(String(entry).trim())) {
+        warn(path, 'dont-shape', "open with Don't / Never / Avoid and name the alternative");
+      }
+    });
+  }
+
+  for (const [path, meaning] of meanings) {
+    const ws = words(meaning);
+    if (ws.length < 3) {
+      warn(path, 'empty-meaning', `${ws.length} word(s) — say what it means, not just that it exists`);
+    }
+    if (ws.slice(0, 4).some((w) => TREATMENT.includes(w))) {
+      warn(path, 'treatment-lead', 'leads with visual treatment — lead with meaning; treatment is optional detail');
+    }
+  }
+
+  return warnings;
+}
+
+const invokedAsCli = process.argv[1]
+  && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedAsCli) {
+  const args = process.argv.slice(2);
+  const asJson = args.includes('--json');
+  const file = args.find((a) => !a.startsWith('--'));
+  if (!file) {
+    console.error('usage: docs-lint.mjs <path/to/Component.doc.json> [--json]');
+    process.exit(2);
+  }
+  let record;
+  try {
+    record = JSON.parse(readFileSync(file, 'utf8'));
+  } catch (e) {
+    console.error(`docs-lint: cannot read ${file}: ${e.message}`);
+    process.exit(2);
+  }
+  const warnings = lintRecord(record);
+  if (asJson) {
+    console.log(JSON.stringify({ warnings }, null, 2));
+  } else {
+    for (const w of warnings) console.log(`${file}: ${w.path}: ${w.rule}: ${w.message}`);
+  }
+  process.exit(0);
+}

--- a/scripts/docs-lint.mjs
+++ b/scripts/docs-lint.mjs
@@ -37,7 +37,7 @@ const STOPWORDS = new Set([
   'under', 'up', 'down', 'out', 'about',
 ]);
 
-const words = (s) => String(s).toLowerCase().match(/[a-z0-9''-]+/g) || [];
+const words = (s) => String(s).toLowerCase().match(/[a-z0-9'’-]+/g) || [];
 // Naive plural/verb-s stemming: enough to match "Triggers" to "trigger".
 const stem = (w) => (w.length > 3 && w.endsWith('s') ? w.slice(0, -1) : w);
 
@@ -113,7 +113,7 @@ export function lintRecord(record) {
       if (!/\.$/.test(String(entry).trim())) {
         warn(path, 'terminal-stop', 'end the entry with a full stop');
       }
-      if (key === 'donts' && !/^(don['']?t|do not|never|avoid)\b/i.test(String(entry).trim())) {
+      if (key === 'donts' && !/^(don['’]?t|do not|never|avoid)\b/i.test(String(entry).trim())) {
         warn(path, 'dont-shape', "open with Don't / Never / Avoid and name the alternative");
       }
     });

--- a/scripts/docs-lint.test.mjs
+++ b/scripts/docs-lint.test.mjs
@@ -1,0 +1,144 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { lintRecord } from './docs-lint.mjs';
+
+const rules = (ws) => ws.map((w) => w.rule);
+const byRule = (ws, rule) => ws.filter((w) => w.rule === rule);
+
+test('machinery vocabulary flagged in prose, exempt fields ignored', () => {
+  const ws = lintRecord({
+    name: 'Button',
+    summary: 'Triggers an action.',
+    description: 'A clickable control that starts an action: saving a form, confirming a choice, opening a dialog. It binds every color, spacing, radius, and type value to the semantic tokens.',
+    tokensUsed: ['color.bg.primary'],
+  });
+  const hits = byRule(ws, 'machinery-vocabulary');
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].path, 'description');
+  // tokensUsed is exempt — its token names must not trip the rule
+  assert.ok(!hits.some((w) => w.path.startsWith('tokensUsed')));
+});
+
+test('summary echo: spec worked example yields 100% and warns', () => {
+  const ws = lintRecord({
+    name: 'Button',
+    summary: 'Triggers an action or event.',
+    description: 'A clickable control that starts an action: saving a form, confirming a choice, opening a dialog.',
+    whenToUse: ['Trigger an action or event — submit, confirm, open a dialog'],
+  });
+  const hits = byRule(ws, 'summary-echo');
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].path, 'whenToUse[0]');
+  assert.match(hits[0].message, /100%/);
+});
+
+test('summary echo: spec after-example does not warn', () => {
+  const ws = lintRecord({
+    name: 'Button',
+    summary: 'Triggers an action or event.',
+    description: 'A clickable control that starts an action: saving a form, confirming a choice, opening a dialog.',
+    whenToUse: ['Something happens on the current page — save, confirm, open a dialog'],
+  });
+  assert.equal(byRule(ws, 'summary-echo').length, 0);
+});
+
+test('run-on sentence over 35 words flagged', () => {
+  const long = 'This sentence keeps going and going with clause after clause after clause because nobody ever stopped it from growing far beyond what any patient reader can comfortably parse in one single breath which is exactly the failure mode';
+  const ws = lintRecord({ name: 'X', summary: 'Short.', description: long + '.' });
+  assert.equal(byRule(ws, 'run-on-sentence').length, 1);
+});
+
+test('summary length over 12 words flagged', () => {
+  const ws = lintRecord({
+    name: 'X',
+    summary: 'This summary uses far too many words to say a very simple thing indeed.',
+    description: 'A clickable control that starts an action: saving a form, confirming a choice, opening a dialog.',
+  });
+  assert.equal(byRule(ws, 'summary-length').length, 1);
+});
+
+test('description length outside 15–70 words flagged, inside passes', () => {
+  const short = lintRecord({ name: 'X', summary: 'Short.', description: 'Too short by far.' });
+  assert.equal(byRule(short, 'description-length').length, 1);
+  const ok = lintRecord({
+    name: 'X', summary: 'Short.',
+    description: 'A clickable control that starts an action: saving a form, confirming a choice, opening a dialog. Its six emphasis levels signal how important an action is.',
+  });
+  assert.equal(byRule(ok, 'description-length').length, 0);
+});
+
+test('guidance length, terminal stop, and dont shape on dos/donts', () => {
+  const ws = lintRecord({
+    name: 'X', summary: 'Short.',
+    description: 'A clickable control that starts an action: saving a form, confirming a choice, opening a dialog.',
+    dos: ['Lead with a verb'],                                     // no terminal stop
+    donts: ["Don't use a button for navigation — use a Link",      // no terminal stop
+            'Use a Link for navigation instead of this.'],          // wrong opener
+  });
+  assert.equal(byRule(ws, 'terminal-stop').length, 2);
+  const shape = byRule(ws, 'dont-shape');
+  assert.equal(shape.length, 1);
+  assert.equal(shape[0].path, 'donts[1]');
+});
+
+test('spec after-example guidance passes clean', () => {
+  const ws = lintRecord({
+    name: 'X', summary: 'Short.',
+    description: 'A clickable control that starts an action: saving a form, confirming a choice, opening a dialog.',
+    donts: ["Don't use a button to navigate. Use a Link."],
+  });
+  assert.equal(rules(ws).filter((r) => ['guidance-length', 'terminal-stop', 'dont-shape'].includes(r)).length, 0);
+});
+
+test('treatment lead flagged in first 4 words of a meaning; later mention passes', () => {
+  const ws = lintRecord({
+    name: 'X', summary: 'Short.',
+    description: 'A clickable control that starts an action: saving a form, confirming a choice, opening a dialog.',
+    variants: { type: {
+      primary: 'Highest-emphasis, solid brand fill — the one primary action in a view.',
+      secondary: 'A supporting action, rendered with a subtle border treatment.',
+    } },
+    states: { disabled: "Can't be clicked or tabbed to." },
+  });
+  const hits = byRule(ws, 'treatment-lead');
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].path, 'variants.type.primary');
+});
+
+test('empty meaning under 3 words flagged', () => {
+  const ws = lintRecord({
+    name: 'X', summary: 'Short.',
+    description: 'A clickable control that starts an action: saving a form, confirming a choice, opening a dialog.',
+    states: { hover: 'Pointer feedback.' },
+  });
+  const hits = byRule(ws, 'empty-meaning');
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].path, 'states.hover');
+});
+
+test('a record following the standard produces zero warnings', () => {
+  const ws = lintRecord({
+    name: 'Button',
+    summary: 'Triggers an action or event.',
+    description: 'A clickable control that starts an action: saving a form, confirming a choice, opening a dialog. Its six emphasis levels signal how important an action is.',
+    whenToUse: ['Something happens on the current page — save, confirm, open a dialog'],
+    whenNotToUse: ['Navigating to another page. Use a Link.'],
+    variants: { type: { primary: 'The one main action in a view.' } },
+    states: { disabled: "Can't be clicked or tabbed to." },
+    dos: ['Lead with a verb.'],
+    donts: ["Don't use a button to navigate. Use a Link."],
+    accessibility: {
+      role: 'button',
+      keyboard: ['Enter or Space activates the button.'],
+      notes: ['An icon-only button needs an `aria-label` so screen readers can announce it.'],
+    },
+    tokensUsed: ['color.bg.primary'],
+    status: 'stable',
+  });
+  assert.deepEqual(ws, []);
+});
+
+test('missing optional blocks lint without crashing', () => {
+  const ws = lintRecord({ name: 'X', summary: 'Short.', description: 'A clickable control that starts an action: saving a form, confirming a choice, opening a dialog.' });
+  assert.equal(rules(ws).length, 0);
+});

--- a/scripts/docs-lint.test.mjs
+++ b/scripts/docs-lint.test.mjs
@@ -85,7 +85,7 @@ test('spec after-example guidance passes clean', () => {
   const ws = lintRecord({
     name: 'X', summary: 'Short.',
     description: 'A clickable control that starts an action: saving a form, confirming a choice, opening a dialog.',
-    donts: ["Don't use a button to navigate. Use a Link."],
+    donts: ["Don’t use a button to navigate. Use a Link."],
   });
   assert.equal(rules(ws).filter((r) => ['guidance-length', 'terminal-stop', 'dont-shape'].includes(r)).length, 0);
 });
@@ -98,7 +98,7 @@ test('treatment lead flagged in first 4 words of a meaning; later mention passes
       primary: 'Highest-emphasis, solid brand fill — the one primary action in a view.',
       secondary: 'A supporting action, rendered with a subtle border treatment.',
     } },
-    states: { disabled: "Can't be clicked or tabbed to." },
+    states: { disabled: "Can’t be clicked or tabbed to." },
   });
   const hits = byRule(ws, 'treatment-lead');
   assert.equal(hits.length, 1);
@@ -141,4 +141,14 @@ test('a record following the standard produces zero warnings', () => {
 test('missing optional blocks lint without crashing', () => {
   const ws = lintRecord({ name: 'X', summary: 'Short.', description: 'A clickable control that starts an action: saving a form, confirming a choice, opening a dialog.' });
   assert.equal(rules(ws).length, 0);
+});
+
+test('curly-apostrophe contractions tokenize and pass dont-shape', () => {
+  const ws = lintRecord({
+    name: 'X', summary: 'Short.',
+    description: 'A clickable control that starts an action: saving a form, confirming a choice, opening a dialog.',
+    donts: ["Don’t use a button to navigate. Use a Link."],
+    states: { disabled: "Can’t be clicked or tabbed to." },
+  });
+  assert.deepEqual(ws, []);
 });

--- a/skills/component-builder/SKILL.md
+++ b/skills/component-builder/SKILL.md
@@ -267,9 +267,10 @@ reference register, not this skill's guide voice.
    `node ${CLAUDE_PLUGIN_ROOT}/scripts/docs-lint.mjs design-system/docs/components/<Name>.doc.json`,
    and fix the warnings it raises — for `imported`/`user` blocks, surface the
    warning to the user and let them decide per item, never silently rewrite.
-   **Show the whole drafted record and get explicit approval** — layers 1–4
-   only fill blocks the ingest step did not, and an `imported`/`user` block is
-   never overwritten.
+   **Show the whole drafted record and get explicit approval before
+   projecting it anywhere** (Figma description, doc card, manifest) — layers
+   1–4 only fill blocks the ingest step did not, and an `imported`/`user`
+   block is never overwritten.
 
 **Write the record and project it:**
 

--- a/skills/component-builder/SKILL.md
+++ b/skills/component-builder/SKILL.md
@@ -241,7 +241,9 @@ Read `${CLAUDE_PLUGIN_ROOT}/references/component-doc-schema.md` for the exact JS
 schema, the fingerprint algorithm, and the projection contract.
 
 **Run the generation pipeline (each layer only fills what it legitimately knows;
-stamp `provenance` per block):**
+stamp `provenance` per block):** all authored prose follows
+`${CLAUDE_PLUGIN_ROOT}/references/doc-writing-standard.md` — its plain
+reference register, not this skill's guide voice.
 
 0. **Ingest existing docs — brownfield only, runs first.** If docs already exist
    for this component (code JSDoc/MDX/README, or a populated Figma component
@@ -260,9 +262,14 @@ stamp `provenance` per block):**
    accessibility idiom to the target framework (the same field you read for variant
    vocabulary). Provenance `framework`.
 4. **Interview for the non-inferable.** Ask the user for brand/product-specific
-   do's & don'ts and intent. Provenance `user`. **Show the whole drafted record and
-   get explicit approval before writing anything** — layers 1–4 only fill blocks the
-   ingest step did not, and an `imported`/`user` block is never overwritten.
+   do's & don'ts and intent. Provenance `user`. Write the draft to
+   `design-system/docs/components/<Name>.doc.json`, run
+   `node ${CLAUDE_PLUGIN_ROOT}/scripts/docs-lint.mjs design-system/docs/components/<Name>.doc.json`,
+   and fix the warnings it raises — for `imported`/`user` blocks, surface the
+   warning to the user and let them decide per item, never silently rewrite.
+   **Show the whole drafted record and get explicit approval** — layers 1–4
+   only fill blocks the ingest step did not, and an `imported`/`user` block is
+   never overwritten.
 
 **Write the record and project it:**
 

--- a/skills/storybook-chromatic-builder/SKILL.md
+++ b/skills/storybook-chromatic-builder/SKILL.md
@@ -34,11 +34,12 @@ Storybook runs and shows the token-themed canvas.
 
 Install the documentation scripts alongside the token scripts (copy from the
 plugin's `scripts/` — `build-docs-digest.mjs`, `docs-check.mjs`,
-`lib/doc-record.mjs`, and `lib/doc-card-plan.mjs` — into the repo and register
-npm scripts):
+`lib/doc-record.mjs`, `lib/doc-card-plan.mjs`, and `docs-lint.mjs` — into the
+repo and register npm scripts):
 
 - `"docs:digest": "node scripts/build-docs-digest.mjs"`
 - `"docs:check": "node scripts/docs-check.mjs"`
+- `"docs:lint": "node scripts/docs-lint.mjs"`
 
 These are the documentation analog of `tokens:validate`; see
 `${CLAUDE_PLUGIN_ROOT}/scripts/README.md`. This copy is setup, not a forever-fork:


### PR DESCRIPTION
Plan 2 of 2 for the doc-card redesign (spec: `docs/superpowers/specs/2026-08-09-doc-card-layout-and-voice-design.md`; plan 1, the deterministic builder, landed in #30). This is the voice phase: the writing standard, the mechanical copy lint, the archetype compliance pass, and the authoring-pipeline wiring.

## What's here

- **`scripts/docs-lint.mjs` + tests** — the ten spec-pinned rules (machinery vocabulary, summary echo at >60% stemmed overlap, run-on >35 words, summary >12, description outside 15–70, guidance >14, don't-shape, terminal stop, treatment-lead, empty meaning). Warnings only, exit 0 on any parseable record, one line per warning (`<file>: <block-path>: <rule>: <message>`), `--json` for programmatic use, exit 2 only for unusable invocation. Zero dependencies; curly-apostrophe-safe tokenization. Verb-presence deliberately not linted, per the spec.
- **`references/doc-writing-standard.md`** — the copy rules in plain-reference register (Polaris/Carbon), explicitly distinct from the guide voice. The spec's before/after examples are carried byte-exact and are the same literal strings the lint's tests assert on; the ten rule slugs match the implementation one-for-one.
- **Archetype compliance pass** — nine entries rewritten across five archetypes (named alternatives on don'ts, machinery vocabulary out, em-dash fragments resolved), plus a preamble stating the clause-style/expansion contract. A seed-derived record now produces zero guaranteed machinery-vocabulary false positives.
- **Pipeline wiring** — the authoring flow in `component-builder` and `/document-component` writes the draft record, runs the lint, fixes warnings, and only then shows the user; for `imported`/`user`-provenance blocks the warning is surfaced per item, never silently rewritten. The approval gate is now explicitly scoped: approval comes **before projecting anywhere** (Figma description, doc card, manifest). `docs-lint.mjs` joins the storybook-chromatic-builder copy list (`docs:lint` npm script) and the `/document-component` freshness-refresh list.

## Verification

- 174/174 tests (`node --test`), adapter `--check` and doc-card-builder `--check` green.
- Every task passed an independent review plus scoped re-reviews; the final whole-branch review (deep tier) came back APPROVED with all cross-artifact seams verified: slugs/thresholds/examples agree byte-for-byte across lint, tests, and standard; the install path closes end-to-end (the lint imports only `node:` builtins, so the copy list carries everything); released changelog headings untouched.
- Spec success criterion 4 holds: the lint flags every mechanically-detectable before-example and none of the after-examples.

## Watch item (carried, not fixed here)

The `/document-component` freshness gate keys on `DOC_CARD_RENDERER_VERSION`, which this release bumps — so existing repos will be prompted to refresh and receive `docs-lint.mjs`. But a future lint-rule-only release won't move that constant, so repo copies of the lint could go stale undetected (low impact: the authoring pipeline always invokes the plugin's copy). Same family as the content-hash follow-up noted on #30.

Free wins per the spec: Storybook MDX, the Figma description field, and the AI digest are projections of the record, so the voice standard reaches them with no extra work. The acceptance test remains the `throughline-sample` dogfood: re-document Button/Input/Card and confirm the new copy reads like published design-system documentation with `docs:check` quiet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013K6HRnMCUxbyA3FHvr2AQf
