### PR TITLE
chore(release): 0.15.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "throughline",
   "description": "ThroughLine — build a complete design system end to end. Author tokens, styles, icons, and components in Figma, then stand up a monorepo, sync tokens to framework-specific code via Style Dictionary, and generate Storybook stories with Chromatic. One unbroken line from design to code. Built for designers becoming developers; explanation scales to your comfort level.",
-  "version": "0.15.0-doc-card.1",
+  "version": "0.15.0",
   "author": {
     "name": "Jordan Pease"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+## [0.15.0] — 2026-08-12
+
 ### Added
 - **Doc-writing standard and lint.** `references/doc-writing-standard.md` sets
   the plain reference register for all doc-record prose — per-block rules for

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@radicool/throughline",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Build a complete design system end to end — author in Figma, sync tokens to code, generate Storybook. Usable from Claude Code, Cursor, Codex, or any AGENTS.md agent.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Cuts the release for the doc-card redesign and the post-dogfood fix batch.

## Version reconciliation

`plugin.json` carried the prerelease `0.15.0-doc-card.1` — introduced so a dev plugin loaded via `--plugin-dir` could be told apart from the enabled marketplace copy, since a feature branch at an identical version string shadows it silently. `package.json` meanwhile still read `0.14.0`. Both now read **`0.15.0`**, and `[Unreleased]` becomes `[0.15.0] — 2026-08-12`.

`ci/extract-changelog.mjs` was run against the new heading to confirm it resolves, so the published GitHub Release body renders rather than coming out empty.

## What ships in 0.15.0

**The doc-writing standard and its lint** (#31) — per-block prose rules with a warnings-only `docs-lint.mjs` installed as `docs:lint`, wired to run before the record-approval gate.

**The deterministic doc-card builder** (#30, #32) — the `Usage` band is rendered by a canonical generated snippet from a pure, unit-tested planner, replacing per-agent improvisation. Now at renderer 4.

**The post-dogfood fix batch** (#32) — seven defects found by a live dogfood plus one found during validation. Three shared a root cause: the builder's contract claimed it never touched the header or specimen, and that was false. The planner read `specimen.width`, then the render widened the card and auto-layout hug propagated the new width back into every `FILL` sibling — including the specimen. It fed its own next invocation a measurement it had moved. Resolved by removing the specimen from the calculation entirely, so the loop is structurally impossible rather than merely corrected.

The builder now also **owns the header's record-derived content**, closing the case where re-documenting a `stable` component left machinery-voice prose and a stale date sitting above the corrected copy, with the drift gate green because no surface tracked the header.

## One behaviour change worth calling out

Regeneration now re-infers `best-practice` and `w3c-apg` provenance blocks, which previously had no stated policy at all. **Protection wins on combinations** — any provenance containing `user` or `imported` is never overwritten, whatever else it carries. This is a change to a protection rule, not a documentation clarification, which is why it is in `### Changed` rather than buried.

## Verification

181 tests pass; `build-doc-card-builder --check`, `adapters/generate --check`, `validate-plugin` and `validate-skills` all clean.

Validated live against a real Figma file: all twelve renderable doc cards re-rendered at renderer 4, component sets intact, nothing detached, idempotent render hashes, and Button's specimen holding at 2040 across two renders where the old code moved that same specimen 1536 → 2040 within a single render. The reference project is reconciled in [throughline-sample#20](https://github.com/jrpease/throughline-sample/pull/20).

## Merging this triggers nothing

Publication is tag-driven: `release.yml` fires on `v*` and runs `npm publish --provenance`. Merging this PR only lands the version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013K6HRnMCUxbyA3FHvr2AQf
