### PR TITLE
feat: validate native token output — catch adapter output that compiles but is wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,8 @@ Future improvements and planned capabilities. Have a request? **[Open an issue](
 - **Expanded component starters** — a larger foundational kit out of the box.
 - **Richer status & auditing** — more from `/design-system-status`, including drift detection between Figma and code.
 - **Built-in accessibility checks** — automatic a11y validation when tokens and components are created, so modes can't be built with poor color contrast and components can't ship with accessibility gaps. Catches issues at creation time rather than in review.
-- **One library, many platforms** — support a single Figma token library that syncs to multiple platforms at once (React, Android, iOS), with a component lifecycle flexible enough to target per platform — every platform, or native-only components that don't need a React counterpart.
+- **Token fan-out to more platforms** — the DTCG token source is platform-neutral, and web targets are in daily use. Native targets (iOS/Swift, Android/Kotlin) currently generate through the Tier 2 protocol and are **validated per build, not assumed** — `tokens:validate-output` checks generated native output against its source, because the stock transforms have been measured emitting wrong-but-compiling values.
+- **Native component code generation** — producing a SwiftUI view or a Compose composable the way Storybook components are produced for React. This does not exist yet; it is a separate, larger effort than token fan-out, and the two were previously described as one roadmap item.
 
 Versioning follows [Semantic Versioning](https://semver.org). The current version lives in [`.claude-plugin/plugin.json`](.claude-plugin/plugin.json); every release is recorded in [`CHANGELOG.md`](CHANGELOG.md).
 

--- a/adapters/codex/prompts/token-crosswalk-builder.md
+++ b/adapters/codex/prompts/token-crosswalk-builder.md
@@ -65,6 +65,8 @@ Copy these from `.throughline/scripts/` into the user's repo **verbatim**
 (they are zero-dependency and version with the user's repo so their CI can run them):
 
 - `lib/crosswalk.mjs` → `packages/tokens/scripts/lib/crosswalk.mjs`
+- `lib/dtcg.mjs` → `packages/tokens/scripts/lib/dtcg.mjs` (required by
+  `validate-crosswalk.mjs` — copying the validator without it breaks the gate at import)
 - `validate-crosswalk.mjs` → `packages/tokens/scripts/validate-crosswalk.mjs`
 - `build-reverse-index.mjs` → `packages/tokens/scripts/build-reverse-index.mjs`
 - `guard-token-removal.mjs` → `packages/tokens/scripts/guard-token-removal.mjs`

--- a/adapters/codex/prompts/token-sync-layer.md
+++ b/adapters/codex/prompts/token-sync-layer.md
@@ -139,11 +139,21 @@ register the platform, transform group, format, and `outputReferences`
 flattens). Web adapters emit `:root`/`.dark` (or `[data-theme]`); the shadcn
 adapter also emits a Tailwind preset.
 
+**Native targets build once per mode, and are validated.** A single build over
+the whole token directory silently drops a mode — Style Dictionary dedupes by
+dot-path, so a light and a dark definition of the same token collapse to
+whichever file sorted last. Configure one build per mode combination with an
+explicit source file list, then run `tokens:validate-output` against each
+generated file with that same list. See
+`.throughline/references/sync-adapters.md`.
+
 **Execution model — subagent dispatch with model routing.** Generating each
 platform's output is independent and verifiable. If your host supports subagent
 dispatch, dispatch **one `code-executor` per adapter** — each produces its
-platform's files and verifies them (the config builds, the expected files
-appear, references resolve for web / flatten for native) — then a **`reviewer`**
+platform's files and verifies them (for web: the config builds, the expected
+files appear, references resolve; for native: `tokens:validate-output` passes —
+"the config builds" is not verification, it is the condition under which all
+four known native failure modes ship silently) — then a **`reviewer`**
 to check each before combining. Choose each subagent's model from its role tier
 per `.throughline/references/agent-routing.md` (`code-executor` → fast,
 `reviewer` → balanced), and only dispatch once each adapter's spec is complete
@@ -158,6 +168,18 @@ Run the Style Dictionary build. Outputs land in `packages/tokens/<platform>/`
 as **build artifacts** — regenerated every sync, never hand-edited. Wire
 `packages/tokens/package.json` to export them so the UI package, Storybook, and
 any future app consume them.
+
+**Install the output validator.** Copy
+`.throughline/scripts/validate-token-output.mjs` into
+`packages/tokens/scripts/` and register it so it stays a live gate on every
+future sync rather than a one-time check:
+
+```json
+"tokens:validate-output": "node scripts/validate-token-output.mjs"
+```
+
+Invoke it once per native output file, passing the same `--source` list that
+file's build used.
 
 ## Step 4.5 — Icon code sync (install check + custom SVGR)
 

--- a/adapters/codex/prompts/token-sync-layer.md
+++ b/adapters/codex/prompts/token-sync-layer.md
@@ -169,10 +169,12 @@ as **build artifacts** — regenerated every sync, never hand-edited. Wire
 `packages/tokens/package.json` to export them so the UI package, Storybook, and
 any future app consume them.
 
-**Install the output validator.** Copy
+**Install the output validator.** Copy **both** files —
 `.throughline/scripts/validate-token-output.mjs` into
-`packages/tokens/scripts/` and register it so it stays a live gate on every
-future sync rather than a one-time check:
+`packages/tokens/scripts/` and `.throughline/scripts/lib/dtcg.mjs` into
+`packages/tokens/scripts/lib/` (the validator imports it; copying one without the
+other breaks the gate at import). Then register it so it stays a live gate on
+every future sync rather than a one-time check:
 
 ```json
 "tokens:validate-output": "node scripts/validate-token-output.mjs"

--- a/adapters/codex/prompts/token-sync-layer.md
+++ b/adapters/codex/prompts/token-sync-layer.md
@@ -41,11 +41,11 @@ fails, offer `figma-environment-setup`.
 Ask which platform(s) the user is building for. Read
 `.throughline/references/sync-adapters.md` for the two-tier adapter model.
 
-- **Curated (Tier 1):** `shadcn`, `tailwind`, `mui`, `vanilla-css`, `ios-swift`.
+- **Curated (Tier 1):** `shadcn`, `tailwind`, `mui`, `vanilla-css`.
   Vetted presets — high confidence.
 - **Generated (Tier 2):** any other framework (Ant Design, Chakra, HeroUI,
-  Android/Kotlin, Flutter, etc.). The skill generates an adapter and verifies it
-  against a real component before trusting it.
+  iOS/Swift, Android/Kotlin, Flutter, etc.). The skill generates an adapter and
+  verifies it against a real component before trusting it.
 
 **Always tell the user which tier they're on.** If they name a curated one, say
 it'll be solid. If they name anything else, be honest: "That's not one I have a

--- a/adapters/codex/prompts/token-sync-layer.md
+++ b/adapters/codex/prompts/token-sync-layer.md
@@ -139,6 +139,14 @@ register the platform, transform group, format, and `outputReferences`
 flattens). Web adapters emit `:root`/`.dark` (or `[data-theme]`); the shadcn
 adapter also emits a Tailwind preset.
 
+**Native targets need the configuration in
+`.throughline/references/native-adapter-config.md`, not a stock
+transform group.** The stock `ios-swift` and `compose` groups emit every
+`px`-authored dimension at ×16 its value — valid, compiling, silently wrong —
+and mishandle `color-mix()` and dual-node DTCG the same way. That file gives the
+preprocessor and transforms that fix it, verified at 196/196 correct symbols
+against a real source.
+
 **Native targets build once per mode, and are validated.** A single build over
 the whole token directory silently drops a mode — Style Dictionary dedupes by
 dot-path, so a light and a dark definition of the same token collapse to

--- a/adapters/cursor/.cursor/rules/token-crosswalk-builder.mdc
+++ b/adapters/cursor/.cursor/rules/token-crosswalk-builder.mdc
@@ -69,6 +69,8 @@ Copy these from `.throughline/scripts/` into the user's repo **verbatim**
 (they are zero-dependency and version with the user's repo so their CI can run them):
 
 - `lib/crosswalk.mjs` → `packages/tokens/scripts/lib/crosswalk.mjs`
+- `lib/dtcg.mjs` → `packages/tokens/scripts/lib/dtcg.mjs` (required by
+  `validate-crosswalk.mjs` — copying the validator without it breaks the gate at import)
 - `validate-crosswalk.mjs` → `packages/tokens/scripts/validate-crosswalk.mjs`
 - `build-reverse-index.mjs` → `packages/tokens/scripts/build-reverse-index.mjs`
 - `guard-token-removal.mjs` → `packages/tokens/scripts/guard-token-removal.mjs`

--- a/adapters/cursor/.cursor/rules/token-sync-layer.mdc
+++ b/adapters/cursor/.cursor/rules/token-sync-layer.mdc
@@ -45,11 +45,11 @@ fails, offer `figma-environment-setup`.
 Ask which platform(s) the user is building for. Read
 `.throughline/references/sync-adapters.md` for the two-tier adapter model.
 
-- **Curated (Tier 1):** `shadcn`, `tailwind`, `mui`, `vanilla-css`, `ios-swift`.
+- **Curated (Tier 1):** `shadcn`, `tailwind`, `mui`, `vanilla-css`.
   Vetted presets — high confidence.
 - **Generated (Tier 2):** any other framework (Ant Design, Chakra, HeroUI,
-  Android/Kotlin, Flutter, etc.). The skill generates an adapter and verifies it
-  against a real component before trusting it.
+  iOS/Swift, Android/Kotlin, Flutter, etc.). The skill generates an adapter and
+  verifies it against a real component before trusting it.
 
 **Always tell the user which tier they're on.** If they name a curated one, say
 it'll be solid. If they name anything else, be honest: "That's not one I have a

--- a/adapters/cursor/.cursor/rules/token-sync-layer.mdc
+++ b/adapters/cursor/.cursor/rules/token-sync-layer.mdc
@@ -143,6 +143,14 @@ register the platform, transform group, format, and `outputReferences`
 flattens). Web adapters emit `:root`/`.dark` (or `[data-theme]`); the shadcn
 adapter also emits a Tailwind preset.
 
+**Native targets need the configuration in
+`.throughline/references/native-adapter-config.md`, not a stock
+transform group.** The stock `ios-swift` and `compose` groups emit every
+`px`-authored dimension at ×16 its value — valid, compiling, silently wrong —
+and mishandle `color-mix()` and dual-node DTCG the same way. That file gives the
+preprocessor and transforms that fix it, verified at 196/196 correct symbols
+against a real source.
+
 **Native targets build once per mode, and are validated.** A single build over
 the whole token directory silently drops a mode — Style Dictionary dedupes by
 dot-path, so a light and a dark definition of the same token collapse to

--- a/adapters/cursor/.cursor/rules/token-sync-layer.mdc
+++ b/adapters/cursor/.cursor/rules/token-sync-layer.mdc
@@ -143,11 +143,21 @@ register the platform, transform group, format, and `outputReferences`
 flattens). Web adapters emit `:root`/`.dark` (or `[data-theme]`); the shadcn
 adapter also emits a Tailwind preset.
 
+**Native targets build once per mode, and are validated.** A single build over
+the whole token directory silently drops a mode — Style Dictionary dedupes by
+dot-path, so a light and a dark definition of the same token collapse to
+whichever file sorted last. Configure one build per mode combination with an
+explicit source file list, then run `tokens:validate-output` against each
+generated file with that same list. See
+`.throughline/references/sync-adapters.md`.
+
 **Execution model — subagent dispatch with model routing.** Generating each
 platform's output is independent and verifiable. If your host supports subagent
 dispatch, dispatch **one `code-executor` per adapter** — each produces its
-platform's files and verifies them (the config builds, the expected files
-appear, references resolve for web / flatten for native) — then a **`reviewer`**
+platform's files and verifies them (for web: the config builds, the expected
+files appear, references resolve; for native: `tokens:validate-output` passes —
+"the config builds" is not verification, it is the condition under which all
+four known native failure modes ship silently) — then a **`reviewer`**
 to check each before combining. Choose each subagent's model from its role tier
 per `.throughline/references/agent-routing.md` (`code-executor` → fast,
 `reviewer` → balanced), and only dispatch once each adapter's spec is complete
@@ -162,6 +172,18 @@ Run the Style Dictionary build. Outputs land in `packages/tokens/<platform>/`
 as **build artifacts** — regenerated every sync, never hand-edited. Wire
 `packages/tokens/package.json` to export them so the UI package, Storybook, and
 any future app consume them.
+
+**Install the output validator.** Copy
+`.throughline/scripts/validate-token-output.mjs` into
+`packages/tokens/scripts/` and register it so it stays a live gate on every
+future sync rather than a one-time check:
+
+```json
+"tokens:validate-output": "node scripts/validate-token-output.mjs"
+```
+
+Invoke it once per native output file, passing the same `--source` list that
+file's build used.
 
 ## Step 4.5 — Icon code sync (install check + custom SVGR)
 

--- a/adapters/cursor/.cursor/rules/token-sync-layer.mdc
+++ b/adapters/cursor/.cursor/rules/token-sync-layer.mdc
@@ -173,10 +173,12 @@ as **build artifacts** — regenerated every sync, never hand-edited. Wire
 `packages/tokens/package.json` to export them so the UI package, Storybook, and
 any future app consume them.
 
-**Install the output validator.** Copy
+**Install the output validator.** Copy **both** files —
 `.throughline/scripts/validate-token-output.mjs` into
-`packages/tokens/scripts/` and register it so it stays a live gate on every
-future sync rather than a one-time check:
+`packages/tokens/scripts/` and `.throughline/scripts/lib/dtcg.mjs` into
+`packages/tokens/scripts/lib/` (the validator imports it; copying one without the
+other breaks the gate at import). Then register it so it stays a live gate on
+every future sync rather than a one-time check:
 
 ```json
 "tokens:validate-output": "node scripts/validate-token-output.mjs"

--- a/adapters/generic/skills/token-crosswalk-builder/SKILL.md
+++ b/adapters/generic/skills/token-crosswalk-builder/SKILL.md
@@ -65,6 +65,8 @@ Copy these from `.throughline/scripts/` into the user's repo **verbatim**
 (they are zero-dependency and version with the user's repo so their CI can run them):
 
 - `lib/crosswalk.mjs` → `packages/tokens/scripts/lib/crosswalk.mjs`
+- `lib/dtcg.mjs` → `packages/tokens/scripts/lib/dtcg.mjs` (required by
+  `validate-crosswalk.mjs` — copying the validator without it breaks the gate at import)
 - `validate-crosswalk.mjs` → `packages/tokens/scripts/validate-crosswalk.mjs`
 - `build-reverse-index.mjs` → `packages/tokens/scripts/build-reverse-index.mjs`
 - `guard-token-removal.mjs` → `packages/tokens/scripts/guard-token-removal.mjs`

--- a/adapters/generic/skills/token-sync-layer/SKILL.md
+++ b/adapters/generic/skills/token-sync-layer/SKILL.md
@@ -139,11 +139,21 @@ register the platform, transform group, format, and `outputReferences`
 flattens). Web adapters emit `:root`/`.dark` (or `[data-theme]`); the shadcn
 adapter also emits a Tailwind preset.
 
+**Native targets build once per mode, and are validated.** A single build over
+the whole token directory silently drops a mode — Style Dictionary dedupes by
+dot-path, so a light and a dark definition of the same token collapse to
+whichever file sorted last. Configure one build per mode combination with an
+explicit source file list, then run `tokens:validate-output` against each
+generated file with that same list. See
+`.throughline/references/sync-adapters.md`.
+
 **Execution model — subagent dispatch with model routing.** Generating each
 platform's output is independent and verifiable. If your host supports subagent
 dispatch, dispatch **one `code-executor` per adapter** — each produces its
-platform's files and verifies them (the config builds, the expected files
-appear, references resolve for web / flatten for native) — then a **`reviewer`**
+platform's files and verifies them (for web: the config builds, the expected
+files appear, references resolve; for native: `tokens:validate-output` passes —
+"the config builds" is not verification, it is the condition under which all
+four known native failure modes ship silently) — then a **`reviewer`**
 to check each before combining. Choose each subagent's model from its role tier
 per `.throughline/references/agent-routing.md` (`code-executor` → fast,
 `reviewer` → balanced), and only dispatch once each adapter's spec is complete
@@ -158,6 +168,18 @@ Run the Style Dictionary build. Outputs land in `packages/tokens/<platform>/`
 as **build artifacts** — regenerated every sync, never hand-edited. Wire
 `packages/tokens/package.json` to export them so the UI package, Storybook, and
 any future app consume them.
+
+**Install the output validator.** Copy
+`.throughline/scripts/validate-token-output.mjs` into
+`packages/tokens/scripts/` and register it so it stays a live gate on every
+future sync rather than a one-time check:
+
+```json
+"tokens:validate-output": "node scripts/validate-token-output.mjs"
+```
+
+Invoke it once per native output file, passing the same `--source` list that
+file's build used.
 
 ## Step 4.5 — Icon code sync (install check + custom SVGR)
 

--- a/adapters/generic/skills/token-sync-layer/SKILL.md
+++ b/adapters/generic/skills/token-sync-layer/SKILL.md
@@ -169,10 +169,12 @@ as **build artifacts** — regenerated every sync, never hand-edited. Wire
 `packages/tokens/package.json` to export them so the UI package, Storybook, and
 any future app consume them.
 
-**Install the output validator.** Copy
+**Install the output validator.** Copy **both** files —
 `.throughline/scripts/validate-token-output.mjs` into
-`packages/tokens/scripts/` and register it so it stays a live gate on every
-future sync rather than a one-time check:
+`packages/tokens/scripts/` and `.throughline/scripts/lib/dtcg.mjs` into
+`packages/tokens/scripts/lib/` (the validator imports it; copying one without the
+other breaks the gate at import). Then register it so it stays a live gate on
+every future sync rather than a one-time check:
 
 ```json
 "tokens:validate-output": "node scripts/validate-token-output.mjs"

--- a/adapters/generic/skills/token-sync-layer/SKILL.md
+++ b/adapters/generic/skills/token-sync-layer/SKILL.md
@@ -41,11 +41,11 @@ fails, offer `figma-environment-setup`.
 Ask which platform(s) the user is building for. Read
 `.throughline/references/sync-adapters.md` for the two-tier adapter model.
 
-- **Curated (Tier 1):** `shadcn`, `tailwind`, `mui`, `vanilla-css`, `ios-swift`.
+- **Curated (Tier 1):** `shadcn`, `tailwind`, `mui`, `vanilla-css`.
   Vetted presets — high confidence.
 - **Generated (Tier 2):** any other framework (Ant Design, Chakra, HeroUI,
-  Android/Kotlin, Flutter, etc.). The skill generates an adapter and verifies it
-  against a real component before trusting it.
+  iOS/Swift, Android/Kotlin, Flutter, etc.). The skill generates an adapter and
+  verifies it against a real component before trusting it.
 
 **Always tell the user which tier they're on.** If they name a curated one, say
 it'll be solid. If they name anything else, be honest: "That's not one I have a

--- a/adapters/generic/skills/token-sync-layer/SKILL.md
+++ b/adapters/generic/skills/token-sync-layer/SKILL.md
@@ -139,6 +139,14 @@ register the platform, transform group, format, and `outputReferences`
 flattens). Web adapters emit `:root`/`.dark` (or `[data-theme]`); the shadcn
 adapter also emits a Tailwind preset.
 
+**Native targets need the configuration in
+`.throughline/references/native-adapter-config.md`, not a stock
+transform group.** The stock `ios-swift` and `compose` groups emit every
+`px`-authored dimension at ×16 its value — valid, compiling, silently wrong —
+and mishandle `color-mix()` and dual-node DTCG the same way. That file gives the
+preprocessor and transforms that fix it, verified at 196/196 correct symbols
+against a real source.
+
 **Native targets build once per mode, and are validated.** A single build over
 the whole token directory silently drops a mode — Style Dictionary dedupes by
 dot-path, so a light and a dark definition of the same token collapse to

--- a/docs/superpowers/plans/2026-08-21-token-output-validation.md
+++ b/docs/superpowers/plans/2026-08-21-token-output-validation.md
@@ -263,7 +263,7 @@ export function magnitudeOf(value) {
 - [ ] **Step 4: Run test to verify it passes**
 
 Run: `node --test scripts/validate-token-output.test.mjs`
-Expected: PASS, 11 tests
+Expected: PASS, 10 tests
 
 - [ ] **Step 5: Commit**
 
@@ -496,7 +496,7 @@ export function validate({ sources, output, platform, minMatch = 0.5 }) {
 - [ ] **Step 4: Run test to verify it passes**
 
 Run: `node --test scripts/validate-token-output.test.mjs`
-Expected: PASS, 24 tests
+Expected: PASS, 23 tests
 
 - [ ] **Step 5: Commit**
 
@@ -640,7 +640,7 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
 - [ ] **Step 4: Run the full suite**
 
 Run: `node --test && node ci/validate-plugin.mjs && node ci/validate-skills.mjs`
-Expected: all PASS, 28 tests in this file
+Expected: all PASS, 26 tests in this file
 
 - [ ] **Step 5: Commit**
 

--- a/docs/superpowers/plans/2026-08-21-token-output-validation.md
+++ b/docs/superpowers/plans/2026-08-21-token-output-validation.md
@@ -1,0 +1,916 @@
+# Token Output Validation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a validator that catches generated native token output which is wrong but passes today's checks, and wire it in as a live gate.
+
+**Architecture:** One zero-dependency Node script, `scripts/validate-token-output.mjs`, exporting pure functions and guarded by a `main()` CLI — the exact shape of `scripts/validate-crosswalk.mjs`. It flattens the DTCG source (dual-node aware, unlike the crosswalk flattener), parses `(symbol, value)` pairs out of the generated Swift/Kotlin, and evaluates four rules. It is then installed into the user's repo as an npm script and referenced from `token-sync-layer`'s verification step, replacing wording that let four real failures through.
+
+**Tech Stack:** Node ≥20 ESM, zero dependencies, `node:test` + `node:assert/strict`, `parseArgs` from `node:util`.
+
+**Spec:** `docs/superpowers/specs/2026-08-21-token-output-validation-design.md`
+
+## Global Constraints
+
+- **Zero dependencies.** `scripts/` is "canonical, vetted, **zero-dependency** Node (ESM)" per `scripts/README.md`. Only `node:` built-ins.
+- **Node ≥20** (`package.json` `engines`).
+- **Test runner is `node --test`** (`.github/workflows/ci.yml:17`). Tests are co-located as `<script>.test.mjs`.
+- **Module guard.** Every script ends with `if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main();` so importing it in tests does not execute it.
+- **Exit codes:** `0` pass, `1` validation failure, `2` usage error.
+- **Do not modify `scripts/validate-crosswalk.mjs`.** Its `flattenDtcg` has the same dual-node hole, but fixing it is explicitly out of scope (spec, Risks) — it is a separate gate with its own tests.
+- **CI must stay green:** `node --test`, `node ci/validate-plugin.mjs`, `node ci/validate-skills.mjs`.
+
+---
+
+### Task 1: DTCG flattening and alias resolution
+
+The crosswalk flattener stops descending as soon as a node has a `$value`, so a dual-node token (`text.sm` carrying both `$value: "14px"` and a `lineHeight` child) loses its child. Those children are exactly the tokens most likely to be wrong, so this validator needs its own walker.
+
+**Files:**
+- Create: `scripts/validate-token-output.mjs`
+- Test: `scripts/validate-token-output.test.mjs`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `flattenDtcg(obj, prefix?, out?) -> { [dotPath: string]: rawValue }` and `resolveValue(name, flat, seen?) -> leafValue` (throws on missing/circular).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `scripts/validate-token-output.test.mjs`:
+
+```js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { flattenDtcg, resolveValue } from './validate-token-output.mjs';
+
+// text.sm is a DUAL-NODE token: it carries its own $value AND a child.
+const dtcg = {
+  text: {
+    sm: {
+      $value: '14px',
+      $type: 'dimension',
+      lineHeight: { $value: '20px', $type: 'dimension' },
+    },
+  },
+  typography: {
+    body: { lineHeight: { $value: '{text.sm.lineHeight}', $type: 'dimension' } },
+  },
+};
+
+test('flattenDtcg yields a dual-node parent AND its child', () => {
+  const flat = flattenDtcg(dtcg);
+  assert.equal(flat['text.sm'], '14px');
+  assert.equal(flat['text.sm.lineHeight'], '20px');
+});
+
+test('flattenDtcg skips $-prefixed meta keys', () => {
+  const flat = flattenDtcg(dtcg);
+  assert.equal(flat['text.sm.$type'], undefined);
+});
+
+test('resolveValue follows an alias into a dual-node child', () => {
+  const flat = flattenDtcg(dtcg);
+  assert.equal(resolveValue('typography.body.lineHeight', flat), '20px');
+});
+
+test('resolveValue throws on a missing token', () => {
+  assert.throws(() => resolveValue('nope', {}), /not found/);
+});
+
+test('resolveValue throws on a circular reference', () => {
+  assert.throws(() => resolveValue('a', { a: '{b}', b: '{a}' }), /circular/);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test scripts/validate-token-output.test.mjs`
+Expected: FAIL — `Cannot find module './validate-token-output.mjs'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `scripts/validate-token-output.mjs`:
+
+```js
+// Native token output validator: assert generated Swift/Kotlin matches its DTCG source.
+// Catches output that compiles but is wrong. Zero dependencies.
+//
+// Usage:
+//   node validate-token-output.mjs --source a.json --source b.json \
+//     --output Tokens.swift --platform ios-swift [--min-match 0.5]
+import { readFileSync } from 'node:fs';
+import { parseArgs } from 'node:util';
+import { pathToFileURL } from 'node:url';
+
+const REF = /^\{([^}]+)\}$/;
+
+// Flatten nested DTCG groups into { "dot.path": rawValue }.
+// Unlike validate-crosswalk.mjs's flattenDtcg, a node carrying BOTH a $value and
+// children yields its own value AND is descended into — the dual-node pattern
+// (text.sm has $value "14px" plus a lineHeight child). Stopping at the first
+// $value silently drops those children.
+export function flattenDtcg(obj, prefix = [], out = {}) {
+  for (const [key, val] of Object.entries(obj)) {
+    if (key.startsWith('$')) continue;
+    if (!val || typeof val !== 'object') continue;
+    const path = [...prefix, key];
+    if ('$value' in val) out[path.join('.')] = val.$value;
+    flattenDtcg(val, path, out);
+  }
+  return out;
+}
+
+// Follow {alias} chains to a leaf literal. Throws on missing or circular refs.
+export function resolveValue(name, flat, seen = new Set()) {
+  if (!(name in flat)) throw new Error(`token "${name}" not found in DTCG source`);
+  const val = flat[name];
+  if (typeof val === 'string') {
+    const m = val.match(REF);
+    if (m) {
+      if (seen.has(name)) throw new Error(`circular reference at "${name}"`);
+      seen.add(name);
+      return resolveValue(m[1], flat, seen);
+    }
+  }
+  return val;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test scripts/validate-token-output.test.mjs`
+Expected: PASS, 5 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/validate-token-output.mjs scripts/validate-token-output.test.mjs
+git commit -m "feat: dual-node-aware DTCG flatten and resolve for token output validation"
+```
+
+---
+
+### Task 2: Extract declarations and magnitudes from generated native source
+
+**Files:**
+- Modify: `scripts/validate-token-output.mjs`
+- Test: `scripts/validate-token-output.test.mjs`
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces: `extractDeclarations(text, platform) -> [{ symbol, value }]` and `magnitudeOf(value) -> number | null` (null when the value is not a dimension emission).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `scripts/validate-token-output.test.mjs`:
+
+```js
+import { extractDeclarations, magnitudeOf } from './validate-token-output.mjs';
+
+const SWIFT = `
+public enum Tokens {
+    public static let textSm = CGFloat(224.00)
+    public static let colorBgCanvas = UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 1)
+    // a comment, not a declaration
+}
+`;
+
+const KOTLIN = `
+object Tokens {
+  val textSm = 224.00.dp
+  val colorBgCanvas = Color(0xffffffff)
+}
+`;
+
+test('extractDeclarations reads Swift static let declarations', () => {
+  const decls = extractDeclarations(SWIFT, 'ios-swift');
+  assert.deepEqual(decls, [
+    { symbol: 'textSm', value: 'CGFloat(224.00)' },
+    { symbol: 'colorBgCanvas', value: 'UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 1)' },
+  ]);
+});
+
+test('extractDeclarations reads Kotlin val declarations', () => {
+  const decls = extractDeclarations(KOTLIN, 'android-kotlin');
+  assert.deepEqual(decls.map((d) => d.symbol), ['textSm', 'colorBgCanvas']);
+});
+
+test('extractDeclarations throws on an unknown platform', () => {
+  assert.throws(() => extractDeclarations(SWIFT, 'flutter'), /unknown platform/);
+});
+
+test('magnitudeOf reads CGFloat, dp/sp, and bare numerics', () => {
+  assert.equal(magnitudeOf('CGFloat(224.00)'), 224);
+  assert.equal(magnitudeOf('224.00.dp'), 224);
+  assert.equal(magnitudeOf('16.sp'), 16);
+  assert.equal(magnitudeOf('1.1'), 1.1);
+  assert.equal(magnitudeOf('-0.03'), -0.03);
+});
+
+test('magnitudeOf returns null for non-dimension values', () => {
+  assert.equal(magnitudeOf('UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 1)'), null);
+  assert.equal(magnitudeOf('Color(0xffffffff)'), null);
+  assert.equal(magnitudeOf('24px'), null);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test scripts/validate-token-output.test.mjs`
+Expected: FAIL — `extractDeclarations is not a function`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `scripts/validate-token-output.mjs`:
+
+```js
+// Declaration patterns per platform. Coupled to the ios-swift/enum.swift and
+// compose/object output formats; a different format needs a different pattern,
+// which surfaces as a zero-match failure rather than a silent pass.
+const DECL = {
+  'ios-swift': /^\s*(?:public\s+)?static\s+let\s+([A-Za-z_]\w*)\s*=\s*(.+?)\s*$/,
+  'android-kotlin': /^\s*val\s+([A-Za-z_]\w*)\s*=\s*(.+?)\s*$/,
+};
+
+export function extractDeclarations(text, platform) {
+  const re = DECL[platform];
+  if (!re) throw new Error(`unknown platform "${platform}"`);
+  const out = [];
+  for (const line of text.split('\n')) {
+    const m = line.match(re);
+    if (m) out.push({ symbol: m[1], value: m[2] });
+  }
+  return out;
+}
+
+// Known dimension wrappers. Multi-argument constructors (colors) never match,
+// so they are exempt from unit-fidelity by construction.
+const MAGNITUDE = [
+  /^CGFloat\(\s*(-?(?:\d+(?:\.\d+)?|\.\d+))\s*\)$/,
+  /^(-?(?:\d+(?:\.\d+)?|\.\d+))\.(?:dp|sp)$/,
+  /^(-?(?:\d+(?:\.\d+)?|\.\d+))$/,
+];
+
+export function magnitudeOf(value) {
+  for (const re of MAGNITUDE) {
+    const m = value.match(re);
+    if (m) return Number(m[1]);
+  }
+  return null;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test scripts/validate-token-output.test.mjs`
+Expected: PASS, 11 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/validate-token-output.mjs scripts/validate-token-output.test.mjs
+git commit -m "feat: extract declarations and magnitudes from generated native source"
+```
+
+---
+
+### Task 3: The four rules and the validate orchestrator
+
+**Files:**
+- Modify: `scripts/validate-token-output.mjs`
+- Test: `scripts/validate-token-output.test.mjs`
+
+**Interfaces:**
+- Consumes: `flattenDtcg`, `resolveValue` (Task 1); `extractDeclarations`, `magnitudeOf` (Task 2).
+- Produces: `normalizeKey(s) -> string`, `expectedMagnitude(sourceValue) -> { magnitude } | { skip }`, `findModeCollisions(sources) -> [{ path, defs }]`, and `validate({ sources, output, platform, minMatch }) -> { total, matched, matchRate, failures, collisions, ok }` where `sources` is `[{ file, dtcg }]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `scripts/validate-token-output.test.mjs`:
+
+```js
+import { normalizeKey, expectedMagnitude, findModeCollisions, validate } from './validate-token-output.mjs';
+
+test('normalizeKey collapses camelCase, snake_case, kebab-case, and dot paths', () => {
+  assert.equal(normalizeKey('color.bg.canvas'), 'colorbgcanvas');
+  assert.equal(normalizeKey('colorBgCanvas'), 'colorbgcanvas');
+  assert.equal(normalizeKey('color_bg_canvas'), 'colorbgcanvas');
+  assert.equal(normalizeKey('color-bg-canvas'), 'colorbgcanvas');
+});
+
+test('expectedMagnitude applies the authored unit, never a fixed factor', () => {
+  assert.deepEqual(expectedMagnitude('14px'), { magnitude: 14 });
+  assert.deepEqual(expectedMagnitude('1rem'), { magnitude: 16 });
+  assert.deepEqual(expectedMagnitude('1.1'), { magnitude: 1.1 });
+});
+
+test('expectedMagnitude skips units with no native equivalent', () => {
+  assert.ok(expectedMagnitude('100%').skip);
+  assert.ok(expectedMagnitude('-0.03em').skip);
+  assert.ok(expectedMagnitude('#ffffff').skip);
+});
+
+test('findModeCollisions flags a path defined twice with different values', () => {
+  const sources = [
+    { file: 'mobile.json', dtcg: { spacing: { grid: { columns: { $value: '{spacing.space.1}' } } } } },
+    { file: 'desktop.json', dtcg: { spacing: { grid: { columns: { $value: '{spacing.space.3}' } } } } },
+  ];
+  const c = findModeCollisions(sources);
+  assert.equal(c.length, 1);
+  assert.equal(c[0].path, 'spacing.grid.columns');
+});
+
+test('findModeCollisions ignores a path repeated with the SAME value', () => {
+  const same = { spacing: { grid: { columns: { $value: '4px' } } } };
+  assert.deepEqual(findModeCollisions([{ file: 'a', dtcg: same }, { file: 'b', dtcg: same }]), []);
+});
+
+const SRC = [{ file: 't.json', dtcg: {
+  text: { sm: { $value: '14px', $type: 'dimension' } },
+  leading: { tight: { $value: '1.1', $type: 'dimension' } },
+} }];
+
+test('unit-fidelity catches the x16 scaling bug', () => {
+  const r = validate({ sources: SRC, output: 'static let textSm = CGFloat(224.00)', platform: 'ios-swift' });
+  assert.equal(r.failures.length, 1);
+  assert.equal(r.failures[0].rule, 'unit-fidelity');
+  assert.equal(r.ok, false);
+});
+
+test('unit-fidelity passes a correctly emitted px value', () => {
+  const r = validate({ sources: SRC, output: 'static let textSm = CGFloat(14.00)', platform: 'ios-swift' });
+  assert.deepEqual(r.failures, []);
+  assert.equal(r.ok, true);
+});
+
+test('unit-fidelity never scales a unitless ratio', () => {
+  const ok = validate({ sources: SRC, output: 'static let leadingTight = CGFloat(1.1)', platform: 'ios-swift' });
+  assert.deepEqual(ok.failures, []);
+  const bad = validate({ sources: SRC, output: 'static let leadingTight = CGFloat(17.6)', platform: 'ios-swift' });
+  assert.equal(bad.failures[0].rule, 'unit-fidelity');
+});
+
+test('no-foreign-syntax catches leaked color-mix', () => {
+  const out = 'static let textSm = color-mix(in srgb, UIColor(red: 1, green: 1, blue: 1, alpha: 1) 4%, transparent)';
+  const r = validate({ sources: SRC, output: out, platform: 'ios-swift' });
+  assert.ok(r.failures.some((f) => f.rule === 'no-foreign-syntax'));
+});
+
+test('no-bare-units catches unresolved aliases, including negative magnitudes', () => {
+  const r = validate({ sources: SRC, output: 'static let textSm = 24px', platform: 'ios-swift' });
+  assert.ok(r.failures.some((f) => f.rule === 'no-bare-units'));
+  const neg = validate({ sources: SRC, output: 'static let textSm = -0.03em', platform: 'ios-swift' });
+  assert.ok(neg.failures.some((f) => f.rule === 'no-bare-units'));
+});
+
+test('zero matches fails rather than passing vacuously', () => {
+  const r = validate({ sources: SRC, output: 'static let somethingElse = CGFloat(14.00)', platform: 'ios-swift' });
+  assert.equal(r.matched, 0);
+  assert.equal(r.ok, false);
+});
+
+test('a match rate below the floor fails', () => {
+  const out = ['static let textSm = CGFloat(14.00)', 'static let unknownA = CGFloat(1)', 'static let unknownB = CGFloat(2)'].join('\n');
+  assert.equal(validate({ sources: SRC, output: out, platform: 'ios-swift', minMatch: 0.5 }).ok, false);
+  assert.equal(validate({ sources: SRC, output: out, platform: 'ios-swift', minMatch: 0.3 }).ok, true);
+});
+
+test('a mode collision fails even when every declaration is correct', () => {
+  const sources = [
+    { file: 'mobile.json', dtcg: { text: { sm: { $value: '14px' } } } },
+    { file: 'desktop.json', dtcg: { text: { sm: { $value: '16px' } } } },
+  ];
+  const r = validate({ sources, output: 'static let textSm = CGFloat(16.00)', platform: 'ios-swift' });
+  assert.equal(r.collisions.length, 1);
+  assert.equal(r.ok, false);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test scripts/validate-token-output.test.mjs`
+Expected: FAIL — `normalizeKey is not a function`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `scripts/validate-token-output.mjs`:
+
+```js
+// Adapters name tokens differently (color.bg.canvas -> colorBgCanvas -> color_bg_canvas).
+// Lowercase and strip every non-alphanumeric so all conventions compare equal.
+export function normalizeKey(s) {
+  return String(s).toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+const UNIT = /^(-?(?:\d+(?:\.\d+)?|\.\d+))([a-z%]*)$/;
+
+// Expected native magnitude for an authored source value. iOS points and Android
+// dp both map 1:1 to CSS px by convention; rem is root-relative at a 16px root;
+// a unitless dimension is a ratio and is never scaled. % and em have no native
+// equivalent, so they are skipped here and caught by no-bare-units if emitted raw.
+export function expectedMagnitude(sourceValue) {
+  if (typeof sourceValue === 'number') return { magnitude: sourceValue };
+  if (typeof sourceValue !== 'string') return { skip: 'non-scalar' };
+  const m = sourceValue.trim().match(UNIT);
+  if (!m) return { skip: 'not-a-dimension' };
+  const n = Number(m[1]);
+  switch (m[2]) {
+    case 'px':
+    case '':
+      return { magnitude: n };
+    case 'rem':
+      return { magnitude: n * 16 };
+    case '%':
+    case 'em':
+      return { skip: 'not-expressible' };
+    default:
+      return { skip: 'not-a-dimension' };
+  }
+}
+
+// A token path defined in more than one source file with differing values means
+// the build's source list spans modes. Style Dictionary dedupes these silently,
+// dropping one whole mode — 864 such collisions produced a light-only build from
+// a dark-default system.
+export function findModeCollisions(sources) {
+  const seen = new Map();
+  for (const { file, dtcg } of sources) {
+    for (const [path, value] of Object.entries(flattenDtcg(dtcg))) {
+      if (!seen.has(path)) seen.set(path, []);
+      seen.get(path).push({ file, value });
+    }
+  }
+  const collisions = [];
+  for (const [path, defs] of seen) {
+    const distinct = new Set(defs.map((d) => JSON.stringify(d.value)));
+    if (defs.length > 1 && distinct.size > 1) collisions.push({ path, defs });
+  }
+  return collisions;
+}
+
+const FOREIGN = /(?:color-mix|calc|var)\s*\(/;
+const BARE_UNIT = /^-?(?:\d+(?:\.\d+)?|\.\d+)(?:px|rem|em|%)$/;
+
+export function validate({ sources, output, platform, minMatch = 0.5 }) {
+  const collisions = findModeCollisions(sources);
+
+  const flat = {};
+  for (const { dtcg } of sources) Object.assign(flat, flattenDtcg(dtcg));
+
+  const byKey = new Map();
+  for (const path of Object.keys(flat)) byKey.set(normalizeKey(path), path);
+
+  const decls = extractDeclarations(output, platform);
+  const failures = [];
+  let matched = 0;
+
+  for (const { symbol, value } of decls) {
+    if (FOREIGN.test(value)) failures.push({ rule: 'no-foreign-syntax', symbol, emitted: value });
+    if (BARE_UNIT.test(value)) failures.push({ rule: 'no-bare-units', symbol, emitted: value });
+
+    const path = byKey.get(normalizeKey(symbol));
+    if (!path) continue;
+    matched += 1;
+
+    let source;
+    try {
+      source = resolveValue(path, flat);
+    } catch {
+      continue;
+    }
+    const expected = expectedMagnitude(source);
+    if (expected.skip) continue;
+    const actual = magnitudeOf(value);
+    if (actual === null) continue;
+    if (Math.abs(actual - expected.magnitude) > 0.001) {
+      failures.push({ rule: 'unit-fidelity', symbol, token: path, source, emitted: value, expected: expected.magnitude, actual });
+    }
+  }
+
+  const matchRate = decls.length ? matched / decls.length : 0;
+  const ok = failures.length === 0 && collisions.length === 0 && matched > 0 && matchRate >= minMatch;
+  return { total: decls.length, matched, matchRate, failures, collisions, minMatch, ok };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test scripts/validate-token-output.test.mjs`
+Expected: PASS, 24 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/validate-token-output.mjs scripts/validate-token-output.test.mjs
+git commit -m "feat: four validation rules and the validate orchestrator"
+```
+
+---
+
+### Task 4: CLI, reporting, and exit codes
+
+**Files:**
+- Modify: `scripts/validate-token-output.mjs`
+- Test: `scripts/validate-token-output.test.mjs`
+
+**Interfaces:**
+- Consumes: `validate` (Task 3).
+- Produces: `formatReport(result) -> string[]` and a `main()` CLI guarded by the module check. Exit `0` pass, `1` validation failure, `2` usage error.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `scripts/validate-token-output.test.mjs`:
+
+```js
+import { formatReport } from './validate-token-output.mjs';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+test('formatReport states the match rate and every failure', () => {
+  const lines = formatReport({
+    total: 2, matched: 1, matchRate: 0.5, minMatch: 0.5, collisions: [],
+    failures: [{ rule: 'unit-fidelity', symbol: 'textSm', token: 'text.sm', source: '14px', emitted: 'CGFloat(224.00)', expected: 14, actual: 224 }],
+    ok: false,
+  }).join('\n');
+  assert.match(lines, /1\/2/);
+  assert.match(lines, /unit-fidelity/);
+  assert.match(lines, /textSm/);
+  assert.match(lines, /224/);
+});
+
+function runCli(args) {
+  try {
+    const stdout = execFileSync('node', ['scripts/validate-token-output.mjs', ...args], { encoding: 'utf8' });
+    return { code: 0, stdout };
+  } catch (e) {
+    return { code: e.status, stdout: `${e.stdout ?? ''}${e.stderr ?? ''}` };
+  }
+}
+
+test('CLI exits 2 when required arguments are missing', () => {
+  assert.equal(runCli([]).code, 2);
+});
+
+test('CLI exits 1 on a real failure and 0 on clean output', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'vto-'));
+  const src = join(dir, 'text.json');
+  writeFileSync(src, JSON.stringify({ text: { sm: { $value: '14px', $type: 'dimension' } } }));
+
+  const bad = join(dir, 'Bad.swift');
+  writeFileSync(bad, 'public static let textSm = CGFloat(224.00)\n');
+  assert.equal(runCli(['--source', src, '--output', bad, '--platform', 'ios-swift']).code, 1);
+
+  const good = join(dir, 'Good.swift');
+  writeFileSync(good, 'public static let textSm = CGFloat(14.00)\n');
+  assert.equal(runCli(['--source', src, '--output', good, '--platform', 'ios-swift']).code, 0);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test scripts/validate-token-output.test.mjs`
+Expected: FAIL — `formatReport is not a function`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `scripts/validate-token-output.mjs`:
+
+```js
+export function formatReport(r) {
+  const lines = [];
+  const pct = (r.matchRate * 100).toFixed(0);
+  lines.push(`tokens:validate-output — ${r.matched}/${r.total} emitted symbols matched a source token (${pct}%)`);
+  if (r.collisions.length) {
+    lines.push(`\n${r.collisions.length} mode collision(s) — the source list spans modes:`);
+    for (const c of r.collisions) {
+      lines.push(`  - ${c.path}: ${c.defs.map((d) => `${d.file}=${JSON.stringify(d.value)}`).join(', ')}`);
+    }
+  }
+  if (r.failures.length) {
+    lines.push(`\n${r.failures.length} rule failure(s):`);
+    for (const f of r.failures) {
+      lines.push(f.rule === 'unit-fidelity'
+        ? `  - [${f.rule}] ${f.symbol}: source ${f.source} expects ${f.expected}, emitted ${f.emitted} (${f.actual})`
+        : `  - [${f.rule}] ${f.symbol}: ${f.emitted}`);
+    }
+  }
+  if (r.matched === 0) {
+    lines.push(`\nNo emitted symbol matched any source token — the adapter's naming convention does not line up, so nothing was actually verified.`);
+  } else if (r.matchRate < r.minMatch) {
+    lines.push(`\nMatch rate ${pct}% is below the ${(r.minMatch * 100).toFixed(0)}% floor — most output went unchecked.`);
+  }
+  return lines;
+}
+
+function main() {
+  const { values } = parseArgs({
+    options: {
+      source: { type: 'string', multiple: true },
+      output: { type: 'string' },
+      platform: { type: 'string' },
+      'min-match': { type: 'string' },
+    },
+  });
+  if (!values.source?.length || !values.output || !values.platform) {
+    console.error('usage: validate-token-output.mjs --source <a.json> [--source <b.json>...] --output <Tokens.swift|Tokens.kt> --platform <ios-swift|android-kotlin> [--min-match <ratio>]');
+    process.exit(2);
+  }
+  const sources = values.source.map((file) => ({ file, dtcg: JSON.parse(readFileSync(file, 'utf8')) }));
+  const output = readFileSync(values.output, 'utf8');
+  const minMatch = values['min-match'] === undefined ? 0.5 : Number(values['min-match']);
+
+  let r;
+  try {
+    r = validate({ sources, output, platform: values.platform, minMatch });
+  } catch (e) {
+    console.error(e.message);
+    process.exit(2);
+  }
+  for (const line of formatReport(r)) console.log(line);
+  if (!r.ok) process.exit(1);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}
+```
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `node --test && node ci/validate-plugin.mjs && node ci/validate-skills.mjs`
+Expected: all PASS, 28 tests in this file
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/validate-token-output.mjs scripts/validate-token-output.test.mjs
+git commit -m "feat: validate-token-output CLI with reporting and exit codes"
+```
+
+---
+
+### Task 5: Verify against the real probe fixture
+
+The unit tests use small hand-built fixtures. This task proves the validator catches the actual failures on the actual token source that motivated it. It is a manual verification step producing no committed code — but if it does not reproduce the four findings, the implementation is wrong.
+
+**Files:**
+- No files changed. Uses `~/Dev/zygarden-frontend` (read-only, via `git show`).
+
+**Interfaces:**
+- Consumes: the finished CLI (Task 4).
+- Produces: confirmation only.
+
+- [ ] **Step 1: Build the fixture from the branch**
+
+```bash
+mkdir -p /tmp/vto-fixture/tokens
+cd ~/Dev/zygarden-frontend
+for f in $(git ls-tree -r --name-only feature/apply-brandguide-styles -- libs/shared/util-tokens/src/tokens); do
+  git show feature/apply-brandguide-styles:$f > /tmp/vto-fixture/tokens/$(basename $f)
+done
+ls /tmp/vto-fixture/tokens | wc -l   # expect 15
+```
+
+- [ ] **Step 2: Generate the known-bad native output**
+
+```bash
+cd /tmp/vto-fixture && npm init -y >/dev/null && npm i style-dictionary@^4 --silent
+cat > build.mjs <<'EOF'
+import SD from 'style-dictionary';
+const PRIMS = ['color-primitives','spacing-primitives','radius-primitives','stroke-primitives',
+  'text-primitives','typography-primitives','leading-primitives','radius-semantic','stroke-semantic'];
+const sd = new SD({
+  source: [...PRIMS.map((p) => `tokens/${p}.json`), 'tokens/color-semantic.light.json',
+           'tokens/spacing-semantic.mobile.json', 'tokens/typography-semantic.mobile.json'],
+  platforms: { ios: { transformGroup: 'ios-swift', buildPath: 'out/', options: { outputReferences: false },
+    files: [{ destination: 'Tokens.swift', format: 'ios-swift/enum.swift', options: { className: 'Tokens' } }] } },
+  log: { verbosity: 'silent', warnings: 'disabled' },
+});
+await sd.buildPlatform('ios');
+EOF
+node build.mjs
+```
+
+- [ ] **Step 3: Run the validator against it**
+
+```bash
+cd ~/Dev/throughline
+node scripts/validate-token-output.mjs \
+  --source /tmp/vto-fixture/tokens/text-primitives.json \
+  --source /tmp/vto-fixture/tokens/spacing-primitives.json \
+  --source /tmp/vto-fixture/tokens/typography-semantic.mobile.json \
+  --output /tmp/vto-fixture/out/Tokens.swift \
+  --platform ios-swift
+```
+
+Expected: exit `1`, with `unit-fidelity` failures reporting `source 14px expects 14, emitted CGFloat(224.00)`, plus `no-bare-units` failures on the `LineHeight` symbols.
+
+- [ ] **Step 4: Confirm the collision rule fires on the naive source list**
+
+```bash
+node scripts/validate-token-output.mjs \
+  --source /tmp/vto-fixture/tokens/spacing-semantic.mobile.json \
+  --source /tmp/vto-fixture/tokens/spacing-semantic.desktop.json \
+  --output /tmp/vto-fixture/out/Tokens.swift \
+  --platform ios-swift
+```
+
+Expected: exit `1`, reporting a `spacing.grid.columns` mode collision between the two files.
+
+- [ ] **Step 5: Clean up**
+
+```bash
+rm -rf /tmp/vto-fixture
+```
+
+No commit — this task changes no files.
+
+---
+
+### Task 6: Wire the validator into the sync skill and register it
+
+**Files:**
+- Modify: `skills/token-sync-layer/SKILL.md:150-151` (Step 3 verification) and Step 4
+- Modify: `scripts/README.md` (script table)
+
+**Interfaces:**
+- Consumes: the finished CLI (Task 4).
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Replace the blind verification criteria**
+
+In `skills/token-sync-layer/SKILL.md`, find this text inside the Step 3 "Execution model" paragraph:
+
+```
+each produces its
+platform's files and verifies them (the config builds, the expected files
+appear, references resolve for web / flatten for native)
+```
+
+Replace with:
+
+```
+each produces its
+platform's files and verifies them (for web: the config builds, the expected
+files appear, references resolve; for native: `tokens:validate-output` passes —
+"the config builds" is not verification, it is the condition under which all
+four known native failure modes ship silently)
+```
+
+- [ ] **Step 2: Add the native build + validation requirement to Step 3**
+
+In `skills/token-sync-layer/SKILL.md`, immediately after the paragraph beginning "Install and configure Style Dictionary v4", add:
+
+```markdown
+**Native targets build once per mode, and are validated.** A single build over
+the whole token directory silently drops a mode — Style Dictionary dedupes by
+dot-path, so a light and a dark definition of the same token collapse to
+whichever file sorted last. Configure one build per mode combination with an
+explicit source file list, then run `tokens:validate-output` against each
+generated file with that same list. See
+`${CLAUDE_PLUGIN_ROOT}/references/sync-adapters.md`.
+```
+
+- [ ] **Step 3: Add the install step**
+
+In `skills/token-sync-layer/SKILL.md`, in Step 4 after the sentence ending "any future app consume them.", add:
+
+```markdown
+**Install the output validator.** Copy
+`${CLAUDE_PLUGIN_ROOT}/scripts/validate-token-output.mjs` into
+`packages/tokens/scripts/` and register it so it stays a live gate on every
+future sync rather than a one-time check:
+
+```json
+"tokens:validate-output": "node scripts/validate-token-output.mjs"
+```
+
+Invoke it once per native output file, passing the same `--source` list that
+file's build used.
+```
+
+- [ ] **Step 4: Register the script in the table**
+
+In `scripts/README.md`, add this row to the table after the `guard-token-removal.mjs` row:
+
+```markdown
+| `validate-token-output.mjs` | Assert generated native token output matches its DTCG source: authored-unit fidelity, no leaked CSS syntax, no bare unit literals, no mode collisions. Fails on zero matches so it can never pass vacuously. | `tokens:validate-output` |
+```
+
+- [ ] **Step 5: Verify CI and commit**
+
+```bash
+node --test && node ci/validate-plugin.mjs && node ci/validate-skills.mjs
+git add skills/token-sync-layer/SKILL.md scripts/README.md
+git commit -m "feat: wire tokens:validate-output into the sync skill and register it"
+```
+
+---
+
+### Task 7: Correct the adapter reference and the README roadmap
+
+**Files:**
+- Modify: `references/sync-adapters.md:27-48` (Tier 1 table and following paragraph), plus a new section
+- Modify: `README.md:208` (roadmap bullet)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing.
+
+- [ ] **Step 1: Demote `ios-swift` out of Tier 1**
+
+In `references/sync-adapters.md`, delete this table row:
+
+```
+| `ios-swift` | Swift enum / asset catalog | light/dark asset variants | flattened | `Color.backgroundPrimary` |
+```
+
+Change the line above the table from `Five built-in adapters ship` to `Four built-in adapters ship`.
+
+- [ ] **Step 2: Rewrite the paragraph that justified five**
+
+Replace the paragraph beginning "These five were chosen for coverage" through "fully supported via Tier 2." with:
+
+```markdown
+These four were chosen for coverage of this plugin's web-first, design-led
+audience: three React framework adapters (shadcn — the dominant new-project
+choice; standalone Tailwind — for the large Tailwind-without-shadcn population;
+MUI — the enterprise/Material standard), plus the universal `vanilla-css`
+escape hatch (plain CSS custom properties, no framework). Everything else —
+Ant Design, Chakra, HeroUI, iOS/Swift, Android/Kotlin, Flutter, React Native,
+etc. — is fully supported via Tier 2.
+
+**`ios-swift` was curated and is not any more.** Run against a real DTCG source
+it emitted every dimension at ×16 the authored value (valid, compiling Swift),
+leaked `color-mix()` expressions, and left dual-node aliases as bare `px`
+literals — the same failures as the generated `android-kotlin` adapter, in the
+same counts. The tier did not predict quality, so the badge came off. Native
+targets go through the Tier 2 protocol, and `tokens:validate-output` is what
+now decides whether an adapter can be trusted. Re-promotion is available to any
+adapter that passes it against a real source.
+```
+
+- [ ] **Step 3: Add the constraints section**
+
+In `references/sync-adapters.md`, immediately before the `## Brownfield value transforms` heading, add:
+
+```markdown
+## What adapters cannot express
+
+These are all legal in a real DTCG source and all silently unsupported. An
+adapter that meets one emits wrong output without failing, which is why
+`tokens:validate-output` exists.
+
+- **CSS expressions in a value** — `color-mix(in srgb, {color.brand.500} 12%,
+  transparent)` is a runtime CSS construct. Flattening it for native means
+  computing the blend; Style Dictionary does not do colour math, and resolves
+  only the inner reference, leaving the function wrapper in the output.
+- **Dual-node tokens** — a node carrying both a `$value` and children (`text.sm`
+  with `$value: "14px"` plus a `text.sm.lineHeight` child). Style Dictionary's
+  resolver will not traverse into one, so every alias to the child fails to
+  resolve and emits as a bare literal.
+- **`%` and `em` dimensions** — parent-relative or container-relative, so there
+  is no build-time native magnitude.
+- **A third mode axis** — this reference models theme (`.dark` /
+  `[data-theme]`) and brand (`[data-brand]`). A viewport axis carrying its own
+  spacing and type scales is common and has no mapping here; on native it is
+  size classes and resource qualifiers, resolved by a different mechanism
+  entirely.
+
+**Native dimension transforms must read the authored unit.** The stock
+`ios-swift` and `compose` transform groups assume `rem` input and multiply by
+16. Against a `px`-authored source that silently produces output at sixteen
+times scale which compiles and ships. Emit 1:1 for `px` and unitless ratios;
+×16 only for `rem`.
+```
+
+- [ ] **Step 4: Split the README roadmap bullet**
+
+In `README.md`, replace line 208 (the bullet beginning `- **One library, many platforms**`) with:
+
+```markdown
+- **Token fan-out to more platforms** — the DTCG token source is platform-neutral, and web targets are in daily use. Native targets (iOS/Swift, Android/Kotlin) currently generate through the Tier 2 protocol and are **validated per build, not assumed** — `tokens:validate-output` checks generated native output against its source, because the stock transforms have been measured emitting wrong-but-compiling values.
+- **Native component code generation** — producing a SwiftUI view or a Compose composable the way Storybook components are produced for React. This does not exist yet; it is a separate, larger effort than token fan-out, and the two were previously described as one roadmap item.
+```
+
+- [ ] **Step 5: Verify CI and commit**
+
+```bash
+node --test && node ci/validate-plugin.mjs && node ci/validate-skills.mjs
+git add references/sync-adapters.md README.md
+git commit -m "docs: demote ios-swift from Tier 1, document adapter limits, split platform roadmap bullet"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** Every spec decision maps to a task: Decision 1 → Tasks 1–4; Decision 2 (unit table) → Task 3 `expectedMagnitude`; Decision 3 (source list + collision rule) → Task 3 `findModeCollisions` and Task 4 CLI `--source` multiple; Decision 4 (normalized key) → Task 3 `normalizeKey`; Decision 5 (dual-node resolver) → Task 1; Decision 6 (zero matches fails) → Task 3 `ok` and Task 4 report; Decision 7 (unmatched informational) → Task 3 `continue` on unmatched; Decision 8 (install as gate) → Task 6; Decision 9 (Tier 1 demotion) → Task 7; Decision 10 (what adapters cannot express) → Task 7 Step 3. The spec's four documented failure modes each have both a unit test (Task 3) and a real-fixture check (Task 5). The README change is Task 7 Step 4.
+
+**Placeholder scan.** No TBD/TODO. Every code step carries runnable code; every doc step carries exact replacement text rather than a description of it.
+
+**Type consistency.** `flattenDtcg` and `resolveValue` (Task 1) keep the signatures Task 3 calls. `extractDeclarations` returns `{ symbol, value }` in Task 2 and is destructured as `{ symbol, value }` in Task 3. `magnitudeOf` returns `number | null` and Task 3 tests `=== null`. `expectedMagnitude` returns `{ magnitude }` or `{ skip }` and Task 3 tests `.skip` then reads `.magnitude`. `validate` returns the same object shape `formatReport` consumes in Task 4, including `minMatch`, which Task 4's test fixture supplies.
+
+**One deviation worth naming:** Task 5 commits nothing. It is a verification gate rather than a deliverable, kept as its own task because a reviewer should be able to reject the implementation on it independently of the code review.

--- a/docs/superpowers/specs/2026-08-21-token-output-validation-design.md
+++ b/docs/superpowers/specs/2026-08-21-token-output-validation-design.md
@@ -216,11 +216,11 @@ match rate clears the floor; exit `1` otherwise.
 
 ## Non-goals
 
-- **Replacing Style Dictionary.** The probe showed zygarden dropped it and
-  replaced it with a 121-line direct DTCG emitter that handles all the
-  fundamental failures. `references/sync-adapters.md:82` states that *every*
-  adapter, both tiers, is a Style Dictionary v4 config preset — so this is a
-  live architectural question. It is deliberately out of scope: the validator
+- **Replacing Style Dictionary.** ⟨superseded — see the Correction below.⟩ The
+  probe showed zygarden dropped it and replaced it with a 121-line direct DTCG
+  emitter. `references/sync-adapters.md:82` states that *every* adapter, both
+  tiers, is a Style Dictionary v4 config preset — so this looked like a live
+  architectural question. It is deliberately out of scope: the validator
   compares source tokens against emitted text and does not depend on how the
   output was produced, so it stays valuable under either answer, and shipping it
   first means the eventual decision is made against measured output rather than
@@ -297,3 +297,49 @@ invented ones — the expected failures and their counts are known exactly:
 - **The validator cannot catch a wrong-but-plausible value that matches its
   source.** It verifies fidelity to the source, not that the source is right.
   Visual regression on native remains unaddressed and unrelated.
+
+## Correction (2026-08-21, post-merge investigation)
+
+**This spec's premise about Style Dictionary was wrong, and the Non-goals
+section overstated the case for replacing it.** Recording the correction here
+rather than editing the argument away, because the reasoning that led to the
+mistake is worth keeping.
+
+**What the spec implied.** That zygarden dropped Style Dictionary because it
+could not handle their token shapes, and that this was "a working existence
+proof" for throughline potentially doing the same.
+
+**What actually happened.** Zygarden removed SD in `zygarden-brand-guide`,
+Phase 4c-B, **May 2026 — before throughline existed**, in their own bespoke
+figma-sync pipeline. The commit (`841cdf6`) says SD's SCSS and JS platforms
+"have no consumers in the repo, so remove them," and explicitly notes that "SD
+outputs can be reintroduced later with custom logic if a consumer needs them."
+It was a YAGNI cleanup of dead output, not a verdict on the tool. A second
+commit calls the dependency "unused."
+
+**What a follow-up spike proved.** Style Dictionary v4, configured with a
+dual-node-aware preprocessor, a `color-mix` transform, and unit-aware dimension
+transforms — about 80 lines — emits **196/196 correct symbols with zero rule
+failures** from the same 322-token source, on both light and dark builds. Every
+failure in this spec's Problem section is a configuration defect, not a tool
+limitation:
+
+| Problem-section finding | Actual cause |
+|---|---|
+| ×16 on every px dimension | stock `size/swift/remToCGFloat` assumes `rem` |
+| 11 leaked `color-mix()` | no transform registered for it |
+| 14 bare `px`/`%` literals | SD's resolver not traversing dual-node nodes |
+| 864 path collisions | naive whole-directory source list (already disproven by the spec's own Run B) |
+
+**What still stands.** Everything the validator does. The four failure classes
+are real, they were measured, and the stock configuration does emit all of them
+at exit `0` — which is precisely why a validator was the right thing to build
+first. Shipping it before deciding the architecture is what made the correction
+possible: the spike's config was proven by running `tokens:validate-output`
+against its output.
+
+**What changed as a result.** The working configuration is documented at
+`references/native-adapter-config.md`, and `references/sync-adapters.md`'s
+constraints section is reframed from "what adapters cannot express" to "what the
+stock configuration gets wrong." Replacing Style Dictionary is no longer an open
+question — the answer is no.

--- a/docs/superpowers/specs/2026-08-21-token-output-validation-design.md
+++ b/docs/superpowers/specs/2026-08-21-token-output-validation-design.md
@@ -1,0 +1,299 @@
+# Token output validation — design
+
+**Date:** 2026-08-21
+**Status:** Proposed — revised after review
+
+> **Origin.** A probe ran throughline's two native adapters (`ios-swift`,
+> `android-kotlin`) against a real, shipping DTCG token source — zygarden's
+> `libs/shared/util-tokens` on branch `feature/apply-brandguide-styles`, 15
+> files, 322 `$value` entries. Both adapters exited `0` and produced output that
+> is roughly half wrong. This spec covers making that class of failure
+> detectable. It does **not** cover replacing Style Dictionary, which the probe
+> also put in question — see Non-goals.
+>
+> **Revision note.** A critic review found the first draft's CLI contract had no
+> mode axis, which broke its own symbol matching. Fixing that (Decision 3)
+> converted a fourth probe finding — the 864 silent collisions — from
+> undetectable into a validator rule. Four other findings are resolved inline
+> and marked ⟨rev⟩.
+
+## Problem
+
+`skills/token-sync-layer/SKILL.md:150` tells the agent to verify each generated
+adapter by checking that "the config builds, the expected files appear,
+references resolve for web / flatten for native."
+
+Every one of those checks passes on output that is unusable. The probe's
+evidence, the first three surviving a *correct* per-mode configuration and the
+fourth arising from the naive one:
+
+| Failure | Count | Detected today? |
+|---|---|---|
+| Dimensions emitted at ×16 the authored value | 34 of 35 px primitives; 80 `CGFloat` emissions carry it | No — valid, compiling code |
+| `color-mix()` expressions leaked into Swift/Kotlin | 11 per file | No — build exits 0 |
+| Bare `px` / `%` literals where an expression belongs | 14 per file | No — build exits 0 |
+| Whole theme dropped by path collision | 864 collisions, dark theme lost | No — build exits 0 |
+
+The ×16 case is the serious one. `text.sm: "14px"` emits `CGFloat(224.00)`.
+That is syntactically valid Swift, it compiles, it ships, and it renders every
+font and spacing value at sixteen times its intended size. The cause is that the
+`ios-swift` and `compose` transform groups assume dimension inputs are authored
+in `rem` and multiply by 16; zygarden authors in `px`. Nothing reconciles the
+assumption against the source.
+
+The others are loud or lossy, but all four get past throughline's own
+verification step and reach the user as "synced."
+
+Two facts sharpen why this is a plugin defect rather than a zygarden quirk:
+
+1. **The curated adapter failed identically to the generated one.**
+   `ios-swift` ships as Tier 1 in `references/sync-adapters.md:38` — a "vetted
+   preset, high confidence, no guessing." `android-kotlin` is Tier 2, explicitly
+   unverified. They produced the same failures in the same counts. The tier
+   distinction did not predict quality, which means the Tier 1 badge on
+   `ios-swift` is currently making a promise the probe disproves.
+
+2. **A precedent for the fix already exists in this repo.**
+   `scripts/validate-crosswalk.mjs` is described in `scripts/README.md` as
+   "resolve every `newToken` against the DTCG token source; assert resolved
+   value == `newValue`, N/N. The CI gate." That is the right shape, pointed at
+   generated native output instead of a crosswalk. Its *resolver* is not
+   reusable — see Decision 5.
+
+## Decisions
+
+1. **Ship a validator, don't just document the hazard.** The failure modes are
+   mechanical and so is their detection. A prose warning in `sync-adapters.md`
+   would not have caught any of the four findings; a script catches all four.
+   This also answers the standing critique that throughline's discipline is
+   documented rather than enforced.
+
+2. **Compare emitted values against the *authored unit*, not a fixed factor.**
+   A source value in `px` must emit 1:1 (iOS points and Android dp both map 1:1
+   to CSS px by convention); a source value in `rem` must emit at ×16. Today's
+   bug is this rule applied unconditionally in one direction. The validator
+   asserts the correct branch per token. ⟨rev⟩ The full unit table, including
+   the unitless and non-expressible cases present in the fixture:
+
+   | Authored | Expected native magnitude | Rationale |
+   |---|---|---|
+   | `px` | 1:1 | pt and dp map 1:1 to px by convention |
+   | `rem` | ×16 | root-relative, 16px root |
+   | unitless (e.g. `leading.tight: "1.1"`) | 1:1 | a ratio, not a length — never scaled |
+   | `%` | *not expressible* | flagged by `no-bare-units`; excluded from `unit-fidelity` |
+   | `em` | *not expressible* | parent-relative, unresolvable at build time |
+
+3. **⟨rev⟩ The validator takes the same explicit source file list the adapter
+   build used — not a directory — and treats a mode collision as a failure.**
+   108 of the fixture's 322 token paths are defined in more than one file with
+   different values per mode (`spacing.grid.columns` is `{spacing.space.3}` on
+   desktop and `{spacing.space.1}` on mobile; every `color.bg.*` differs between
+   light and dark). A directory glob therefore hands the matcher two or more
+   conflicting source values per token with no way to choose.
+
+   Passing the build's exact file list guarantees the validator and the build
+   see identical inputs, with no separate mode vocabulary to drift. To close the
+   case where *both* are wrong because the build globbed everything, a
+   `no-mode-collision` rule fails when any token path is defined more than once
+   with differing values across the given set. This is what makes the probe's
+   864 collisions detectable, and it is why the mode fix earns its own rule
+   rather than just a flag.
+
+4. **Match emitted symbols to source tokens by normalized key.** Adapters name
+   things differently (`color.bg.canvas` → `colorBgCanvas` in Swift,
+   `color_bg_canvas` elsewhere). The validator lowercases both sides and strips
+   every non-alphanumeric character, so both normalize to `colorbgcanvas`. The
+   review confirmed the fixture has no cross-token collisions under this scheme
+   once Decision 3 removes the mode-driven ones.
+
+5. **⟨rev⟩ Write a dual-node-aware resolver; the crosswalk resolver cannot be
+   reused.** A semantic token's unit lives on the primitive it references, so
+   aliases must resolve to a terminal literal before the unit is read. But
+   `flattenDtcg` in `scripts/validate-crosswalk.mjs:17-19` stops recursing at
+   the first `$value` node, silently dropping dual-node children like
+   `text.sm.lineHeight` — precisely the tokens most likely to be wrong. Zygarden's
+   `walkTokens` (`emit-css.mjs:41-56`) is the correct shape: yield the node's own
+   `$value` *and* keep descending into its non-`$`-prefixed children.
+
+6. **⟨rev⟩ Zero matches is a failure, not a clean pass.** Exit 0 must mean
+   "checked and correct," never "checked nothing." An adapter that renames
+   systematically (`bg` → `background`, exactly the pattern `sync-adapters.md:38`
+   shows with `Color.backgroundPrimary`) would match no tokens and pass every
+   rule vacuously. The validator fails on zero matches and reports the match
+   rate on every run; `--min-match <ratio>` (default `0.5`) sets a floor. The
+   default is a heuristic guard against a broken naming assumption, not a
+   correctness threshold, and is documented as such.
+
+7. **Unmatched symbols are informational.** An adapter may legitimately emit
+   tokens with no 1:1 source (composite text styles) or omit source tokens that
+   don't apply to the platform. Failing on these would make the validator
+   unusable; Decision 6 covers the case where the count is pathological.
+
+8. **Install it into the user's repo, not just run it once.** Following
+   `validate-crosswalk.mjs`'s model, the script is copied into
+   `packages/tokens/scripts/` and registered as an npm script, so it remains a
+   live gate on every future sync rather than a one-time check during setup.
+
+9. **Correct the Tier 1 claim now, on this evidence.** `ios-swift` moves out of
+   the curated table. This is not a deprecation — the adapter still works via
+   the Tier 2 path — it removes a confidence claim the probe falsified.
+   Re-promotion is available once it passes the validator against a real source.
+
+10. **State what the adapter contract cannot express.** CSS expressions,
+    dual-node DTCG, `%`/`em` dimensions, and a third mode axis are all legal in
+    real token sources and all silently unsupported today. Naming them costs a
+    short section and prevents the next silent failure.
+
+## The validator
+
+**File:** `scripts/validate-token-output.mjs`, with `scripts/validate-token-output.test.mjs`.
+Zero-dependency ESM, `parseArgs` CLI, exported functions for testing — matching
+every other script in `scripts/`.
+
+**Invocation:**
+
+```
+node validate-token-output.mjs \
+  --source <file.json...> \        # the exact list the adapter build used
+  --output <file.swift|file.kt> \
+  --platform <ios-swift|android-kotlin> \
+  [--min-match <ratio>]            # default 0.5
+```
+
+**⟨rev⟩ Extraction.** Emitted `(symbol, value)` pairs are read from the
+generated source with a per-platform declaration pattern — `public static let
+<name> = <value>` for Swift, `val <name> = <value>` for Kotlin — taking the
+remainder of the line as the raw value. Magnitude is then read from the known
+dimension wrappers: `CGFloat(N)`, `N.dp`, `N.sp`, or a bare numeric. Values that
+match no wrapper (colors such as `UIColor(red:…)` / `Color(0xff…)`, strings) are
+exempt from `unit-fidelity` and subject only to the syntax rules. Multi-argument
+constructors are never parsed for magnitude.
+
+**Four rules:**
+
+| Rule | Fails when | Catches |
+|---|---|---|
+| `unit-fidelity` | emitted magnitude ≠ expected magnitude for the authored unit (per Decision 2's table) | the ×16 scaling bug |
+| `no-foreign-syntax` | output value contains `color-mix(`, `calc(`, or `var(` | leaked CSS expressions |
+| `no-bare-units` | output value matches `/^-?(\d+(\.\d+)?\|\.\d+)(px\|rem\|em\|%)$/` | unresolved dual-node aliases |
+| `no-mode-collision` | a token path is defined more than once across `--source` with differing values | the 864 silent collisions |
+
+⟨rev⟩ The `no-bare-units` pattern admits negative and leading-dot magnitudes —
+the fixture contains `-0.03em` at `typography-primitives.json:33`, which the
+first draft's pattern would have passed.
+
+**Output:** a per-rule tally, the match rate, and a list of failing tokens with
+source value, emitted value, and rule name. Exit `0` when all rules pass and the
+match rate clears the floor; exit `1` otherwise.
+
+**Scope limits, stated rather than assumed:**
+
+- **Native source files only in v1.** The web adapters emit CSS where `var()`
+  and bare units are correct, so rules 2 and 3 invert there; a web mode is
+  deferred rather than guessed at.
+- **⟨rev⟩ Single output file per invocation.** `sync-adapters.md:38` describes
+  `ios-swift` storing colors in asset-catalog light/dark variants — many JSON
+  files. v1 validates the Swift/Kotlin source file only. Asset-catalog
+  validation is a deliberate v1 limit, not an oversight; per-mode builds mean
+  one invocation per mode already.
+
+## Changes to existing files
+
+- **`skills/token-sync-layer/SKILL.md`** — Step 3's verification criteria are
+  replaced with running the validator. The current wording ("the config builds,
+  the expected files appear, references resolve") is what let all four failures
+  through and must not survive. Step 4 gains the install + npm-script
+  registration, following the pattern `token-crosswalk-builder` uses.
+- **`references/sync-adapters.md`** — `ios-swift` removed from the Tier 1 table
+  (Decision 9); the curated set becomes four. Add a "What adapters cannot
+  express" section (Decision 10). Add the unit-awareness requirement to the
+  native-adapter description. Add the per-mode build requirement — the probe's
+  864 collisions came from the naive reading of "the DTCG JSON is the universal
+  input," which nothing currently warns against.
+- **`README.md`** — split the "One library, many platforms" roadmap bullet
+  (`README.md:208`) into an honest statement of current state.
+- **`scripts/README.md`** — register the new script in the table.
+
+## Non-goals
+
+- **Replacing Style Dictionary.** The probe showed zygarden dropped it and
+  replaced it with a 121-line direct DTCG emitter that handles all the
+  fundamental failures. `references/sync-adapters.md:82` states that *every*
+  adapter, both tiers, is a Style Dictionary v4 config preset — so this is a
+  live architectural question. It is deliberately out of scope: the validator
+  compares source tokens against emitted text and does not depend on how the
+  output was produced, so it stays valuable under either answer, and shipping it
+  first means the eventual decision is made against measured output rather than
+  argument.
+- **Fixing the transforms themselves.** The validator makes the ×16 bug
+  *detectable*. Making it *not happen* means a custom unit-aware transform per
+  native adapter, which is the natural next change but depends on the Style
+  Dictionary decision above.
+- **A web mode for the validator**, and **asset-catalog validation.** Both per
+  the Scope limits above.
+- **Per-platform component status, native component generation, mobile apps.**
+  All downstream of a working token layer.
+- **The viewport mode axis.** Documented as unsupported (Decision 10); mapping
+  it to size classes and resource qualifiers is its own design.
+
+## Phasing
+
+- **Phase 1 — validator + tests.** The script, its unit tests built from the
+  probe's real failure cases, and the `scripts/README.md` entry. Independently
+  verifiable: it must flag exactly the four findings on the probe fixture and
+  pass clean on a correct fixture.
+- **Phase 2 — wire it in.** `token-sync-layer` Step 3 verification and Step 4
+  install/registration.
+- **Phase 3 — doc corrections.** `sync-adapters.md` tier change and new section;
+  `README.md` roadmap bullet. No dependency on Phases 1–2; can land first if
+  preferred.
+
+## Testing
+
+`node --test` (repo convention), plus `node ci/validate-plugin.mjs` and
+`node ci/validate-skills.mjs` must stay green.
+
+Validator unit tests assert against cases taken from the probe rather than
+invented ones — the expected failures and their counts are known exactly:
+
+- `text.sm: "14px"` emitting `CGFloat(224.00)` → one `unit-fidelity` failure.
+- A `rem`-authored token emitting ×16 → passes (guards against over-correction).
+- ⟨rev⟩ `leading.tight: "1.1"` (unitless) emitting `1.1` → passes; emitting
+  `17.6` → one `unit-fidelity` failure.
+- `color-mix(in srgb, UIColor(...) 4%, transparent)` → one `no-foreign-syntax`
+  failure.
+- `typographyTextStyleBodyLgLineHeight = 24px` → one `no-bare-units` failure.
+- ⟨rev⟩ A bare `-0.03em` → one `no-bare-units` failure.
+- ⟨rev⟩ `spacing.grid.columns` present in both mobile and desktop sources with
+  differing values → one `no-mode-collision` failure.
+- ⟨rev⟩ An output whose symbols match no source token → exit 1 on zero matches,
+  not a vacuous pass.
+- A clean native file → exit 0, zero failures.
+- Symbol matching across camelCase / snake_case / kebab-case normalizes equal.
+- ⟨rev⟩ A dual-node source (`text.sm` with both `$value` and a `lineHeight`
+  child) → the resolver yields both, guarding the Decision 5 hole.
+
+## Risks / open items
+
+- **The 1:1 px→pt/dp rule is a convention, not a law.** It is the correct
+  default and matches how both platforms are used in practice, but a user
+  targeting a genuinely different density basis would see false failures. If
+  that surfaces, the rule needs an opt-out flag; adding one now would be
+  speculative.
+- **⟨rev⟩ `validate-crosswalk.mjs` has the same dual-node hole, in shipped
+  code.** `flattenDtcg:17-19` stops at the first `$value`, so crosswalk
+  validation silently skips dual-node children today. This spec does not fix it
+  — that is a separate change to a separate gate — but it is a real latent bug
+  and should be filed rather than forgotten.
+- **The extraction regexes are format-coupled.** They assume the
+  `ios-swift/enum.swift` and `compose/object` output shapes. A different format
+  option would need a different pattern; the validator should fail loudly on
+  zero parsed declarations rather than silently matching nothing (Decision 6
+  covers this).
+- **Removing `ios-swift` from Tier 1 is user-visible.** The curated set drops
+  from five to four. This is the honest move on the evidence, but it is a
+  documented capability reduction and should be called out in the changelog
+  rather than slipped in.
+- **The validator cannot catch a wrong-but-plausible value that matches its
+  source.** It verifies fidelity to the source, not that the source is right.
+  Visual regression on native remains unaddressed and unrelated.

--- a/references/manifest-schema.md
+++ b/references/manifest-schema.md
@@ -291,8 +291,8 @@ bailing or running silently.
 
 ### `sync`
 - `platforms` — array of adapter targets configured, e.g.
-  `["shadcn", "ios-swift"]`. Curated adapters map to vetted presets; any other
-  name is a generated (Tier 2) adapter.
+  `["shadcn", "android-kotlin"]`. Curated adapters map to vetted presets; any
+  other name is a generated (Tier 2) adapter.
 - `customAdapters` — names of validated generated adapters saved to
   `packages/tokens/adapters/` for reuse, so future syncs don't regenerate them.
 - `lastRun` — ISO timestamp the sync command last ran.

--- a/references/native-adapter-config.md
+++ b/references/native-adapter-config.md
@@ -1,0 +1,214 @@
+# Native adapter configuration
+
+The Style Dictionary configuration a native adapter (`ios-swift`, `android-kotlin`,
+or any generated native target) needs in order to emit **correct** output from a
+real DTCG token source.
+
+**Why this file exists.** The stock `ios-swift` and `compose` transform groups
+produce output that compiles and is wrong. Run against a real source, the stock
+configuration emitted every `px`-authored dimension at ×16 its authored value,
+leaked `color-mix()` expressions into Swift, and left dual-node aliases as bare
+`px` literals — all at exit `0`. None of that is a Style Dictionary limitation.
+All of it is configuration, and the four pieces below fix it.
+
+Verified: with this configuration, `tokens:validate-output` reports **196/196
+emitted symbols matched, zero rule failures**, on both the light and dark builds
+of a real 322-token DTCG source. The same source under the stock configuration
+produced roughly half-wrong output.
+
+Pair this with `${CLAUDE_PLUGIN_ROOT}/references/sync-adapters.md`, which covers
+the adapter contract itself.
+
+## The four pieces
+
+### 1. Preprocessor — resolve aliases, including into dual-node children
+
+Style Dictionary's resolver will not traverse into a node that carries both a
+`$value` and children. The dual-node pattern is legal DTCG and common in
+Figma-derived sources: `text.sm` holds `$value: "14px"` *and* a
+`text.sm.lineHeight` child. Every alias to such a child fails to resolve.
+
+Resolve aliases yourself, before Style Dictionary sees them. This also handles
+references embedded inside an expression, which SD's whole-value matcher misses.
+
+The dual-node-aware `flattenDtcg` and `resolveValue` this needs already ship at
+`${CLAUDE_PLUGIN_ROOT}/scripts/lib/dtcg.mjs` — import them rather than rewriting.
+
+```js
+import { flattenDtcg, resolveValue } from './lib/dtcg.mjs';
+
+function interpolate(value, flat) {
+  return value.replace(/\{([^}]+)\}/g, (m, ref) => {
+    try { return String(resolveValue(ref, flat)); } catch { return m; }
+  });
+}
+
+function resolveInPlace(node, flat, prefix = []) {
+  for (const [key, val] of Object.entries(node)) {
+    if (key.startsWith('$')) continue;
+    if (!val || typeof val !== 'object') continue;
+    const path = [...prefix, key];
+    if ('$value' in val && typeof val.$value === 'string') {
+      val.$value = /^\{[^}]+\}$/.test(val.$value)
+        ? resolveValue(path.join('.'), flat)
+        : interpolate(val.$value, flat);
+    }
+    resolveInPlace(val, flat, path);
+  }
+  return node;
+}
+```
+
+Pre-resolving costs nothing on native targets: they set
+`outputReferences: false` anyway, so references flatten to literals regardless.
+
+### 2. Preprocessor — hoist dual-node children so they get emitted
+
+Resolving aliases fixes the *references*. The children themselves still never
+become tokens, because SD's collector also stops at the first `$value` — so
+`text.sm.lineHeight` is never emitted as its own constant.
+
+Move each dual-node child to a sibling key. `text.sm.lineHeight` becomes
+`text.smLineHeight`, which `name/camel` renders as `textSmLineHeight` — the
+identical symbol name the un-hoisted path would have produced.
+
+```js
+function hoistDualNodes(node) {
+  for (const [key, val] of Object.entries(node)) {
+    if (key.startsWith('$') || !val || typeof val !== 'object') continue;
+    hoistDualNodes(val);
+    if ('$value' in val) {
+      for (const [ck, cv] of Object.entries(val)) {
+        if (ck.startsWith('$') || !cv || typeof cv !== 'object') continue;
+        node[key + ck[0].toUpperCase() + ck.slice(1)] = cv;
+        delete val[ck];
+      }
+    }
+  }
+  return node;
+}
+
+StyleDictionary.registerPreprocessor({
+  name: 'dtcg/resolve-dual-node',
+  preprocessor: (dict) =>
+    hoistDualNodes(resolveInPlace(structuredClone(dict), flattenDtcg(dict))),
+});
+```
+
+### 3. Transform — compute `color-mix()` to a literal
+
+A CSS expression has no native equivalent, and Style Dictionary does no colour
+math. `sync-adapters.md` says native adapters resolve to literals; for a
+`color-mix` that means actually computing the blend. Against `transparent` in
+`srgb` the result is the inner colour at the stated alpha.
+
+```js
+const MIX = /^color-mix\(in srgb,\s*(#[0-9a-fA-F]{6})\s+([\d.]+)%,\s*transparent\)$/;
+
+StyleDictionary.registerTransform({
+  name: 'value/color-mix-to-hex8', type: 'value', transitive: true,
+  filter: (t) => typeof t.$value === 'string' && MIX.test(t.$value),
+  transform: (t) => {
+    const [, hex, pct] = t.$value.match(MIX);
+    const a = Math.round((Number(pct) / 100) * 255).toString(16).padStart(2, '0');
+    return `${hex}${a}`;
+  },
+});
+```
+
+Register it **before** the platform's colour transform, so the colour transform
+receives a valid hex8 rather than a CSS function.
+
+### 4. Transform — read the authored unit
+
+**This replaces `size/swift/remToCGFloat` and the `size/compose/*` transforms,
+and it is the single most important change here.** Those assume every dimension
+is authored in `rem` and multiply by 16. Against a `px`-authored source that
+silently produces output at sixteen times scale which compiles and ships.
+
+Read the unit from `token.original.$value` and branch on it. iOS points and
+Android dp both map 1:1 to CSS px by convention; a unitless dimension is a ratio
+and is never scaled.
+
+```js
+function magnitude(orig) {
+  const m = String(orig).trim().match(/^(-?(?:\d+(?:\.\d+)?|\.\d+))([a-z%]*)$/);
+  if (!m) return null;
+  const n = Number(m[1]);
+  if (m[2] === 'px' || m[2] === '') return n;   // px 1:1; unitless ratio unscaled
+  if (m[2] === 'rem') return n * 16;
+  return null;                                   // % / em: no native equivalent
+}
+
+const isDim = (t) => magnitude(t.original?.$value ?? t.$value) !== null;
+
+StyleDictionary.registerTransform({
+  name: 'size/unit-aware/swift', type: 'value', transitive: true,
+  filter: (t) => t.$type === 'dimension' && isDim(t),
+  transform: (t) => `CGFloat(${magnitude(t.original?.$value ?? t.$value).toFixed(2)})`,
+});
+
+StyleDictionary.registerTransform({
+  name: 'size/unit-aware/compose', type: 'value', transitive: true,
+  filter: (t) => t.$type === 'dimension' && isDim(t),
+  transform: (t) => `${magnitude(t.original?.$value ?? t.$value).toFixed(2)}.dp`,
+});
+```
+
+## Assembling the platform
+
+Build the transform list explicitly rather than using a stock `transformGroup`,
+so the unit-aware transform replaces the rem-assuming one instead of running
+alongside it.
+
+```js
+platforms: {
+  ios: {
+    transforms: [
+      'attribute/cti', 'name/camel',
+      'value/color-mix-to-hex8', 'color/UIColorSwift',
+      'size/unit-aware/swift',
+    ],
+    buildPath: `out/${theme}-${viewport}/`,
+    options: { outputReferences: false },
+    files: [{
+      destination: 'Tokens.swift',
+      format: 'ios-swift/enum.swift',
+      options: { className: 'Tokens' },
+      filter: nativeFilter,
+    }],
+  },
+}
+```
+
+**Filter web-only units out.** `%` and `em` are container- or parent-relative,
+so there is no build-time native magnitude. Filter on the authored value, not on
+`$type` — a `100%` token may be typed `string`, not `dimension`:
+
+```js
+const nativeFilter = (t) =>
+  !/^-?[\d.]+(%|em)$/.test(String(t.original?.$value ?? t.$value).trim());
+```
+
+**One build per mode combination.** Style Dictionary deduplicates by dot-path,
+so a light and a dark definition of the same token collapse to whichever file
+sorted last — silently dropping a whole mode. Pass an explicit source list per
+mode; never glob the token directory. See `sync-adapters.md`.
+
+## Verify, always
+
+Configuration this specific is exactly what regresses unnoticed, because every
+failure mode above produces output that compiles. Run
+`tokens:validate-output` against each generated file with the same `--source`
+list that file's build used, and treat it as a gate rather than a spot check:
+
+```
+node scripts/validate-token-output.mjs \
+  --source tokens/color-primitives.json --source tokens/text-primitives.json \
+  ... \
+  --output out/light-mobile/Tokens.swift --platform ios-swift
+```
+
+A clean run reports 100% of emitted symbols matched with zero rule failures.
+Anything less means the configuration drifted — see
+`${CLAUDE_PLUGIN_ROOT}/scripts/README.md`.

--- a/references/sync-adapters.md
+++ b/references/sync-adapters.md
@@ -26,7 +26,7 @@ they're on** — this manages expectations honestly.
 
 ### Tier 1 — curated adapters (vetted presets)
 
-Five built-in adapters ship with framework-specific knowledge baked in. When the
+Four built-in adapters ship with framework-specific knowledge baked in. When the
 user names one of these, use the vetted preset — high confidence, no guessing.
 
 | Adapter | Values live in | Modes via | Sem→prim refs | Naming |
@@ -35,16 +35,23 @@ user names one of these, use the vetted preset — high confidence, no guessing.
 | `tailwind` | tailwind theme config | `dark:` variant / class strategy | preserved (via CSS vars) | `colors.background` |
 | `mui` | JS theme object | `createTheme` palettes | preserved (object refs) | `palette.primary.main` |
 | `vanilla-css` | one CSS file | `:root` + `[data-theme]` | preserved | `--color-bg-default` |
-| `ios-swift` | Swift enum / asset catalog | light/dark asset variants | flattened | `Color.backgroundPrimary` |
 
-These five were chosen for coverage of this plugin's web-first, design-led
+These four were chosen for coverage of this plugin's web-first, design-led
 audience: three React framework adapters (shadcn — the dominant new-project
 choice; standalone Tailwind — for the large Tailwind-without-shadcn population;
-MUI — the enterprise/Material standard), the universal `vanilla-css` escape
-hatch (plain CSS custom properties, no framework), and one native slot
-(`ios-swift`, the more standardized native pattern). Everything else —
-Ant Design, Chakra, HeroUI, Android/Kotlin, Flutter, React Native, etc. — is
-fully supported via Tier 2.
+MUI — the enterprise/Material standard), plus the universal `vanilla-css`
+escape hatch (plain CSS custom properties, no framework). Everything else —
+Ant Design, Chakra, HeroUI, iOS/Swift, Android/Kotlin, Flutter, React Native,
+etc. — is fully supported via Tier 2.
+
+**`ios-swift` was curated and is not any more.** Run against a real DTCG source
+it emitted every dimension at ×16 the authored value (valid, compiling Swift),
+leaked `color-mix()` expressions, and left dual-node aliases as bare `px`
+literals — the same failures as the generated `android-kotlin` adapter, in the
+same counts. The tier did not predict quality, so the badge came off. Native
+targets go through the Tier 2 protocol, and `tokens:validate-output` is what
+now decides whether an adapter can be trusted. Re-promotion is available to any
+adapter that passes it against a real source.
 
 `shadcn` vs `tailwind`: shadcn emits CSS vars *plus* the specific var names
 shadcn components expect; `tailwind` targets Tailwind used on its own, mapping
@@ -101,6 +108,34 @@ emit as references to primitive vars rather than flattened literals.
   values at build time, because the target language has no runtime var
   indirection. Modes map to the platform's native mechanism (asset catalog
   variants, resource qualifiers).
+
+## What adapters cannot express
+
+These are all legal in a real DTCG source and all silently unsupported. An
+adapter that meets one emits wrong output without failing, which is why
+`tokens:validate-output` exists.
+
+- **CSS expressions in a value** — `color-mix(in srgb, {color.brand.500} 12%,
+  transparent)` is a runtime CSS construct. Flattening it for native means
+  computing the blend; Style Dictionary does not do colour math, and resolves
+  only the inner reference, leaving the function wrapper in the output.
+- **Dual-node tokens** — a node carrying both a `$value` and children (`text.sm`
+  with `$value: "14px"` plus a `text.sm.lineHeight` child). Style Dictionary's
+  resolver will not traverse into one, so every alias to the child fails to
+  resolve and emits as a bare literal.
+- **`%` and `em` dimensions** — parent-relative or container-relative, so there
+  is no build-time native magnitude.
+- **A third mode axis** — this reference models theme (`.dark` /
+  `[data-theme]`) and brand (`[data-brand]`). A viewport axis carrying its own
+  spacing and type scales is common and has no mapping here; on native it is
+  size classes and resource qualifiers, resolved by a different mechanism
+  entirely.
+
+**Native dimension transforms must read the authored unit.** The stock
+`ios-swift` and `compose` transform groups assume `rem` input and multiply by
+16. Against a `px`-authored source that silently produces output at sixteen
+times scale which compiles and ships. Emit 1:1 for `px` and unitless ratios;
+×16 only for `rem`.
 
 ## Brownfield value transforms
 

--- a/references/sync-adapters.md
+++ b/references/sync-adapters.md
@@ -48,7 +48,7 @@ etc. — is fully supported via Tier 2.
 it emitted px-authored dimensions at ×16 their authored value (valid, compiling Swift),
 leaked `color-mix()` expressions, and left dual-node aliases as bare `px`
 literals — the same failures as the generated `android-kotlin` adapter, in the
-same counts. The tier did not predict quality, so the badge came off. Native
+same counts. The tier did not predict quality, so the badge came off. The cause was the stock transform group, not the adapter concept: configured per `${CLAUDE_PLUGIN_ROOT}/references/native-adapter-config.md`, the same source validates 196/196. Re-promotion is available once a native preset ships that configuration by default. Native
 targets go through the Tier 2 protocol, and `tokens:validate-output` is what
 now decides whether an adapter can be trusted. Re-promotion is available to any
 adapter that passes it against a real source.
@@ -109,22 +109,32 @@ emit as references to primitive vars rather than flattened literals.
   indirection. Modes map to the platform's native mechanism (asset catalog
   variants, resource qualifiers).
 
-## What adapters cannot express
+## What the stock configuration gets wrong
 
-These are all legal in a real DTCG source and all silently unsupported. An
-adapter that meets one emits wrong output without failing, which is why
-`tokens:validate-output` exists.
+These are all legal in a real DTCG source, and a **stock** Style Dictionary
+transform group mishandles every one of them silently — emitting output that
+compiles and is wrong, which is why `tokens:validate-output` exists.
+
+**None of these are Style Dictionary limitations.** All four are fixed by
+roughly 80 lines of preprocessor and transform code, given in
+`${CLAUDE_PLUGIN_ROOT}/references/native-adapter-config.md`, which has been
+verified to emit 196/196 correct symbols from a real 322-token source. Configure
+a native adapter from that file rather than from a stock `transformGroup`.
 
 - **CSS expressions in a value** — `color-mix(in srgb, {color.brand.500} 12%,
-  transparent)` is a runtime CSS construct. Flattening it for native means
-  computing the blend; Style Dictionary does not do colour math, and resolves
-  only the inner reference, leaving the function wrapper in the output.
+  transparent)` is a runtime CSS construct. Style Dictionary does no colour
+  math, so it resolves only the inner reference and leaves the function wrapper
+  in the output. *Fix: a transform that computes the blend to a literal.*
 - **Dual-node tokens** — a node carrying both a `$value` and children (`text.sm`
   with `$value: "14px"` plus a `text.sm.lineHeight` child). Style Dictionary's
   resolver will not traverse into one, so every alias to the child fails to
-  resolve and emits as a bare literal.
+  resolve and emits as a bare literal; its collector also stops there, so the
+  child is never emitted at all. *Fix: a preprocessor that resolves aliases and
+  hoists the children.*
 - **`%` and `em` dimensions** — parent-relative or container-relative, so there
-  is no build-time native magnitude.
+  genuinely is no build-time native magnitude. This one is a real limit rather
+  than a configuration gap. *Handling: filter them out of native builds — on the
+  authored value, since a `100%` token may be typed `string`, not `dimension`.*
 - **A third mode axis** — this reference models theme (`.dark` /
   `[data-theme]`) and brand (`[data-brand]`). A viewport axis carrying its own
   spacing and type scales is common and has no mapping here; on native it is

--- a/references/sync-adapters.md
+++ b/references/sync-adapters.md
@@ -45,7 +45,7 @@ Ant Design, Chakra, HeroUI, iOS/Swift, Android/Kotlin, Flutter, React Native,
 etc. — is fully supported via Tier 2.
 
 **`ios-swift` was curated and is not any more.** Run against a real DTCG source
-it emitted every dimension at ×16 the authored value (valid, compiling Swift),
+it emitted px-authored dimensions at ×16 their authored value (valid, compiling Swift),
 leaked `color-mix()` expressions, and left dual-node aliases as bare `px`
 literals — the same failures as the generated `android-kotlin` adapter, in the
 same counts. The tier did not predict quality, so the badge came off. Native
@@ -59,7 +59,7 @@ tokens into the Tailwind theme config. Related but distinct targets.
 
 ### Tier 2 — generated adapters (any other framework)
 
-When the user names a framework **not** in the curated five, the skill does NOT
+When the user names a framework **not** in the curated four, the skill does NOT
 refuse and does NOT pretend it's curated. It **generates an adapter** via a
 structured protocol:
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,7 +10,7 @@ tested here; copied verbatim by `token-crosswalk-builder` into the user's
 | `validate-crosswalk.mjs` | Resolve every `newToken` against the DTCG token source; assert resolved value == `newValue`, N/N. The CI gate. | `tokens:validate` |
 | `build-reverse-index.mjs` | Emit a `codeToken -> newToken` map from the crosswalk to semi-automate SCSS/Tailwind swaps. | `tokens:reverse-index` |
 | `guard-token-removal.mjs` | Grep `.ts/.tsx` (minus generated + tests) for about-to-be-deleted symbols; blocks cleanup until zero references remain. | run during the cleanup phase |
-| `validate-token-output.mjs` | Assert generated native token output matches its DTCG source: authored-unit fidelity, no leaked CSS syntax, no bare unit literals, no mode collisions. Fails on zero matches so it can never pass vacuously. | `tokens:validate-output` |
+| `validate-token-output.mjs` | Assert generated native token output matches its DTCG source: authored-unit fidelity, no leaked CSS syntax, no bare unit literals, no mode collisions. Fails when no emitted symbol matches a source token, and reports match rate, unparsed lines, and unemitted tokens on every run. | `tokens:validate-output` |
 | `lib/crosswalk.mjs` | Shared loader + structural validation for `crosswalk.json` (used by the validator and reverse-index). | copied alongside |
 | `crosswalk.schema.json` | The finalized JSON Schema for `crosswalk.json` (contract + editor support). | copied beside `crosswalk.json` |
 | `build-docs-digest.mjs` | Aggregate every `design-system/docs/components/*.doc.json` into `design-system/docs/index.json` + `llms.txt` for AI/human consumers. | `docs:digest` |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,6 +12,7 @@ tested here; copied verbatim by `token-crosswalk-builder` into the user's
 | `guard-token-removal.mjs` | Grep `.ts/.tsx` (minus generated + tests) for about-to-be-deleted symbols; blocks cleanup until zero references remain. | run during the cleanup phase |
 | `validate-token-output.mjs` | Assert generated native token output matches its DTCG source: authored-unit fidelity, no leaked CSS syntax, no bare unit literals, no mode collisions. Fails when no emitted symbol matches a source token, and reports match rate, unparsed lines, and unemitted tokens on every run. | `tokens:validate-output` |
 | `lib/crosswalk.mjs` | Shared loader + structural validation for `crosswalk.json` (used by the validator and reverse-index). | copied alongside |
+| `lib/dtcg.mjs` | Shared DTCG flatten + `{alias}` resolution. Dual-node aware: a node carrying both a `$value` and children yields its own value **and** is descended into. Used by `validate-crosswalk.mjs` and `validate-token-output.mjs`. | copied alongside both |
 | `crosswalk.schema.json` | The finalized JSON Schema for `crosswalk.json` (contract + editor support). | copied beside `crosswalk.json` |
 | `build-docs-digest.mjs` | Aggregate every `design-system/docs/components/*.doc.json` into `design-system/docs/index.json` + `llms.txt` for AI/human consumers. | `docs:digest` |
 | `docs-check.mjs` | Drift gate — verifies each component's doc surfaces still match its canonical record (via `lib/doc-record.mjs` fingerprints). Exits 1 on drift. | `docs:check` |
@@ -55,9 +56,9 @@ conflict, or remaining reference), `2` bad CLI arguments.
 
 ## How the skill installs these
 
-`token-crosswalk-builder` copies `lib/crosswalk.mjs`, `validate-crosswalk.mjs`,
-`build-reverse-index.mjs`, `guard-token-removal.mjs`, and `crosswalk.schema.json`
-into the user's `packages/tokens/scripts/` (schema beside `crosswalk.json`), then
+`token-crosswalk-builder` copies `lib/crosswalk.mjs`, `lib/dtcg.mjs`,
+`validate-crosswalk.mjs`, `build-reverse-index.mjs`, `guard-token-removal.mjs`, and
+`crosswalk.schema.json` into the user's `packages/tokens/scripts/` (schema beside `crosswalk.json`), then
 wires `packages/tokens/package.json`:
 
 ```jsonc
@@ -66,6 +67,11 @@ wires `packages/tokens/package.json`:
   "tokens:reverse-index": "node scripts/build-reverse-index.mjs --crosswalk crosswalk.json --out crosswalk.reverse.json"
 }
 ```
+
+`token-sync-layer` copies `validate-token-output.mjs` **and** `lib/dtcg.mjs`, and
+wires `"tokens:validate-output"`. Both validators import `lib/dtcg.mjs`, so it must
+travel with either one — installing a validator without it breaks the gate at
+import time.
 
 The scripts version with the user's repo so their CI runs them locally — a path
 inside the plugin install would not be reachable from the user's CI.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,6 +10,7 @@ tested here; copied verbatim by `token-crosswalk-builder` into the user's
 | `validate-crosswalk.mjs` | Resolve every `newToken` against the DTCG token source; assert resolved value == `newValue`, N/N. The CI gate. | `tokens:validate` |
 | `build-reverse-index.mjs` | Emit a `codeToken -> newToken` map from the crosswalk to semi-automate SCSS/Tailwind swaps. | `tokens:reverse-index` |
 | `guard-token-removal.mjs` | Grep `.ts/.tsx` (minus generated + tests) for about-to-be-deleted symbols; blocks cleanup until zero references remain. | run during the cleanup phase |
+| `validate-token-output.mjs` | Assert generated native token output matches its DTCG source: authored-unit fidelity, no leaked CSS syntax, no bare unit literals, no mode collisions. Fails on zero matches so it can never pass vacuously. | `tokens:validate-output` |
 | `lib/crosswalk.mjs` | Shared loader + structural validation for `crosswalk.json` (used by the validator and reverse-index). | copied alongside |
 | `crosswalk.schema.json` | The finalized JSON Schema for `crosswalk.json` (contract + editor support). | copied beside `crosswalk.json` |
 | `build-docs-digest.mjs` | Aggregate every `design-system/docs/components/*.doc.json` into `design-system/docs/index.json` + `llms.txt` for AI/human consumers. | `docs:digest` |

--- a/scripts/lib/dtcg.mjs
+++ b/scripts/lib/dtcg.mjs
@@ -1,0 +1,39 @@
+// Shared DTCG reading: flatten a token tree to dot-paths, resolve {alias} chains.
+// Zero dependencies. Consumed by validate-crosswalk.mjs and validate-token-output.mjs,
+// and copied alongside both when a skill installs either gate.
+
+const REF = /^\{([^}]+)\}$/;
+
+// Flatten nested DTCG groups into { "dot.path": rawValue }. Skips $-prefixed meta keys.
+//
+// A node carrying BOTH a $value and children yields its own value AND is descended
+// into — the dual-node pattern, where `text.sm` has `$value: "14px"` plus a
+// `text.sm.lineHeight` child. Stopping at the first $value drops those children,
+// which makes every alias to one unresolvable: the crosswalk gate reported them as
+// "missing from the DTCG source" though they exist, and the output validator could
+// not check them at all.
+export function flattenDtcg(obj, prefix = [], out = {}) {
+  for (const [key, val] of Object.entries(obj)) {
+    if (key.startsWith('$')) continue;
+    if (!val || typeof val !== 'object') continue;
+    const path = [...prefix, key];
+    if ('$value' in val) out[path.join('.')] = val.$value;
+    flattenDtcg(val, path, out);
+  }
+  return out;
+}
+
+// Follow {alias} chains to a leaf literal. Throws on missing or circular refs.
+export function resolveValue(name, flat, seen = new Set()) {
+  if (!(name in flat)) throw new Error(`token "${name}" not found in DTCG source`);
+  const val = flat[name];
+  if (typeof val === 'string') {
+    const m = val.match(REF);
+    if (m) {
+      if (seen.has(name)) throw new Error(`circular reference at "${name}"`);
+      seen.add(name);
+      return resolveValue(m[1], flat, seen);
+    }
+  }
+  return val;
+}

--- a/scripts/lib/dtcg.test.mjs
+++ b/scripts/lib/dtcg.test.mjs
@@ -1,0 +1,58 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { flattenDtcg, resolveValue } from './dtcg.mjs';
+
+// text.sm is a DUAL-NODE token: it carries its own $value AND a child.
+const dtcg = {
+  text: {
+    sm: {
+      $value: '14px',
+      $type: 'dimension',
+      lineHeight: { $value: '20px', $type: 'dimension' },
+    },
+  },
+  color: {
+    gray: { 900: { $value: '#111827', $type: 'color' } },
+    text: { primary: { $value: '{color.gray.900}', $type: 'color' } },
+  },
+  typography: {
+    body: { lineHeight: { $value: '{text.sm.lineHeight}', $type: 'dimension' } },
+  },
+};
+
+test('flattenDtcg produces dot-path keys with raw $value', () => {
+  const flat = flattenDtcg(dtcg);
+  assert.equal(flat['color.gray.900'], '#111827');
+  assert.equal(flat['color.text.primary'], '{color.gray.900}');
+});
+
+test('flattenDtcg yields a dual-node parent AND its child', () => {
+  const flat = flattenDtcg(dtcg);
+  assert.equal(flat['text.sm'], '14px');
+  assert.equal(flat['text.sm.lineHeight'], '20px');
+});
+
+test('flattenDtcg skips $-prefixed meta keys', () => {
+  const flat = flattenDtcg(dtcg);
+  assert.equal(flat['text.sm.$type'], undefined);
+  assert.equal(flat['text.sm.$value'], undefined);
+});
+
+test('resolveValue follows alias chains to a leaf', () => {
+  const flat = flattenDtcg(dtcg);
+  assert.equal(resolveValue('color.text.primary', flat), '#111827');
+  assert.equal(resolveValue('color.gray.900', flat), '#111827');
+});
+
+test('resolveValue follows an alias into a dual-node child', () => {
+  const flat = flattenDtcg(dtcg);
+  assert.equal(resolveValue('typography.body.lineHeight', flat), '20px');
+});
+
+test('resolveValue throws on a missing token', () => {
+  assert.throws(() => resolveValue('color.nope', {}), /not found/);
+});
+
+test('resolveValue throws on a circular reference', () => {
+  assert.throws(() => resolveValue('a', { a: '{b}', b: '{a}' }), /circular/);
+});

--- a/scripts/validate-crosswalk.mjs
+++ b/scripts/validate-crosswalk.mjs
@@ -7,36 +7,10 @@ import { readFileSync } from 'node:fs';
 import { parseArgs } from 'node:util';
 import { pathToFileURL } from 'node:url';
 import { loadCrosswalk, statusCounts } from './lib/crosswalk.mjs';
+import { flattenDtcg, resolveValue } from './lib/dtcg.mjs';
 
-const REF = /^\{([^}]+)\}$/;
-
-// Flatten nested DTCG groups into { "dot.path": rawValue }. Skips $-prefixed meta keys.
-export function flattenDtcg(obj, prefix = [], out = {}) {
-  for (const [key, val] of Object.entries(obj)) {
-    if (key.startsWith('$')) continue;
-    if (val && typeof val === 'object' && '$value' in val) {
-      out[[...prefix, key].join('.')] = val.$value;
-    } else if (val && typeof val === 'object') {
-      flattenDtcg(val, [...prefix, key], out);
-    }
-  }
-  return out;
-}
-
-// Follow {alias} chains to a leaf literal. Throws on missing or circular refs.
-export function resolveValue(name, flat, seen = new Set()) {
-  if (!(name in flat)) throw new Error(`token "${name}" not found in DTCG source`);
-  const val = flat[name];
-  if (typeof val === 'string') {
-    const m = val.match(REF);
-    if (m) {
-      if (seen.has(name)) throw new Error(`circular reference at "${name}"`);
-      seen.add(name);
-      return resolveValue(m[1], flat, seen);
-    }
-  }
-  return val;
-}
+// Re-exported so consumers (and the test file) keep one import surface.
+export { flattenDtcg, resolveValue };
 
 function norm(v) {
   return String(v).trim().toLowerCase();

--- a/scripts/validate-crosswalk.test.mjs
+++ b/scripts/validate-crosswalk.test.mjs
@@ -82,3 +82,26 @@ test('validate reports a token missing from the DTCG source', () => {
   assert.deepEqual(r.missing, ['color.ghost']);
   assert.equal(r.passed, 0);
 });
+
+// Regression: a dual-node DTCG token (`text.sm` carrying both a $value and a
+// `lineHeight` child) used to flatten to `text.sm` only, so a crosswalk row
+// pointing at the child was reported as "missing from the DTCG source" though
+// it exists. See scripts/lib/dtcg.mjs.
+test('validate resolves a crosswalk row pointing at a dual-node child', () => {
+  const dualNode = {
+    text: {
+      sm: {
+        $value: '14px',
+        $type: 'dimension',
+        lineHeight: { $value: '20px', $type: 'dimension' },
+      },
+    },
+  };
+  const crosswalk = { version: 1, tokens: [
+    { newToken: 'text.sm.lineHeight', newValue: '20px', tier: 'primitive', figmaOld: null, codeTokens: [], status: 'aligned', recommendedSemantic: null },
+    { newToken: 'text.sm', newValue: '14px', tier: 'primitive', figmaOld: null, codeTokens: [], status: 'aligned', recommendedSemantic: null },
+  ]};
+  const r = validate(crosswalk, dualNode);
+  assert.deepEqual(r.missing, []);
+  assert.equal(r.passed, 2);
+});

--- a/scripts/validate-token-output.mjs
+++ b/scripts/validate-token-output.mjs
@@ -49,13 +49,19 @@ const DECL = {
   'android-kotlin': /^\s*val\s+([A-Za-z_]\w*)\s*=\s*(.+?)\s*$/,
 };
 
+// Style Dictionary's ios-swift/enum.swift format emits an inline trailing
+// comment for any token carrying a $description ("... /** Small body text */").
+// Strip a TRAILING comment only — a value that legitimately contains "//"
+// inside a string literal must survive untouched.
+const TRAILING_COMMENT = /\s+(\/\*\*?[\s\S]*\*\/|\/\/.*)$/;
+
 export function extractDeclarations(text, platform) {
   const re = DECL[platform];
   if (!re) throw new Error(`unknown platform "${platform}"`);
   const out = [];
   for (const line of text.split('\n')) {
     const m = line.match(re);
-    if (m) out.push({ symbol: m[1], value: m[2] });
+    if (m) out.push({ symbol: m[1], value: m[2].replace(TRAILING_COMMENT, '').trim() });
   }
   return out;
 }
@@ -131,6 +137,31 @@ export function findModeCollisions(sources) {
 const FOREIGN = /(?:color-mix|calc|var)\s*\(/;
 const BARE_UNIT = /^-?(?:\d+(?:\.\d+)?|\.\d+)(?:px|rem|em|%)$/;
 
+// Lines that are obviously not a would-be token declaration: braces-only,
+// comments, imports/package/annotations, or the container declarations
+// (enum/object/class) themselves. Anything else that DECL failed to match is
+// a genuine unparsed line, not noise — conservatively under-count rather than
+// over-count (a false "unparsed" is noise the brief warns against).
+const STRUCTURAL_PREFIX = /^(\/\/|\/\*|\*|import\b|package\b|@)/;
+const STRUCTURAL_CONTAINS = /\b(enum|object|class)\s/;
+
+// Non-blank output lines DECL could not parse and that aren't structural —
+// the denominator's blind spot. Made visible, not enforced (Decision 6 only
+// covers zero matches).
+function countUnparsedLines(text, declRe) {
+  let count = 0;
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    if (declRe.test(line)) continue;
+    if (/^[{}]+$/.test(trimmed)) continue;
+    if (STRUCTURAL_PREFIX.test(trimmed)) continue;
+    if (STRUCTURAL_CONTAINS.test(trimmed)) continue;
+    count += 1;
+  }
+  return count;
+}
+
 export function validate({ sources, output, platform, minMatch = 0.5 }) {
   const collisions = findModeCollisions(sources);
 
@@ -162,7 +193,10 @@ export function validate({ sources, output, platform, minMatch = 0.5 }) {
     const expected = expectedMagnitude(source);
     if (expected.skip) continue;
     const actual = magnitudeOf(value);
-    if (actual === null) continue;
+    if (actual === null) {
+      failures.push({ rule: 'unverifiable-dimension', symbol, token: path, source, emitted: value });
+      continue;
+    }
     if (Math.abs(actual - expected.magnitude) > 0.001) {
       failures.push({ rule: 'unit-fidelity', symbol, token: path, source, emitted: value, expected: expected.magnitude, actual });
     }
@@ -170,7 +204,13 @@ export function validate({ sources, output, platform, minMatch = 0.5 }) {
 
   const matchRate = decls.length ? matched / decls.length : 0;
   const ok = failures.length === 0 && collisions.length === 0 && matched > 0 && matchRate >= minMatch;
-  return { total: decls.length, matched, matchRate, failures, collisions, minMatch, ok };
+
+  const unparsedLines = countUnparsedLines(output, DECL[platform]);
+  const emittedKeys = new Set(decls.map((d) => normalizeKey(d.symbol)));
+  let unemittedTokens = 0;
+  for (const key of byKey.keys()) if (!emittedKeys.has(key)) unemittedTokens += 1;
+
+  return { total: decls.length, matched, matchRate, failures, collisions, minMatch, ok, unparsedLines, unemittedTokens };
 }
 
 export function formatReport(r) {
@@ -186,15 +226,25 @@ export function formatReport(r) {
   if (r.failures.length) {
     lines.push(`\n${r.failures.length} rule failure(s):`);
     for (const f of r.failures) {
-      lines.push(f.rule === 'unit-fidelity'
-        ? `  - [${f.rule}] ${f.symbol}: source ${f.source} expects ${f.expected}, emitted ${f.emitted} (${f.actual})`
-        : `  - [${f.rule}] ${f.symbol}: ${f.emitted}`);
+      lines.push(
+        f.rule === 'unit-fidelity'
+          ? `  - [${f.rule}] ${f.symbol}: source ${f.source} expects ${f.expected}, emitted ${f.emitted} (${f.actual})`
+          : f.rule === 'unverifiable-dimension'
+            ? `  - [${f.rule}] ${f.symbol}: source ${f.source} has a dimension magnitude but emitted ${f.emitted} could not be read — the token was never actually compared`
+            : `  - [${f.rule}] ${f.symbol}: ${f.emitted}`,
+      );
     }
   }
   if (r.matched === 0) {
-    lines.push(`\nNo emitted symbol matched any source token — the adapter's naming convention does not line up, so nothing was actually verified.`);
+    lines.push(`\nNo emitted symbol matched any source token — the adapter's naming convention does not line up, so nothing was actually verified. A likely cause is a declaration form the DECL pattern does not match (e.g. a different accessControl such as "internal static let ...").`);
   } else if (r.matchRate < r.minMatch) {
     lines.push(`\nMatch rate ${pct}% is below the ${(r.minMatch * 100).toFixed(0)}% floor — most output went unchecked.`);
+  }
+  if (r.unparsedLines) {
+    lines.push(`\n${r.unparsedLines} unparsed line(s) — declaration-shaped lines the extractor could not read; they count in neither the numerator nor the denominator above.`);
+  }
+  if (r.unemittedTokens) {
+    lines.push(`\n${r.unemittedTokens} source token(s) had no matching emitted symbol.`);
   }
   return lines;
 }
@@ -221,12 +271,14 @@ function main() {
     process.exit(2);
   }
 
-  let sources;
-  try {
-    sources = values.source.map((file) => ({ file, dtcg: JSON.parse(readFileSync(file, 'utf8')) }));
-  } catch (e) {
-    console.error(`error reading or parsing ${e.path || 'source file'}: ${e.message}`);
-    process.exit(2);
+  const sources = [];
+  for (const file of values.source) {
+    try {
+      sources.push({ file, dtcg: JSON.parse(readFileSync(file, 'utf8')) });
+    } catch (e) {
+      console.error(`error reading or parsing ${file}: ${e.message}`);
+      process.exit(2);
+    }
   }
 
   let output;

--- a/scripts/validate-token-output.mjs
+++ b/scripts/validate-token-output.mjs
@@ -172,3 +172,61 @@ export function validate({ sources, output, platform, minMatch = 0.5 }) {
   const ok = failures.length === 0 && collisions.length === 0 && matched > 0 && matchRate >= minMatch;
   return { total: decls.length, matched, matchRate, failures, collisions, minMatch, ok };
 }
+
+export function formatReport(r) {
+  const lines = [];
+  const pct = (r.matchRate * 100).toFixed(0);
+  lines.push(`tokens:validate-output — ${r.matched}/${r.total} emitted symbols matched a source token (${pct}%)`);
+  if (r.collisions.length) {
+    lines.push(`\n${r.collisions.length} mode collision(s) — the source list spans modes:`);
+    for (const c of r.collisions) {
+      lines.push(`  - ${c.path}: ${c.defs.map((d) => `${d.file}=${JSON.stringify(d.value)}`).join(', ')}`);
+    }
+  }
+  if (r.failures.length) {
+    lines.push(`\n${r.failures.length} rule failure(s):`);
+    for (const f of r.failures) {
+      lines.push(f.rule === 'unit-fidelity'
+        ? `  - [${f.rule}] ${f.symbol}: source ${f.source} expects ${f.expected}, emitted ${f.emitted} (${f.actual})`
+        : `  - [${f.rule}] ${f.symbol}: ${f.emitted}`);
+    }
+  }
+  if (r.matched === 0) {
+    lines.push(`\nNo emitted symbol matched any source token — the adapter's naming convention does not line up, so nothing was actually verified.`);
+  } else if (r.matchRate < r.minMatch) {
+    lines.push(`\nMatch rate ${pct}% is below the ${(r.minMatch * 100).toFixed(0)}% floor — most output went unchecked.`);
+  }
+  return lines;
+}
+
+function main() {
+  const { values } = parseArgs({
+    options: {
+      source: { type: 'string', multiple: true },
+      output: { type: 'string' },
+      platform: { type: 'string' },
+      'min-match': { type: 'string' },
+    },
+  });
+  if (!values.source?.length || !values.output || !values.platform) {
+    console.error('usage: validate-token-output.mjs --source <a.json> [--source <b.json>...] --output <Tokens.swift|Tokens.kt> --platform <ios-swift|android-kotlin> [--min-match <ratio>]');
+    process.exit(2);
+  }
+  const sources = values.source.map((file) => ({ file, dtcg: JSON.parse(readFileSync(file, 'utf8')) }));
+  const output = readFileSync(values.output, 'utf8');
+  const minMatch = values['min-match'] === undefined ? 0.5 : Number(values['min-match']);
+
+  let r;
+  try {
+    r = validate({ sources, output, platform: values.platform, minMatch });
+  } catch (e) {
+    console.error(e.message);
+    process.exit(2);
+  }
+  for (const line of formatReport(r)) console.log(line);
+  if (!r.ok) process.exit(1);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/validate-token-output.mjs
+++ b/scripts/validate-token-output.mjs
@@ -75,3 +75,99 @@ export function magnitudeOf(value) {
   }
   return null;
 }
+
+// Adapters name tokens differently (color.bg.canvas -> colorBgCanvas -> color_bg_canvas).
+// Lowercase and strip every non-alphanumeric so all conventions compare equal.
+export function normalizeKey(s) {
+  return String(s).toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+const UNIT = /^(-?(?:\d+(?:\.\d+)?|\.\d+))([a-z%]*)$/;
+
+// Expected native magnitude for an authored source value. iOS points and Android
+// dp both map 1:1 to CSS px by convention; rem is root-relative at a 16px root;
+// a unitless dimension is a ratio and is never scaled. % and em have no native
+// equivalent, so they are skipped here and caught by no-bare-units if emitted raw.
+export function expectedMagnitude(sourceValue) {
+  if (typeof sourceValue === 'number') return { magnitude: sourceValue };
+  if (typeof sourceValue !== 'string') return { skip: 'non-scalar' };
+  const m = sourceValue.trim().match(UNIT);
+  if (!m) return { skip: 'not-a-dimension' };
+  const n = Number(m[1]);
+  switch (m[2]) {
+    case 'px':
+    case '':
+      return { magnitude: n };
+    case 'rem':
+      return { magnitude: n * 16 };
+    case '%':
+    case 'em':
+      return { skip: 'not-expressible' };
+    default:
+      return { skip: 'not-a-dimension' };
+  }
+}
+
+// A token path defined in more than one source file with differing values means
+// the build's source list spans modes. Style Dictionary dedupes these silently,
+// dropping one whole mode — 864 such collisions produced a light-only build from
+// a dark-default system.
+export function findModeCollisions(sources) {
+  const seen = new Map();
+  for (const { file, dtcg } of sources) {
+    for (const [path, value] of Object.entries(flattenDtcg(dtcg))) {
+      if (!seen.has(path)) seen.set(path, []);
+      seen.get(path).push({ file, value });
+    }
+  }
+  const collisions = [];
+  for (const [path, defs] of seen) {
+    const distinct = new Set(defs.map((d) => JSON.stringify(d.value)));
+    if (defs.length > 1 && distinct.size > 1) collisions.push({ path, defs });
+  }
+  return collisions;
+}
+
+const FOREIGN = /(?:color-mix|calc|var)\s*\(/;
+const BARE_UNIT = /^-?(?:\d+(?:\.\d+)?|\.\d+)(?:px|rem|em|%)$/;
+
+export function validate({ sources, output, platform, minMatch = 0.5 }) {
+  const collisions = findModeCollisions(sources);
+
+  const flat = {};
+  for (const { dtcg } of sources) Object.assign(flat, flattenDtcg(dtcg));
+
+  const byKey = new Map();
+  for (const path of Object.keys(flat)) byKey.set(normalizeKey(path), path);
+
+  const decls = extractDeclarations(output, platform);
+  const failures = [];
+  let matched = 0;
+
+  for (const { symbol, value } of decls) {
+    if (FOREIGN.test(value)) failures.push({ rule: 'no-foreign-syntax', symbol, emitted: value });
+    if (BARE_UNIT.test(value)) failures.push({ rule: 'no-bare-units', symbol, emitted: value });
+
+    const path = byKey.get(normalizeKey(symbol));
+    if (!path) continue;
+    matched += 1;
+
+    let source;
+    try {
+      source = resolveValue(path, flat);
+    } catch {
+      continue;
+    }
+    const expected = expectedMagnitude(source);
+    if (expected.skip) continue;
+    const actual = magnitudeOf(value);
+    if (actual === null) continue;
+    if (Math.abs(actual - expected.magnitude) > 0.001) {
+      failures.push({ rule: 'unit-fidelity', symbol, token: path, source, emitted: value, expected: expected.magnitude, actual });
+    }
+  }
+
+  const matchRate = decls.length ? matched / decls.length : 0;
+  const ok = failures.length === 0 && collisions.length === 0 && matched > 0 && matchRate >= minMatch;
+  return { total: decls.length, matched, matchRate, failures, collisions, minMatch, ok };
+}

--- a/scripts/validate-token-output.mjs
+++ b/scripts/validate-token-output.mjs
@@ -200,21 +200,53 @@ export function formatReport(r) {
 }
 
 function main() {
-  const { values } = parseArgs({
-    options: {
-      source: { type: 'string', multiple: true },
-      output: { type: 'string' },
-      platform: { type: 'string' },
-      'min-match': { type: 'string' },
-    },
-  });
+  let values;
+  try {
+    const parsed = parseArgs({
+      options: {
+        source: { type: 'string', multiple: true },
+        output: { type: 'string' },
+        platform: { type: 'string' },
+        'min-match': { type: 'string' },
+      },
+    });
+    values = parsed.values;
+  } catch (e) {
+    console.error(e.message);
+    process.exit(2);
+  }
+
   if (!values.source?.length || !values.output || !values.platform) {
     console.error('usage: validate-token-output.mjs --source <a.json> [--source <b.json>...] --output <Tokens.swift|Tokens.kt> --platform <ios-swift|android-kotlin> [--min-match <ratio>]');
     process.exit(2);
   }
-  const sources = values.source.map((file) => ({ file, dtcg: JSON.parse(readFileSync(file, 'utf8')) }));
-  const output = readFileSync(values.output, 'utf8');
-  const minMatch = values['min-match'] === undefined ? 0.5 : Number(values['min-match']);
+
+  let sources;
+  try {
+    sources = values.source.map((file) => ({ file, dtcg: JSON.parse(readFileSync(file, 'utf8')) }));
+  } catch (e) {
+    console.error(`error reading or parsing ${e.path || 'source file'}: ${e.message}`);
+    process.exit(2);
+  }
+
+  let output;
+  try {
+    output = readFileSync(values.output, 'utf8');
+  } catch (e) {
+    console.error(`error reading output file ${values.output}: ${e.message}`);
+    process.exit(2);
+  }
+
+  let minMatch;
+  try {
+    minMatch = values['min-match'] === undefined ? 0.5 : Number(values['min-match']);
+    if (!Number.isFinite(minMatch)) {
+      throw new Error(`--min-match must be a finite number, got "${values['min-match']}"`);
+    }
+  } catch (e) {
+    console.error(e.message);
+    process.exit(2);
+  }
 
   let r;
   try {

--- a/scripts/validate-token-output.mjs
+++ b/scripts/validate-token-output.mjs
@@ -1,0 +1,42 @@
+// Native token output validator: assert generated Swift/Kotlin matches its DTCG source.
+// Catches output that compiles but is wrong. Zero dependencies.
+//
+// Usage:
+//   node validate-token-output.mjs --source a.json --source b.json \
+//     --output Tokens.swift --platform ios-swift [--min-match 0.5]
+import { readFileSync } from 'node:fs';
+import { parseArgs } from 'node:util';
+import { pathToFileURL } from 'node:url';
+
+const REF = /^\{([^}]+)\}$/;
+
+// Flatten nested DTCG groups into { "dot.path": rawValue }.
+// Unlike validate-crosswalk.mjs's flattenDtcg, a node carrying BOTH a $value and
+// children yields its own value AND is descended into — the dual-node pattern
+// (text.sm has $value "14px" plus a lineHeight child). Stopping at the first
+// $value silently drops those children.
+export function flattenDtcg(obj, prefix = [], out = {}) {
+  for (const [key, val] of Object.entries(obj)) {
+    if (key.startsWith('$')) continue;
+    if (!val || typeof val !== 'object') continue;
+    const path = [...prefix, key];
+    if ('$value' in val) out[path.join('.')] = val.$value;
+    flattenDtcg(val, path, out);
+  }
+  return out;
+}
+
+// Follow {alias} chains to a leaf literal. Throws on missing or circular refs.
+export function resolveValue(name, flat, seen = new Set()) {
+  if (!(name in flat)) throw new Error(`token "${name}" not found in DTCG source`);
+  const val = flat[name];
+  if (typeof val === 'string') {
+    const m = val.match(REF);
+    if (m) {
+      if (seen.has(name)) throw new Error(`circular reference at "${name}"`);
+      seen.add(name);
+      return resolveValue(m[1], flat, seen);
+    }
+  }
+  return val;
+}

--- a/scripts/validate-token-output.mjs
+++ b/scripts/validate-token-output.mjs
@@ -40,3 +40,38 @@ export function resolveValue(name, flat, seen = new Set()) {
   }
   return val;
 }
+
+// Declaration patterns per platform. Coupled to the ios-swift/enum.swift and
+// compose/object output formats; a different format needs a different pattern,
+// which surfaces as a zero-match failure rather than a silent pass.
+const DECL = {
+  'ios-swift': /^\s*(?:public\s+)?static\s+let\s+([A-Za-z_]\w*)\s*=\s*(.+?)\s*$/,
+  'android-kotlin': /^\s*val\s+([A-Za-z_]\w*)\s*=\s*(.+?)\s*$/,
+};
+
+export function extractDeclarations(text, platform) {
+  const re = DECL[platform];
+  if (!re) throw new Error(`unknown platform "${platform}"`);
+  const out = [];
+  for (const line of text.split('\n')) {
+    const m = line.match(re);
+    if (m) out.push({ symbol: m[1], value: m[2] });
+  }
+  return out;
+}
+
+// Known dimension wrappers. Multi-argument constructors (colors) never match,
+// so they are exempt from unit-fidelity by construction.
+const MAGNITUDE = [
+  /^CGFloat\(\s*(-?(?:\d+(?:\.\d+)?|\.\d+))\s*\)$/,
+  /^(-?(?:\d+(?:\.\d+)?|\.\d+))\.(?:dp|sp)$/,
+  /^(-?(?:\d+(?:\.\d+)?|\.\d+))$/,
+];
+
+export function magnitudeOf(value) {
+  for (const re of MAGNITUDE) {
+    const m = value.match(re);
+    if (m) return Number(m[1]);
+  }
+  return null;
+}

--- a/scripts/validate-token-output.mjs
+++ b/scripts/validate-token-output.mjs
@@ -150,7 +150,6 @@ export function validate({ sources, output, platform, minMatch = 0.5 }) {
 
     const path = byKey.get(normalizeKey(symbol));
     if (!path) continue;
-    matched += 1;
 
     let source;
     try {
@@ -158,6 +157,8 @@ export function validate({ sources, output, platform, minMatch = 0.5 }) {
     } catch {
       continue;
     }
+    matched += 1;
+
     const expected = expectedMagnitude(source);
     if (expected.skip) continue;
     const actual = magnitudeOf(value);

--- a/scripts/validate-token-output.mjs
+++ b/scripts/validate-token-output.mjs
@@ -7,39 +7,10 @@
 import { readFileSync } from 'node:fs';
 import { parseArgs } from 'node:util';
 import { pathToFileURL } from 'node:url';
+import { flattenDtcg, resolveValue } from './lib/dtcg.mjs';
 
-const REF = /^\{([^}]+)\}$/;
-
-// Flatten nested DTCG groups into { "dot.path": rawValue }.
-// Unlike validate-crosswalk.mjs's flattenDtcg, a node carrying BOTH a $value and
-// children yields its own value AND is descended into — the dual-node pattern
-// (text.sm has $value "14px" plus a lineHeight child). Stopping at the first
-// $value silently drops those children.
-export function flattenDtcg(obj, prefix = [], out = {}) {
-  for (const [key, val] of Object.entries(obj)) {
-    if (key.startsWith('$')) continue;
-    if (!val || typeof val !== 'object') continue;
-    const path = [...prefix, key];
-    if ('$value' in val) out[path.join('.')] = val.$value;
-    flattenDtcg(val, path, out);
-  }
-  return out;
-}
-
-// Follow {alias} chains to a leaf literal. Throws on missing or circular refs.
-export function resolveValue(name, flat, seen = new Set()) {
-  if (!(name in flat)) throw new Error(`token "${name}" not found in DTCG source`);
-  const val = flat[name];
-  if (typeof val === 'string') {
-    const m = val.match(REF);
-    if (m) {
-      if (seen.has(name)) throw new Error(`circular reference at "${name}"`);
-      seen.add(name);
-      return resolveValue(m[1], flat, seen);
-    }
-  }
-  return val;
-}
+// Re-exported so consumers (and the test file) keep one import surface.
+export { flattenDtcg, resolveValue };
 
 // Declaration patterns per platform. Coupled to the ios-swift/enum.swift and
 // compose/object output formats; a different format needs a different pattern,

--- a/scripts/validate-token-output.test.mjs
+++ b/scripts/validate-token-output.test.mjs
@@ -199,3 +199,48 @@ test('unit-fidelity handles rem-authored tokens emitting ×16 correctly (guards 
   assert.deepEqual(r.failures, []);
   assert.equal(r.ok, true);
 });
+
+import { formatReport } from './validate-token-output.mjs';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+test('formatReport states the match rate and every failure', () => {
+  const lines = formatReport({
+    total: 2, matched: 1, matchRate: 0.5, minMatch: 0.5, collisions: [],
+    failures: [{ rule: 'unit-fidelity', symbol: 'textSm', token: 'text.sm', source: '14px', emitted: 'CGFloat(224.00)', expected: 14, actual: 224 }],
+    ok: false,
+  }).join('\n');
+  assert.match(lines, /1\/2/);
+  assert.match(lines, /unit-fidelity/);
+  assert.match(lines, /textSm/);
+  assert.match(lines, /224/);
+});
+
+function runCli(args) {
+  try {
+    const stdout = execFileSync('node', ['scripts/validate-token-output.mjs', ...args], { encoding: 'utf8' });
+    return { code: 0, stdout };
+  } catch (e) {
+    return { code: e.status, stdout: `${e.stdout ?? ''}${e.stderr ?? ''}` };
+  }
+}
+
+test('CLI exits 2 when required arguments are missing', () => {
+  assert.equal(runCli([]).code, 2);
+});
+
+test('CLI exits 1 on a real failure and 0 on clean output', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'vto-'));
+  const src = join(dir, 'text.json');
+  writeFileSync(src, JSON.stringify({ text: { sm: { $value: '14px', $type: 'dimension' } } }));
+
+  const bad = join(dir, 'Bad.swift');
+  writeFileSync(bad, 'public static let textSm = CGFloat(224.00)\n');
+  assert.equal(runCli(['--source', src, '--output', bad, '--platform', 'ios-swift']).code, 1);
+
+  const good = join(dir, 'Good.swift');
+  writeFileSync(good, 'public static let textSm = CGFloat(14.00)\n');
+  assert.equal(runCli(['--source', src, '--output', good, '--platform', 'ios-swift']).code, 0);
+});

--- a/scripts/validate-token-output.test.mjs
+++ b/scripts/validate-token-output.test.mjs
@@ -87,3 +87,99 @@ test('magnitudeOf returns null for non-dimension values', () => {
   assert.equal(magnitudeOf('Color(0xffffffff)'), null);
   assert.equal(magnitudeOf('24px'), null);
 });
+
+import { normalizeKey, expectedMagnitude, findModeCollisions, validate } from './validate-token-output.mjs';
+
+test('normalizeKey collapses camelCase, snake_case, kebab-case, and dot paths', () => {
+  assert.equal(normalizeKey('color.bg.canvas'), 'colorbgcanvas');
+  assert.equal(normalizeKey('colorBgCanvas'), 'colorbgcanvas');
+  assert.equal(normalizeKey('color_bg_canvas'), 'colorbgcanvas');
+  assert.equal(normalizeKey('color-bg-canvas'), 'colorbgcanvas');
+});
+
+test('expectedMagnitude applies the authored unit, never a fixed factor', () => {
+  assert.deepEqual(expectedMagnitude('14px'), { magnitude: 14 });
+  assert.deepEqual(expectedMagnitude('1rem'), { magnitude: 16 });
+  assert.deepEqual(expectedMagnitude('1.1'), { magnitude: 1.1 });
+});
+
+test('expectedMagnitude skips units with no native equivalent', () => {
+  assert.ok(expectedMagnitude('100%').skip);
+  assert.ok(expectedMagnitude('-0.03em').skip);
+  assert.ok(expectedMagnitude('#ffffff').skip);
+});
+
+test('findModeCollisions flags a path defined twice with different values', () => {
+  const sources = [
+    { file: 'mobile.json', dtcg: { spacing: { grid: { columns: { $value: '{spacing.space.1}' } } } } },
+    { file: 'desktop.json', dtcg: { spacing: { grid: { columns: { $value: '{spacing.space.3}' } } } } },
+  ];
+  const c = findModeCollisions(sources);
+  assert.equal(c.length, 1);
+  assert.equal(c[0].path, 'spacing.grid.columns');
+});
+
+test('findModeCollisions ignores a path repeated with the SAME value', () => {
+  const same = { spacing: { grid: { columns: { $value: '4px' } } } };
+  assert.deepEqual(findModeCollisions([{ file: 'a', dtcg: same }, { file: 'b', dtcg: same }]), []);
+});
+
+const SRC = [{ file: 't.json', dtcg: {
+  text: { sm: { $value: '14px', $type: 'dimension' } },
+  leading: { tight: { $value: '1.1', $type: 'dimension' } },
+} }];
+
+test('unit-fidelity catches the x16 scaling bug', () => {
+  const r = validate({ sources: SRC, output: 'static let textSm = CGFloat(224.00)', platform: 'ios-swift' });
+  assert.equal(r.failures.length, 1);
+  assert.equal(r.failures[0].rule, 'unit-fidelity');
+  assert.equal(r.ok, false);
+});
+
+test('unit-fidelity passes a correctly emitted px value', () => {
+  const r = validate({ sources: SRC, output: 'static let textSm = CGFloat(14.00)', platform: 'ios-swift' });
+  assert.deepEqual(r.failures, []);
+  assert.equal(r.ok, true);
+});
+
+test('unit-fidelity never scales a unitless ratio', () => {
+  const ok = validate({ sources: SRC, output: 'static let leadingTight = CGFloat(1.1)', platform: 'ios-swift' });
+  assert.deepEqual(ok.failures, []);
+  const bad = validate({ sources: SRC, output: 'static let leadingTight = CGFloat(17.6)', platform: 'ios-swift' });
+  assert.equal(bad.failures[0].rule, 'unit-fidelity');
+});
+
+test('no-foreign-syntax catches leaked color-mix', () => {
+  const out = 'static let textSm = color-mix(in srgb, UIColor(red: 1, green: 1, blue: 1, alpha: 1) 4%, transparent)';
+  const r = validate({ sources: SRC, output: out, platform: 'ios-swift' });
+  assert.ok(r.failures.some((f) => f.rule === 'no-foreign-syntax'));
+});
+
+test('no-bare-units catches unresolved aliases, including negative magnitudes', () => {
+  const r = validate({ sources: SRC, output: 'static let textSm = 24px', platform: 'ios-swift' });
+  assert.ok(r.failures.some((f) => f.rule === 'no-bare-units'));
+  const neg = validate({ sources: SRC, output: 'static let textSm = -0.03em', platform: 'ios-swift' });
+  assert.ok(neg.failures.some((f) => f.rule === 'no-bare-units'));
+});
+
+test('zero matches fails rather than passing vacuously', () => {
+  const r = validate({ sources: SRC, output: 'static let somethingElse = CGFloat(14.00)', platform: 'ios-swift' });
+  assert.equal(r.matched, 0);
+  assert.equal(r.ok, false);
+});
+
+test('a match rate below the floor fails', () => {
+  const out = ['static let textSm = CGFloat(14.00)', 'static let unknownA = CGFloat(1)', 'static let unknownB = CGFloat(2)'].join('\n');
+  assert.equal(validate({ sources: SRC, output: out, platform: 'ios-swift', minMatch: 0.5 }).ok, false);
+  assert.equal(validate({ sources: SRC, output: out, platform: 'ios-swift', minMatch: 0.3 }).ok, true);
+});
+
+test('a mode collision fails even when every declaration is correct', () => {
+  const sources = [
+    { file: 'mobile.json', dtcg: { text: { sm: { $value: '14px' } } } },
+    { file: 'desktop.json', dtcg: { text: { sm: { $value: '16px' } } } },
+  ];
+  const r = validate({ sources, output: 'static let textSm = CGFloat(16.00)', platform: 'ios-swift' });
+  assert.equal(r.collisions.length, 1);
+  assert.equal(r.ok, false);
+});

--- a/scripts/validate-token-output.test.mjs
+++ b/scripts/validate-token-output.test.mjs
@@ -200,6 +200,81 @@ test('unit-fidelity handles rem-authored tokens emitting ×16 correctly (guards 
   assert.equal(r.ok, true);
 });
 
+// A documented token ($description) emits an inline trailing comment under
+// ios-swift/enum.swift. A commented value must still be checked, not counted
+// as verified while never actually being compared.
+test('extractDeclarations strips a trailing // comment from the value', () => {
+  const [d] = extractDeclarations('public static let textSm = CGFloat(224.00) // Small body text', 'ios-swift');
+  assert.equal(d.value, 'CGFloat(224.00)');
+});
+
+test('extractDeclarations strips a trailing /** ... */ comment from the value', () => {
+  const [d] = extractDeclarations('public static let textSm = CGFloat(224.00) /** Small body text */', 'ios-swift');
+  assert.equal(d.value, 'CGFloat(224.00)');
+});
+
+test('extractDeclarations does not damage a value that legitimately contains // with no preceding whitespace', () => {
+  const [d] = extractDeclarations('static let urlToken = "https://example.com"', 'ios-swift');
+  assert.equal(d.value, '"https://example.com"');
+});
+
+test('a trailing // comment does not defeat unit-fidelity', () => {
+  const r = validate({ sources: SRC, output: 'static let textSm = CGFloat(224.00) // Small body text', platform: 'ios-swift' });
+  assert.ok(r.failures.some((f) => f.rule === 'unit-fidelity'));
+  assert.equal(r.ok, false);
+});
+
+test('a trailing /** ... */ comment does not defeat unit-fidelity', () => {
+  const r = validate({ sources: SRC, output: 'static let textSm = CGFloat(224.00) /** Small body text */', platform: 'ios-swift' });
+  assert.ok(r.failures.some((f) => f.rule === 'unit-fidelity'));
+  assert.equal(r.ok, false);
+});
+
+const COLOR_SRC = [{ file: 'c.json', dtcg: { color: { bg: { canvas: { $value: '#ffffff', $type: 'color' } } } } }];
+
+test('a colour token does not trigger unverifiable-dimension', () => {
+  const r = validate({ sources: COLOR_SRC, output: 'static let colorBgCanvas = UIColor(red: 1, green: 1, blue: 1, alpha: 1)', platform: 'ios-swift' });
+  assert.ok(!r.failures.some((f) => f.rule === 'unverifiable-dimension'));
+});
+
+test('an unreadable dimension emission produces unverifiable-dimension rather than counting as matched-and-checked', () => {
+  const r = validate({ sources: SRC, output: 'static let textSm = someUnknownWrapper(14)', platform: 'ios-swift' });
+  assert.ok(r.failures.some((f) => f.rule === 'unverifiable-dimension'));
+  assert.equal(r.ok, false);
+});
+
+// The match-rate denominator only sees lines DECL could parse. Unparsed
+// declaration-shaped lines and unemitted source tokens must be surfaced.
+const UNPARSED_OUT = `
+public enum Tokens {
+    internal static let textSm = CGFloat(14.00)
+    internal static let textMd = CGFloat(16.00)
+    internal static let textLg = CGFloat(18.00)
+}
+`;
+
+test('several unparsed declaration-shaped lines report a non-zero unparsedLines count', () => {
+  const r = validate({ sources: SRC, output: UNPARSED_OUT, platform: 'ios-swift' });
+  assert.equal(r.total, 0);
+  assert.equal(r.unparsedLines, 3);
+});
+
+const MANY_SRC = [{ file: 't2.json', dtcg: {
+  text: { sm: { $value: '14px' }, md: { $value: '16px' }, lg: { $value: '18px' } },
+} }];
+
+test('source tokens absent from the output report a non-zero unemittedTokens count', () => {
+  const r = validate({ sources: MANY_SRC, output: 'static let textSm = CGFloat(14.00)', platform: 'ios-swift' });
+  assert.equal(r.unemittedTokens, 2);
+});
+
+test('a clean matched run reports neither unparsedLines nor unemittedTokens', () => {
+  const out = 'static let textSm = CGFloat(14.00)\nstatic let leadingTight = CGFloat(1.1)';
+  const r = validate({ sources: SRC, output: out, platform: 'ios-swift' });
+  assert.equal(r.unparsedLines, 0);
+  assert.equal(r.unemittedTokens, 0);
+});
+
 import { formatReport } from './validate-token-output.mjs';
 import { execFileSync } from 'node:child_process';
 import { mkdtempSync, writeFileSync } from 'node:fs';
@@ -216,6 +291,32 @@ test('formatReport states the match rate and every failure', () => {
   assert.match(lines, /unit-fidelity/);
   assert.match(lines, /textSm/);
   assert.match(lines, /224/);
+});
+
+test('formatReport renders an unverifiable-dimension failure', () => {
+  const lines = formatReport({
+    total: 1, matched: 1, matchRate: 1, minMatch: 0.5, collisions: [],
+    failures: [{ rule: 'unverifiable-dimension', symbol: 'textSm', token: 'text.sm', source: '14px', emitted: 'someUnknownWrapper(14)' }],
+    ok: false,
+  }).join('\n');
+  assert.match(lines, /unverifiable-dimension/);
+  assert.match(lines, /textSm/);
+});
+
+test('formatReport prints unparsedLines and unemittedTokens only when non-zero', () => {
+  const zero = formatReport({
+    total: 1, matched: 1, matchRate: 1, minMatch: 0.5, collisions: [], failures: [], ok: true,
+    unparsedLines: 0, unemittedTokens: 0,
+  }).join('\n');
+  assert.doesNotMatch(zero, /unparsed line/);
+  assert.doesNotMatch(zero, /had no matching emitted symbol/);
+
+  const nonzero = formatReport({
+    total: 1, matched: 1, matchRate: 1, minMatch: 0.5, collisions: [], failures: [], ok: true,
+    unparsedLines: 2, unemittedTokens: 3,
+  }).join('\n');
+  assert.match(nonzero, /2 unparsed line/);
+  assert.match(nonzero, /3 source token\(s\) had no matching emitted symbol/);
 });
 
 function runCli(args) {

--- a/scripts/validate-token-output.test.mjs
+++ b/scripts/validate-token-output.test.mjs
@@ -183,3 +183,19 @@ test('a mode collision fails even when every declaration is correct', () => {
   assert.equal(r.collisions.length, 1);
   assert.equal(r.ok, false);
 });
+
+test('a dangling alias does not inflate matched count', () => {
+  const sources = [{ file: 't.json', dtcg: { a: { b: { $value: '{c.d}' } } } }];
+  const r = validate({ sources, output: 'static let aB = CGFloat(999.00)', platform: 'ios-swift' });
+  assert.equal(r.matched, 0);
+  assert.equal(r.ok, false);
+});
+
+test('unit-fidelity handles rem-authored tokens emitting ×16 correctly (guards against over-correction)', () => {
+  const sources = [{ file: 't.json', dtcg: {
+    spacing: { base: { $value: '1rem', $type: 'dimension' } },
+  } }];
+  const r = validate({ sources, output: 'static let spacingBase = CGFloat(16.00)', platform: 'ios-swift' });
+  assert.deepEqual(r.failures, []);
+  assert.equal(r.ok, true);
+});

--- a/scripts/validate-token-output.test.mjs
+++ b/scripts/validate-token-output.test.mjs
@@ -39,3 +39,51 @@ test('resolveValue throws on a missing token', () => {
 test('resolveValue throws on a circular reference', () => {
   assert.throws(() => resolveValue('a', { a: '{b}', b: '{a}' }), /circular/);
 });
+
+import { extractDeclarations, magnitudeOf } from './validate-token-output.mjs';
+
+const SWIFT = `
+public enum Tokens {
+    public static let textSm = CGFloat(224.00)
+    public static let colorBgCanvas = UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 1)
+    // a comment, not a declaration
+}
+`;
+
+const KOTLIN = `
+object Tokens {
+  val textSm = 224.00.dp
+  val colorBgCanvas = Color(0xffffffff)
+}
+`;
+
+test('extractDeclarations reads Swift static let declarations', () => {
+  const decls = extractDeclarations(SWIFT, 'ios-swift');
+  assert.deepEqual(decls, [
+    { symbol: 'textSm', value: 'CGFloat(224.00)' },
+    { symbol: 'colorBgCanvas', value: 'UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 1)' },
+  ]);
+});
+
+test('extractDeclarations reads Kotlin val declarations', () => {
+  const decls = extractDeclarations(KOTLIN, 'android-kotlin');
+  assert.deepEqual(decls.map((d) => d.symbol), ['textSm', 'colorBgCanvas']);
+});
+
+test('extractDeclarations throws on an unknown platform', () => {
+  assert.throws(() => extractDeclarations(SWIFT, 'flutter'), /unknown platform/);
+});
+
+test('magnitudeOf reads CGFloat, dp/sp, and bare numerics', () => {
+  assert.equal(magnitudeOf('CGFloat(224.00)'), 224);
+  assert.equal(magnitudeOf('224.00.dp'), 224);
+  assert.equal(magnitudeOf('16.sp'), 16);
+  assert.equal(magnitudeOf('1.1'), 1.1);
+  assert.equal(magnitudeOf('-0.03'), -0.03);
+});
+
+test('magnitudeOf returns null for non-dimension values', () => {
+  assert.equal(magnitudeOf('UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 1)'), null);
+  assert.equal(magnitudeOf('Color(0xffffffff)'), null);
+  assert.equal(magnitudeOf('24px'), null);
+});

--- a/scripts/validate-token-output.test.mjs
+++ b/scripts/validate-token-output.test.mjs
@@ -1,0 +1,41 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { flattenDtcg, resolveValue } from './validate-token-output.mjs';
+
+// text.sm is a DUAL-NODE token: it carries its own $value AND a child.
+const dtcg = {
+  text: {
+    sm: {
+      $value: '14px',
+      $type: 'dimension',
+      lineHeight: { $value: '20px', $type: 'dimension' },
+    },
+  },
+  typography: {
+    body: { lineHeight: { $value: '{text.sm.lineHeight}', $type: 'dimension' } },
+  },
+};
+
+test('flattenDtcg yields a dual-node parent AND its child', () => {
+  const flat = flattenDtcg(dtcg);
+  assert.equal(flat['text.sm'], '14px');
+  assert.equal(flat['text.sm.lineHeight'], '20px');
+});
+
+test('flattenDtcg skips $-prefixed meta keys', () => {
+  const flat = flattenDtcg(dtcg);
+  assert.equal(flat['text.sm.$type'], undefined);
+});
+
+test('resolveValue follows an alias into a dual-node child', () => {
+  const flat = flattenDtcg(dtcg);
+  assert.equal(resolveValue('typography.body.lineHeight', flat), '20px');
+});
+
+test('resolveValue throws on a missing token', () => {
+  assert.throws(() => resolveValue('nope', {}), /not found/);
+});
+
+test('resolveValue throws on a circular reference', () => {
+  assert.throws(() => resolveValue('a', { a: '{b}', b: '{a}' }), /circular/);
+});

--- a/scripts/validate-token-output.test.mjs
+++ b/scripts/validate-token-output.test.mjs
@@ -244,3 +244,19 @@ test('CLI exits 1 on a real failure and 0 on clean output', () => {
   writeFileSync(good, 'public static let textSm = CGFloat(14.00)\n');
   assert.equal(runCli(['--source', src, '--output', good, '--platform', 'ios-swift']).code, 0);
 });
+
+test('CLI exits 2 on an unreadable --source file', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'vto-'));
+  const good = join(dir, 'Good.swift');
+  writeFileSync(good, 'public static let textSm = CGFloat(14.00)\n');
+  assert.equal(runCli(['--source', '/nonexistent/file.json', '--output', good, '--platform', 'ios-swift']).code, 2);
+});
+
+test('CLI exits 2 on a non-numeric --min-match', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'vto-'));
+  const src = join(dir, 'text.json');
+  writeFileSync(src, JSON.stringify({ text: { sm: { $value: '14px', $type: 'dimension' } } }));
+  const good = join(dir, 'Good.swift');
+  writeFileSync(good, 'public static let textSm = CGFloat(14.00)\n');
+  assert.equal(runCli(['--source', src, '--output', good, '--platform', 'ios-swift', '--min-match', 'abc']).code, 2);
+});

--- a/skills/token-crosswalk-builder/SKILL.md
+++ b/skills/token-crosswalk-builder/SKILL.md
@@ -70,6 +70,8 @@ Copy these from `${CLAUDE_PLUGIN_ROOT}/scripts/` into the user's repo **verbatim
 (they are zero-dependency and version with the user's repo so their CI can run them):
 
 - `lib/crosswalk.mjs` → `packages/tokens/scripts/lib/crosswalk.mjs`
+- `lib/dtcg.mjs` → `packages/tokens/scripts/lib/dtcg.mjs` (required by
+  `validate-crosswalk.mjs` — copying the validator without it breaks the gate at import)
 - `validate-crosswalk.mjs` → `packages/tokens/scripts/validate-crosswalk.mjs`
 - `build-reverse-index.mjs` → `packages/tokens/scripts/build-reverse-index.mjs`
 - `guard-token-removal.mjs` → `packages/tokens/scripts/guard-token-removal.mjs`

--- a/skills/token-sync-layer/SKILL.md
+++ b/skills/token-sync-layer/SKILL.md
@@ -144,6 +144,14 @@ register the platform, transform group, format, and `outputReferences`
 flattens). Web adapters emit `:root`/`.dark` (or `[data-theme]`); the shadcn
 adapter also emits a Tailwind preset.
 
+**Native targets need the configuration in
+`${CLAUDE_PLUGIN_ROOT}/references/native-adapter-config.md`, not a stock
+transform group.** The stock `ios-swift` and `compose` groups emit every
+`px`-authored dimension at ×16 its value — valid, compiling, silently wrong —
+and mishandle `color-mix()` and dual-node DTCG the same way. That file gives the
+preprocessor and transforms that fix it, verified at 196/196 correct symbols
+against a real source.
+
 **Native targets build once per mode, and are validated.** A single build over
 the whole token directory silently drops a mode — Style Dictionary dedupes by
 dot-path, so a light and a dark definition of the same token collapse to

--- a/skills/token-sync-layer/SKILL.md
+++ b/skills/token-sync-layer/SKILL.md
@@ -46,11 +46,11 @@ fails, offer `figma-environment-setup`.
 Ask which platform(s) the user is building for. Read
 `${CLAUDE_PLUGIN_ROOT}/references/sync-adapters.md` for the two-tier adapter model.
 
-- **Curated (Tier 1):** `shadcn`, `tailwind`, `mui`, `vanilla-css`, `ios-swift`.
+- **Curated (Tier 1):** `shadcn`, `tailwind`, `mui`, `vanilla-css`.
   Vetted presets — high confidence.
 - **Generated (Tier 2):** any other framework (Ant Design, Chakra, HeroUI,
-  Android/Kotlin, Flutter, etc.). The skill generates an adapter and verifies it
-  against a real component before trusting it.
+  iOS/Swift, Android/Kotlin, Flutter, etc.). The skill generates an adapter and
+  verifies it against a real component before trusting it.
 
 **Always tell the user which tier they're on.** If they name a curated one, say
 it'll be solid. If they name anything else, be honest: "That's not one I have a

--- a/skills/token-sync-layer/SKILL.md
+++ b/skills/token-sync-layer/SKILL.md
@@ -144,11 +144,21 @@ register the platform, transform group, format, and `outputReferences`
 flattens). Web adapters emit `:root`/`.dark` (or `[data-theme]`); the shadcn
 adapter also emits a Tailwind preset.
 
+**Native targets build once per mode, and are validated.** A single build over
+the whole token directory silently drops a mode — Style Dictionary dedupes by
+dot-path, so a light and a dark definition of the same token collapse to
+whichever file sorted last. Configure one build per mode combination with an
+explicit source file list, then run `tokens:validate-output` against each
+generated file with that same list. See
+`${CLAUDE_PLUGIN_ROOT}/references/sync-adapters.md`.
+
 **Execution model — subagent dispatch with model routing.** Generating each
 platform's output is independent and verifiable. If your host supports subagent
 dispatch, dispatch **one `code-executor` per adapter** — each produces its
-platform's files and verifies them (the config builds, the expected files
-appear, references resolve for web / flatten for native) — then a **`reviewer`**
+platform's files and verifies them (for web: the config builds, the expected
+files appear, references resolve; for native: `tokens:validate-output` passes —
+"the config builds" is not verification, it is the condition under which all
+four known native failure modes ship silently) — then a **`reviewer`**
 to check each before combining. Choose each subagent's model from its role tier
 per `${CLAUDE_PLUGIN_ROOT}/references/agent-routing.md` (`code-executor` → fast,
 `reviewer` → balanced), and only dispatch once each adapter's spec is complete
@@ -163,6 +173,18 @@ Run the Style Dictionary build. Outputs land in `packages/tokens/<platform>/`
 as **build artifacts** — regenerated every sync, never hand-edited. Wire
 `packages/tokens/package.json` to export them so the UI package, Storybook, and
 any future app consume them.
+
+**Install the output validator.** Copy
+`${CLAUDE_PLUGIN_ROOT}/scripts/validate-token-output.mjs` into
+`packages/tokens/scripts/` and register it so it stays a live gate on every
+future sync rather than a one-time check:
+
+```json
+"tokens:validate-output": "node scripts/validate-token-output.mjs"
+```
+
+Invoke it once per native output file, passing the same `--source` list that
+file's build used.
 
 ## Step 4.5 — Icon code sync (install check + custom SVGR)
 

--- a/skills/token-sync-layer/SKILL.md
+++ b/skills/token-sync-layer/SKILL.md
@@ -174,10 +174,12 @@ as **build artifacts** — regenerated every sync, never hand-edited. Wire
 `packages/tokens/package.json` to export them so the UI package, Storybook, and
 any future app consume them.
 
-**Install the output validator.** Copy
+**Install the output validator.** Copy **both** files —
 `${CLAUDE_PLUGIN_ROOT}/scripts/validate-token-output.mjs` into
-`packages/tokens/scripts/` and register it so it stays a live gate on every
-future sync rather than a one-time check:
+`packages/tokens/scripts/` and `${CLAUDE_PLUGIN_ROOT}/scripts/lib/dtcg.mjs` into
+`packages/tokens/scripts/lib/` (the validator imports it; copying one without the
+other breaks the gate at import). Then register it so it stays a live gate on
+every future sync rather than a one-time check:
 
 ```json
 "tokens:validate-output": "node scripts/validate-token-output.mjs"


### PR DESCRIPTION
## Why

throughline's native token adapters were pointed at a real, shipping DTCG token source for the first time — zygarden's `libs/shared/util-tokens` (15 files, 322 `$value` entries). Both `ios-swift` and `android-kotlin` exited `0` and produced output that was roughly half wrong.

The serious case is silent: `text.sm: "14px"` emitted `CGFloat(224.00)`. That is valid Swift. It compiles, it ships, and it renders every font and spacing value at sixteen times its intended size. The stock `ios-swift` and `compose` transform groups assume `rem` input and multiply by 16; zygarden authors in `px`, and nothing reconciled the two.

`token-sync-layer`'s verification step asked whether "the config builds, the expected files appear, references resolve." All three passed on that output.

Notably, the **curated Tier 1 `ios-swift` adapter failed identically to the generated Tier 2 `android-kotlin` one**, in the same counts — so the tier badge was not predicting quality.

## What this adds

`scripts/validate-token-output.mjs` — zero-dependency, following `validate-crosswalk.mjs`'s shape. Five rules:

| Rule | Catches |
|---|---|
| `unit-fidelity` | dimensions emitted at the wrong scale, judged against the **authored unit** (`px` → 1:1, `rem` → ×16, unitless ratios never scaled) |
| `no-foreign-syntax` | `color-mix()` / `calc()` / `var()` leaking into Swift or Kotlin |
| `no-bare-units` | unresolved dual-node DTCG aliases emitting bare `24px` / `100%` |
| `no-mode-collision` | one token path defined twice across the source list with different values |
| `unverifiable-dimension` | a real dimension whose emitted form could not be read at all |

Exit `0` pass, `1` validation failure, `2` usage error. Zero matches is a **failure**, never a clean pass.

## Verified against the real fixture

Run against zygarden's actual tokens, it caught all four measured failure classes: 38 `unit-fidelity`, 11 `no-foreign-syntax`, 14 `no-bare-units` (13 dual-node `lineHeight` aliases + one `100%`), and the `spacing.grid.columns` mode collision.

## Documentation corrections

- **`ios-swift` demoted out of Tier 1** in `references/sync-adapters.md` *and* in `skills/token-sync-layer/SKILL.md`, which is the surface that actually tells a user which tier they are on. The curated set is now four.
- New **"What adapters cannot express"** section: CSS expressions, dual-node DTCG, `%`/`em` dimensions, and a third (viewport) mode axis are all legal in real sources and all silently unsupported.
- The README's **"One library, many platforms"** bullet is split. It conflated token fan-out with native component code generation — two efforts of very different size — and that phrasing is what let the capability gap go unnoticed.

## Review notes

Reviewers caught two things worth naming:

1. The plan's own reference implementation violated the plan's own exit-code contract — usage errors exited `1` with a raw stack trace, and a mistyped `--min-match` produced a silent phantom failure with no explanation. Both fixed.
2. A deferral ruling I made rested on a false premise. `ios-swift/enum.swift` overrides only `suffix` in `createPropertyFormatter`, leaving inline comments on — so any token with a `$description` emitted `... = CGFloat(224.00) /** Small body text */`, which matched no pattern and counted as verified while never being compared. **A file with every dimension 16× wrong reported "3/3 matched (100%)" and exited 0.** Fixed and reproduced before and after.

## Deliberately out of scope

- **Replacing Style Dictionary.** Originally left open. **Now answered: no.** See the correction below.
- **Making every existing adapter use the fixed configuration.** The config is documented and verified; retrofitting the shipped `ios-swift`/`android-kotlin` presets to use it by default is a separate change.
- `scripts/validate-crosswalk.mjs` is untouched — it has the same dual-node blind spot, but it is a separate gate with its own tests. Worth filing.

## Correction: Style Dictionary is not the problem

The branch originally implied Style Dictionary could not handle these token shapes, citing zygarden's removal of it as evidence. **Both halves of that were wrong**, and the branch now says so.

**On the history.** Zygarden removed SD in `zygarden-brand-guide`, Phase 4c-B, **May 2026 — before throughline existed**, in their own figma-sync pipeline. The commit removed SD's SCSS and JS platforms because *"those outputs have no consumers in the repo"* and explicitly noted *"SD outputs can be reintroduced later with custom logic if a consumer needs them."* A YAGNI cleanup of dead output, not a verdict on the tool.

**On the capability.** A spike built exactly that custom logic — a dual-node-aware preprocessor, a `color-mix` transform, and unit-aware dimension transforms, about 80 lines. Result against the same 322-token source, verified with this branch's own validator on both light and dark builds:

```
tokens:validate-output — 196/196 emitted symbols matched a source token (100%)
EXIT=0
```

Every finding traced to configuration, not to Style Dictionary:

| Finding | Actual cause |
|---|---|
| ×16 on every px dimension | stock `size/swift/remToCGFloat` assumes `rem` |
| 11 leaked `color-mix()` | no transform registered for it |
| 14 bare `px` literals | SD's resolver not traversing dual-node nodes |
| 864 collisions | naive whole-directory source list |

Only `%` and `em` are genuine limits — they are container-relative and have no build-time native magnitude.

The working configuration ships as `references/native-adapter-config.md`, reusing `scripts/lib/dtcg.mjs` for the resolver. `sync-adapters.md`'s constraints section is reframed from *"what adapters cannot express"* to *"what the stock configuration gets wrong."* The design spec carries an appended Correction rather than an edited-away argument, so the reasoning that produced the mistake stays on the record.

**The validator is unaffected.** The four failure classes are real and were measured; the stock configuration does emit all of them at exit `0`. Shipping detection before deciding architecture is what made this correction possible — the spike's config was proven by running `tokens:validate-output` against its output.

## Testing

223 tests pass. `ci/validate-plugin.mjs`, `ci/validate-skills.mjs`, and `scripts/adapters/generate.mjs --check` all green.

Spec: `docs/superpowers/specs/2026-08-21-token-output-validation-design.md`
Plan: `docs/superpowers/plans/2026-08-21-token-output-validation.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6zsxr3abwpVMhYh7cNdB1

