### PR TITLE
fix: hoistDualNodes silently discarded a token on collision and dropped $type (#55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,18 +14,35 @@ to [Semantic Versioning](https://semver.org).
   dual node's child hoisted earlier in the same pass — `preprocess` now
   throws, naming both colliding paths, instead of silently overwriting one
   and dropping the other. A build that previously succeeded may now throw
-  here; that is the point, not a regression — it surfaces a token your build
-  was already losing without telling you, rather than causing a new loss.
+  here; in almost every case that is the point rather than a regression — it
+  surfaces a token your build was already losing without telling you. The one
+  exception: when the two colliding nodes are deeply identical, the overwrite
+  was lossless, and such a build now throws having lost nothing. Renaming
+  either path resolves it.
 - **A hoisted dual-node child now inherits the dual node's `$type`** when it
   has none of its own — the dual node is the child's closest `$type`-bearing
   ancestor as authored, and that ancestry is lost once the hoist makes the
   child a sibling instead. A child whose authored value was a whole-value
   reference is excluded and keeps its referent's resolved type per DTCG
-  5.2.2. Two consequences are knowingly accepted and covered by tests: an
-  untyped `fontSize` child hoisted under a `dimension`-typed parent now emits
-  through the `dimension` size transform (`.dp` on Android, not `.sp`), and
-  an untyped unitless child now emits as a `dimension`. This does not make
-  native output compile-verified or validate DTCG conformance on its own.
+  5.2.2. Three consequences are knowingly accepted, and none is subtle enough
+  to leave implicit:
+  - An untyped `fontSize` child under a `dimension`-typed parent now emits
+    through the `dimension` transform — `.dp` on Android rather than `.sp`,
+    which **defeats the user's font-scale accessibility setting**. It
+    previously emitted a bare literal that `tokens:validate-output` caught
+    loudly; that gate no longer fires on it.
+  - An untyped unitless child now emits as a `dimension` — a ratio rendered in
+    density-independent pixels. Also previously caught loudly.
+  - Where an enclosing *group* carries a `$type` that correctly describes the
+    child, the dual node's type now shadows it, so a token that resolved
+    correctly before can resolve wrongly. Contrived, and not present in any
+    source we have measured, but it is the one case that turns right into
+    wrong rather than loud into silent.
+
+  The first two are covered by tests; the third is documented in
+  `docs/superpowers/specs/2026-08-23-hoist-dual-nodes-design.md` and is not.
+  This does not make native output compile-verified or validate DTCG
+  conformance on its own.
 - **`no-foreign-syntax` reconciled with the native output filter.** An
   unrescued `calc(...)`, `var(...)`, or `color-mix(...)` variant was
   previously dropped from native output by `sd-native.mjs`'s filter before

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ to [Semantic Versioning](https://semver.org).
 ## [Unreleased]
 
 ### Fixed
+- **`preprocess` throws on a dual-node hoist collision instead of silently
+  discarding a token.** `hoistDualNodes` renames a dual node's child to a
+  camel-joined sibling (`text.sm.lineHeight` becomes `text.smLineHeight`).
+  When that name is already taken — by an authored sibling, or by another
+  dual node's child hoisted earlier in the same pass — `preprocess` now
+  throws, naming both colliding paths, instead of silently overwriting one
+  and dropping the other. A build that previously succeeded may now throw
+  here; that is the point, not a regression — it surfaces a token your build
+  was already losing without telling you, rather than causing a new loss.
+- **A hoisted dual-node child now inherits the dual node's `$type`** when it
+  has none of its own — the dual node is the child's closest `$type`-bearing
+  ancestor as authored, and that ancestry is lost once the hoist makes the
+  child a sibling instead. A child whose authored value was a whole-value
+  reference is excluded and keeps its referent's resolved type per DTCG
+  5.2.2. Two consequences are knowingly accepted and covered by tests: an
+  untyped `fontSize` child hoisted under a `dimension`-typed parent now emits
+  through the `dimension` size transform (`.dp` on Android, not `.sp`), and
+  an untyped unitless child now emits as a `dimension`. This does not make
+  native output compile-verified or validate DTCG conformance on its own.
 - **`no-foreign-syntax` reconciled with the native output filter.** An
   unrescued `calc(...)`, `var(...)`, or `color-mix(...)` variant was
   previously dropped from native output by `sd-native.mjs`'s filter before

--- a/adapters/codex/prompts/token-sync-layer.md
+++ b/adapters/codex/prompts/token-sync-layer.md
@@ -173,9 +173,11 @@ for (const mode of MODES) {                     // e.g. ['light', 'dark']
 by dot-path, so a single build over the whole token directory collapses light
 and dark into whichever file sorted last, silently dropping a mode. Passing each
 mode's sources through `nativeSources` turns that into a thrown error naming the
-colliding paths. Then run `tokens:validate-output` against each generated file
-with that same source list. See
-`.throughline/references/native-adapter-config.md`.
+colliding paths. The `dtcg/resolve-dual-node` preprocessor throws too, on its
+own collision: a dual node's hoisted child renamed to a camel-joined name that
+an existing sibling or an earlier hoist in the same pass already has. Then run
+`tokens:validate-output` against each generated file with that same source
+list. See `.throughline/references/native-adapter-config.md`.
 
 **Execution model — subagent dispatch with model routing.** Generating each
 platform's output is independent and verifiable. If your host supports subagent

--- a/adapters/cursor/.cursor/rules/token-sync-layer.mdc
+++ b/adapters/cursor/.cursor/rules/token-sync-layer.mdc
@@ -177,9 +177,11 @@ for (const mode of MODES) {                     // e.g. ['light', 'dark']
 by dot-path, so a single build over the whole token directory collapses light
 and dark into whichever file sorted last, silently dropping a mode. Passing each
 mode's sources through `nativeSources` turns that into a thrown error naming the
-colliding paths. Then run `tokens:validate-output` against each generated file
-with that same source list. See
-`.throughline/references/native-adapter-config.md`.
+colliding paths. The `dtcg/resolve-dual-node` preprocessor throws too, on its
+own collision: a dual node's hoisted child renamed to a camel-joined name that
+an existing sibling or an earlier hoist in the same pass already has. Then run
+`tokens:validate-output` against each generated file with that same source
+list. See `.throughline/references/native-adapter-config.md`.
 
 **Execution model — subagent dispatch with model routing.** Generating each
 platform's output is independent and verifiable. If your host supports subagent

--- a/adapters/generic/skills/token-sync-layer/SKILL.md
+++ b/adapters/generic/skills/token-sync-layer/SKILL.md
@@ -173,9 +173,11 @@ for (const mode of MODES) {                     // e.g. ['light', 'dark']
 by dot-path, so a single build over the whole token directory collapses light
 and dark into whichever file sorted last, silently dropping a mode. Passing each
 mode's sources through `nativeSources` turns that into a thrown error naming the
-colliding paths. Then run `tokens:validate-output` against each generated file
-with that same source list. See
-`.throughline/references/native-adapter-config.md`.
+colliding paths. The `dtcg/resolve-dual-node` preprocessor throws too, on its
+own collision: a dual node's hoisted child renamed to a camel-joined name that
+an existing sibling or an earlier hoist in the same pass already has. Then run
+`tokens:validate-output` against each generated file with that same source
+list. See `.throughline/references/native-adapter-config.md`.
 
 **Execution model — subagent dispatch with model routing.** Generating each
 platform's output is independent and verifiable. If your host supports subagent

--- a/docs/superpowers/notes/2026-08-23-ranked-backlog-handoff.md
+++ b/docs/superpowers/notes/2026-08-23-ranked-backlog-handoff.md
@@ -1,0 +1,119 @@
+# Ranked backlog session — handoff
+
+**Date:** 2026-08-23
+**Branches:** `fix/53-native-literal-validity` (PR [#56](https://github.com/jrpease/throughline/pull/56), open) → `fix/55-hoist-dual-nodes` (stacked, local only)
+
+## The agreed order
+
+Working the open-issue backlog in this order, one item at a time, full
+brainstorm → spec → `/review-spec` → plan → subagent execution → PR:
+
+**#53 ✅ → #55 (in progress) → #51 → #52 → #36 → #54**
+
+Chosen over starting with #39 (the consumption-layer keystone) because #53 and
+#55 are correctness debt on code that just shipped, and the epic should start on
+a clean base. Checkpoint agreed: pause after each PR, not at each stage.
+
+## What shipped — #53
+
+[PR #56](https://github.com/jrpease/throughline/pull/56), 12 commits, **open and
+awaiting review**. Native token output that did not compile is fixed and gated.
+
+| | before | after |
+|---|---|---|
+| declarations | 196 | 195 |
+| broken symbols | 15 | 0 |
+| `value-verified` | 107 | 107 (unchanged) |
+
+312 tests, six gates green. Residual review findings filed as
+[#57](https://github.com/jrpease/throughline/issues/57).
+
+New surface worth knowing about: `scripts/lib/native-literal.mjs` — a
+zero-dependency literal grammar with two consumers, `sd-native.mjs`'s output
+filter and `validate-token-output.mjs`'s `invalid-literal` rule.
+
+**The one thing to understand before touching this area:** three separate
+definitions of "CSS-function-like" now exist — `CSS_CONSTRUCT` and
+`CSS_FUNCTION` in `native-literal.mjs`/`sd-native.mjs`, and `FOREIGN` in
+`validate-token-output.mjs`. They agree today and nothing enforces that. Adding
+a name to `FOREIGN` alone re-creates a bug where the build silently drops the
+very value the gate was just taught to catch. That is #57 item 1.
+
+## In progress — #55
+
+Branch `fix/55-hoist-dual-nodes`, **two commits, spec only, no code written.**
+Stacked on the #53 branch deliberately: both touch `scripts/lib/sd-native.mjs`,
+and `references/native-adapter-config.md` is generated from that whole module,
+so branching off `main` guarantees a conflict. **It must merge after #56.**
+
+Spec: `docs/superpowers/specs/2026-08-23-hoist-dual-nodes-design.md`, at
+revision 2 after `/review-spec` returned "needs revision".
+
+### The finding that reframes the issue
+
+**DTCG forbids dual nodes.** #55's premise — "DTCG permits a node carrying both
+a `$value` and children" — is false against the current draft (30 July 2026,
+§6.1, MUST-level), and §6.2's `$root` is the sanctioned alternative, so the
+prohibition is deliberate. Two repo comments repeat the falsehood and are
+corrected as part of this work: `sd-native.mjs:61` and
+`build-native-adapter-config.mjs:102`.
+
+This does **not** change what throughline does — Figma emits dual nodes and
+`hoistDualNodes` stays. It removes the open question #55 was blocked on: there
+is no conforming reading to discover, so the behaviour is a judgment about
+malformed input and must be argued that way, not as a spec interpretation.
+
+### Three things measured, not assumed
+
+1. Both defects reproduce against the shipped function.
+2. **A third collision variant the issue does not name:** two *hoists* can
+   collide with each other with no authored sibling involved — `t.a.bC` and
+   `t.aB.c` both camel-join to `t.aBC`, and one token vanishes.
+3. **The naive `$type`-carry rule manufactures a new #52.** DTCG §5.2.2 orders
+   its rules: a reference-valued token takes its *referent's* type, outranking
+   group inheritance. But `preprocess` runs `resolveInPlace` before
+   `hoistDualNodes`, so every whole-value reference is already a literal by hoist
+   time and the parent's `$type` gets stamped over the referent's. The spec's
+   exclusion handles this with a module-private `Symbol` set where the reference
+   is still visible.
+
+### Next step
+
+Write the implementation plan from the spec, then execute. The spec's Testing
+section is already decomposed into 12 numbered items with the depth each
+exercises named — the plan can lean on it directly.
+
+Two things the plan must not lose:
+
+- **The idempotency test does not exist.** `sd-native.mjs:246` asserts
+  idempotency in prose and real builds rely on it, but there is no test. It has
+  to be written, not preserved.
+- **Neither defect is reachable from the real source.** Zygarden's `text.*`
+  children each carry `$type: dimension` and no name collides. Coverage is
+  synthetic fixtures; the e2e run's only job is to prove *nothing moved*
+  (195 / 0 / 107). Do not let the e2e run be described as validating the fix.
+
+## Open questions
+
+- **Merge order.** #55 is stacked on #53. If #56 gets substantive review changes,
+  #55 needs a rebase. Alternatively merge #56 first and rebase #55 onto `main`.
+- **Should dual nodes be reported as invalid DTCG?** Now that the shape is known
+  non-conforming, detecting and warning on it is a real option — but it belongs
+  in a validator, not in a preprocessor whose job is to make the build work.
+  Deliberately out of scope for #55; not yet filed as an issue.
+
+## Working notes
+
+- **The e2e harness is a scratchpad artifact and will not survive.** It lived at
+  `<session-scratchpad>/e2e` with style-dictionary 4.4.0 installed and
+  `scripts/lib` symlinked to the repo's live code, so builds tested shipping
+  code rather than a snapshot. No token source is vendored in this repo —
+  zygarden is external, at `~/Dev/zygarden-frontend`, branch
+  `feature/apply-brandguide-styles`, read with `git show <branch>:<path>`; do not
+  check it out or modify it. Rebuilding the harness is the first step of any
+  future e2e run.
+- Reviews on the escalated tier earned their cost twice this session, both times
+  on defects that were invisible to a green test suite: the gradient shipping
+  *quoted* rather than dropped, and the filter silently swallowing the
+  `calc`/`var`/`color-mix` set. Both were spec defects of mine, not
+  implementation errors.

--- a/docs/superpowers/notes/2026-08-23-ranked-backlog-handoff.md
+++ b/docs/superpowers/notes/2026-08-23-ranked-backlog-handoff.md
@@ -100,7 +100,7 @@ Two things the plan must not lose:
 - **Should dual nodes be reported as invalid DTCG?** Now that the shape is known
   non-conforming, detecting and warning on it is a real option — but it belongs
   in a validator, not in a preprocessor whose job is to make the build work.
-  Deliberately out of scope for #55; not yet filed as an issue.
+  Deliberately out of scope for #55; filed as [#58](https://github.com/jrpease/throughline/issues/58).
 
 ## Working notes
 

--- a/docs/superpowers/notes/2026-08-24-hoist-dual-nodes-e2e.md
+++ b/docs/superpowers/notes/2026-08-24-hoist-dual-nodes-e2e.md
@@ -1,0 +1,144 @@
+# hoist-dual-nodes (#55) — e2e proof that nothing moved
+
+**Date:** 2026-08-24
+**Gate for:** Task 3 of the `#55` plan (`hoistDualNodes`: collision throw, `$type`
+carry-through)
+**Verdict:** PASS against the stated bar — `diff -r` between a build at this
+branch's HEAD and a build at `main` (pre-`#55`) is **empty**. All eight output
+files (four per build) show `decls=195 broken=0`. The assertion is narrower
+than a validator run: this proves *byte-identical output*, nothing more.
+
+## Why this run exists
+
+Tasks 1 and 2 fixed two defects in `hoistDualNodes` — a silent token loss on a
+name collision, and a hoisted child losing its `$type`. Neither defect is
+authored anywhere in zygarden's real token source (see below), so the purpose
+of this run is not to exercise the fixes. It is to prove the fixes did not
+perturb output on a real, unrelated source — i.e. that Tasks 1 and 2 changed
+behaviour only on the paths they targeted.
+
+## Harness
+
+Reused, not rebuilt — it already existed from the prior native-config e2e work
+and was live at the time this task started:
+
+```
+/private/tmp/claude-501/-Users-jordansstudio-Dev-throughline/395cf4ed-9e55-4c18-a73d-e9980db4545c/scratchpad/e2e
+```
+
+- **Style Dictionary:** `4.4.0`, installed in the scratch directory.
+- **`scripts/lib`:** a symlink, swapped between the two builds below — not a
+  copy — so each build exercises the module's actual source at that commit,
+  not a snapshot.
+- **Source:** the same 15 zygarden JSON files already extracted into
+  `tokens/` from prior work (`libs/shared/util-tokens/src/tokens/`,
+  `feature/apply-brandguide-styles`). Not re-extracted; the zygarden repo was
+  not touched.
+- **`build.mjs`:** the harness's existing script — `ios-swift` and
+  `android-kotlin`, light/dark, mobile viewport axis,
+  `packageName: 'com.zygarden.tokens'` for Kotlin. Unmodified.
+
+## Procedure
+
+1. `scripts/lib` symlinked to this branch's live tree
+   (`/Users/jordansstudio/Dev/throughline/scripts/lib`, HEAD =
+   `9ef5230`), built, output moved to `out-55/`.
+2. `git worktree add /tmp/tl-main main` — a throwaway worktree at `main`
+   (pre-`#55`), to get the un-patched module without touching this branch's
+   checkout.
+3. `scripts/lib` re-pointed to `/tmp/tl-main/scripts/lib`, built, output moved
+   to `out-main/`.
+4. `diff -r out-main out-55`.
+5. `git worktree remove /tmp/tl-main`.
+
+```
+$ node build.mjs        # HEAD (fix/55-hoist-dual-nodes)
+ios-swift
+✔︎ out/light/ios/Tokens.swift
+built ios-swift / light
+
+android-kotlin
+✔︎ out/light/android/Tokens.kt
+built android-kotlin / light
+
+ios-swift
+✔︎ out/dark/ios/Tokens.swift
+built ios-swift / dark
+
+android-kotlin
+✔︎ out/dark/android/Tokens.kt
+built android-kotlin / dark
+EXIT:0
+
+$ mv out out-55
+
+$ git worktree add /tmp/tl-main main
+Preparing worktree (checking out 'main')
+HEAD is now at 698a236 fix: native token output that does not compile — quote string values, reject invalid literals (#53) (#56)
+
+$ ln -sfn /tmp/tl-main/scripts/lib scripts/lib
+$ node build.mjs        # main (pre-#55)
+ios-swift
+✔︎ out/light/ios/Tokens.swift
+built ios-swift / light
+
+android-kotlin
+✔︎ out/light/android/Tokens.kt
+built android-kotlin / light
+
+ios-swift
+✔︎ out/dark/ios/Tokens.swift
+built ios-swift / dark
+
+android-kotlin
+✔︎ out/dark/android/Tokens.kt
+built android-kotlin / dark
+EXIT:0
+
+$ mv out out-main
+
+$ diff -r out-main out-55
+$ echo "DIFF_EXIT:$?"
+DIFF_EXIT:0
+```
+
+`diff -r` produced no output and exited `0`: the two builds are byte-identical.
+
+## Declaration / broken-symbol counts
+
+```
+out-55/dark/ios/Tokens.swift    decls=195 broken=0
+out-55/light/ios/Tokens.swift   decls=195 broken=0
+out-55/dark/android/Tokens.kt   decls=195 broken=0
+out-55/light/android/Tokens.kt  decls=195 broken=0
+out-main/dark/ios/Tokens.swift   decls=195 broken=0
+out-main/light/ios/Tokens.swift  decls=195 broken=0
+out-main/dark/android/Tokens.kt  decls=195 broken=0
+out-main/light/android/Tokens.kt decls=195 broken=0
+```
+
+All eight files: `decls=195 broken=0`. Matches the prior recorded count for
+this source, and matches identically between HEAD and `main`.
+
+## What this run does NOT establish
+
+- **Neither defect is reachable from this source.** Zygarden's `text.*`
+  children each carry an explicit `$type: dimension` and no camel-joined name
+  collides, so this e2e run does **not** validate either fix — synthetic unit
+  fixtures do (see Tasks 1 and 2's test suites). Proving *nothing moved* is
+  this run's entire job, and is the only thing it claims to have proven.
+- **Nothing was compiled.** No `swiftc` or `kotlinc` ran. `decls`/`broken` are
+  `grep`-based counts, not a compiler's verdict, and `diff -r` establishes
+  byte-identity, not correctness of what those bytes mean.
+- **The two widenings recorded in the spec (`#52` and `#51`) are unreachable
+  in this source for the same reason.** `#52` (untyped unitless literal child
+  under a `dimension` dual node emitting `dp`) and `#51` (untyped `fontSize`
+  child under a `dimension` dual node emitting `dp` instead of `sp`) both
+  require an untyped hoisted child — zygarden's `text.*` children are always
+  explicitly typed, so neither widening fires here. This run says nothing
+  about them one way or the other.
+- **No validator (`tokens:validate-output`) was run this time.** The prior
+  `2026-08-21-native-config-e2e-results.md` run already established the
+  validator's bar on this same source; this run's only new claim is
+  byte-identity across the `#55` change, which a diff answers more directly
+  than re-running the validator would.

--- a/docs/superpowers/notes/2026-08-24-ranked-backlog-handoff.md
+++ b/docs/superpowers/notes/2026-08-24-ranked-backlog-handoff.md
@@ -1,0 +1,84 @@
+# Ranked backlog — session 2 handoff
+
+**Date:** 2026-08-24
+**Supersedes:** `2026-08-23-ranked-backlog-handoff.md`
+
+## Where the backlog stands
+
+Agreed order, one item at a time, full brainstorm → spec → `/review-spec` → plan
+→ subagent execution → PR, pausing after each PR:
+
+**#53 ✅ merged → #55 ✅ PR #59 open → #51 → #52 → #36 → #54**
+
+| | |
+|---|---|
+| **#53** | Merged as `698a236`. Native output that did not compile: 196 declarations with 15 broken symbols → **195 with 0**. |
+| **#55** | [PR #59](https://github.com/jrpease/throughline/pull/59), open, 20 commits. Collision throw + `$type` inheritance. **331 tests**, six gates green. |
+| Follow-ups filed | [#57](https://github.com/jrpease/throughline/issues/57), [#58](https://github.com/jrpease/throughline/issues/58), [#60](https://github.com/jrpease/throughline/issues/60), [#61](https://github.com/jrpease/throughline/issues/61) |
+
+## Start here — three things that change how the next item goes
+
+**1. #51 is no longer the issue it was when we ranked it.** #59 *widens* it,
+deliberately and with a test recording that: an untyped `fontSize` child hoisted
+under a `dimension`-typed dual node now inherits `dimension` and emits `.dp`
+rather than `.sp`, which defeats the user's font-scale accessibility setting.
+The bare literal it used to emit was caught loudly by `no-bare-units`; that gate
+no longer fires on it. So #51's blast radius grew, and its fix — deciding how
+DTCG font sizes are identified without a name-based heuristic — is now
+load-bearing for two changes rather than one.
+
+**2. Branch off the open native branch, not `main`.** `scripts/lib/sd-native.mjs`
+generates `references/native-adapter-config.md` from its *whole body*, so two
+branches that both touch it conflict guaranteed. #55 was stacked on #53 for this
+reason and rebased with `git rebase --onto main <old-tip>` after the squash
+merge. #51, #52 and #54 all touch the same file. Also: regenerate the doc at the
+end of **every** task, not once at the end — a freshness test goes red the moment
+the module changes, and a suite with a known failure is one a real regression
+hides behind.
+
+**3. The e2e harness is scratchpad-only and will not survive.** It lived at
+`<session-scratchpad>/e2e` with style-dictionary 4.4.0 and `scripts/lib`
+symlinked to the repo's live code. No token source is vendored here — zygarden
+is external, at `~/Dev/zygarden-frontend`, branch
+`feature/apply-brandguide-styles`, read with `git show <branch>:<path>`. Do not
+check it out or modify it. Rebuilding is the first step of any e2e run.
+
+**The assertion worth reusing:** rather than counting declarations, build at
+`main` and at `HEAD` and `diff -r`. Byte-identical output rules out compensating
+changes that counts would miss, and with the harness up it is nearly free.
+
+## What #55 established that outlives it
+
+**DTCG forbids dual nodes.** #55's premise — "DTCG permits a node carrying both
+a `$value` and children" — is false against the 30 July 2026 draft, §6.1,
+MUST-level, and §6.2's `$root` is the sanctioned alternative. Two repo comments
+repeating that falsehood are corrected in #59. This does not change what
+throughline does — Figma emits dual nodes — but behaviour for the shape is a
+judgment about malformed input, and must not be argued as spec interpretation.
+
+**DTCG §5.2.2 orders type resolution**, and the ordering is load-bearing here: a
+reference-valued token takes its *referent's* type, outranking group
+inheritance. `preprocess` runs `resolveInPlace` before `hoistDualNodes`, so by
+hoist time every whole-value reference is already a literal and the hoist cannot
+tell. A module-level `WeakSet` records them while the reference is still
+visible. Anything touching that pipeline must preserve this.
+
+## Open questions
+
+- **Merge order.** #59 targets `main` and is mergeable. Nothing blocks it.
+- **#60 is the honest loose end of #59.** Where an enclosing *group* carries a
+  `$type` that correctly describes a hoisted child, the dual node's type shadows
+  it — the one accepted cost that turns correct output into wrong, and the only
+  one with no test. Deliberate: a test would read as endorsement.
+- **Does the consumption-layer epic (#39–#44) start after #54, or sooner?** The
+  original reasoning was that #39 should begin on a clean base. Two of the four
+  correctness items are now done.
+
+## Working note on process
+
+Across #53 and #55, reviews caught six defects a green suite could not, and
+**every one was a defect in the written design, not the implementation**. Two
+reached code and were caught only by an escalated-tier review reading real
+output. Both had the same cause: narrowing or deleting a shared helper without
+accounting for every consumer it served. Worth spending review budget on the
+spec and on the diff against real output rather than on transcription.

--- a/docs/superpowers/plans/2026-08-24-hoist-dual-nodes.md
+++ b/docs/superpowers/plans/2026-08-24-hoist-dual-nodes.md
@@ -1,0 +1,528 @@
+# hoistDualNodes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop `hoistDualNodes` silently discarding a token on a name collision, and stop it dropping the `$type` a hoisted child should keep.
+
+**Architecture:** Both fixes live in one module-private function in `scripts/lib/sd-native.mjs`. Collision detection threads an accumulator through the recursion and throws once from `preprocess`, after the whole tree is walked. `$type` inheritance carries the dual node's type onto an untyped child, except where the child's authored value was a whole-value reference — those are tagged by `resolveInPlace` with a module-private `Symbol` while the reference is still visible.
+
+**Tech Stack:** Node ≥20, ES modules, `node:test` + `node:assert/strict`. Zero runtime dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-08-23-hoist-dual-nodes-design.md` (revision 2)
+
+## Global Constraints
+
+- **Zero dependencies.** `scripts/lib/sd-native.mjs` imports only `node:*` builtins and local modules. Style Dictionary is a parameter, never an import.
+- **Node ≥20**, ESM.
+- **Every line of code added to `sd-native.mjs` must sit inside the `preprocess` `@doc-section` pair** (currently lines 56–124). Only blank lines and `//` comments may sit outside a pair; `node scripts/build-native-adapter-config.mjs --check` fails loudly otherwise. Regenerate the doc in the same commit.
+- **Do not fix, mask, or work around #51, #52, #54.** Task 2 deliberately *widens* #52 and must prove it by test rather than hide it.
+- **`scripts/lib/dtcg.mjs` is NOT touched.** Spec revision 1 listed it in error; it makes no legality claim.
+- **Test style:** `import { test } from 'node:test'; import assert from 'node:assert/strict';` — flat `test(...)` calls, no suites.
+- Baseline: `node --test` = **312 pass / 0 fail**; all six gates green; `main` is at `698a236`.
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `scripts/lib/sd-native.mjs` | modify | `hoistDualNodes` (collision + `$type`), `resolveInPlace` (reference tag), `preprocess` (throw). |
+| `scripts/lib/sd-native.test.mjs` | modify | Fixtures for both defects, the third collision variant, the exclusion, idempotency. |
+| `scripts/build-native-adapter-config.mjs` | modify | Correct the "legal DTCG" narrative prose at line 102. |
+| `references/native-adapter-config.md` | **generated** | Regenerate; never hand-edit. |
+
+Task 1 and Task 2 both edit `hoistDualNodes` and must run in order. Task 3 depends on both.
+
+---
+
+### Task 1: Collision detection
+
+**Files:**
+- Modify: `scripts/lib/sd-native.mjs` — `hoistDualNodes` (line 106), `preprocess` (line 121)
+- Test: `scripts/lib/sd-native.test.mjs`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `hoistDualNodes(node, collisions, prefix)` — module-private, signature changed. `preprocess(dict)` unchanged externally, but now throws on collision.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/lib/sd-native.test.mjs`:
+
+```js
+// A dual node's child is renamed to a camel-joined sibling. If that name is
+// already taken, the pre-fix code overwrote it and a token vanished with no
+// diagnostic — the same class as the mode collision nativeSources guards.
+test('preprocess throws when a hoisted name collides with an authored token', () => {
+  assert.throws(
+    () =>
+      preprocess({
+        text: {
+          sm: { $value: '14px', lineHeight: { $value: '20px' } },
+          smLineHeight: { $value: '28px' },
+        },
+      }),
+    (err) => {
+      assert.match(err.message, /collide/i);
+      assert.match(err.message, /text\.sm\.lineHeight/);
+      assert.match(err.message, /text\.smLineHeight/);
+      return true;
+    },
+  );
+});
+
+// A group, not a token — hoisting onto it would destroy a whole subtree.
+test('preprocess throws when a hoisted name collides with an authored group', () => {
+  assert.throws(
+    () =>
+      preprocess({
+        text: {
+          sm: { $value: '14px', lineHeight: { $value: '20px' } },
+          smLineHeight: { bold: { $value: '28px' } },
+        },
+      }),
+    /collide/i,
+  );
+});
+
+// Neither name is authored: t.a.bC and t.aB.c both camel-join to t.aBC.
+// The issue does not name this variant; it was found by probing.
+test('preprocess throws when two hoists collide with each other', () => {
+  assert.throws(
+    () =>
+      preprocess({
+        t: {
+          a: { $value: '1px', bC: { $value: '2px' } },
+          aB: { $value: '3px', c: { $value: '4px' } },
+        },
+      }),
+    /collide/i,
+  );
+});
+
+// findModeCollisions exempts identical values because it is deduping across
+// files. This is not a dedupe — two distinct authored tokens land on one name,
+// and they may differ in $type or $description even with equal $value.
+test('preprocess throws on collision even when the values are identical', () => {
+  assert.throws(
+    () =>
+      preprocess({
+        text: {
+          sm: { $value: '14px', lineHeight: { $value: '20px' } },
+          smLineHeight: { $value: '20px' },
+        },
+      }),
+    /collide/i,
+  );
+});
+
+// The recursion is depth-first, so the deepest frame finishes first. An
+// implementation that throws per-frame reports one subtree and stops.
+test('preprocess reports every collision, across depths, in one error', () => {
+  assert.throws(
+    () =>
+      preprocess({
+        outer: {
+          a: { $value: '1px', b: { $value: '2px' } },
+          aB: { $value: '3px' },
+          nested: {
+            c: { $value: '4px', d: { $value: '5px' } },
+            cD: { $value: '6px' },
+          },
+        },
+      }),
+    (err) => {
+      assert.match(err.message, /outer\.a\.b/);
+      assert.match(err.message, /outer\.nested\.c\.d/);
+      assert.match(err.message, /^2 hoisted token name/m);
+      return true;
+    },
+  );
+});
+
+// sd-native.mjs states in prose that preprocess is idempotent, and real builds
+// rely on it (a project may declare the preprocessor at top level as well as on
+// the platform). No test asserted it before this one.
+test('preprocess is idempotent', () => {
+  const input = {
+    text: {
+      sm: { $value: '14px', $type: 'dimension', lineHeight: { $value: '20px', $type: 'dimension' } },
+    },
+  };
+  const once = preprocess(input);
+  const twice = preprocess(once);
+  assert.deepEqual(twice, once);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `node --test scripts/lib/sd-native.test.mjs`
+Expected: the five collision tests FAIL (no throw). The idempotency test should already PASS — it documents existing behaviour; if it fails, stop and report, because that is a pre-existing bug outside this task.
+
+- [ ] **Step 3: Thread the accumulator and detect**
+
+In `scripts/lib/sd-native.mjs`, replace `hoistDualNodes` (line 106) entirely:
+
+```js
+// text.sm.lineHeight becomes text.smLineHeight, which name/camel renders as
+// textSmLineHeight — the identical symbol the un-hoisted path would produce.
+//
+// Collisions are COLLECTED, not thrown here: the walk has to continue to report
+// every one, and the recursion is depth-first, so throwing from a frame would
+// report one subtree. preprocess throws once, after the whole tree is walked.
+//
+// On collision the assignment is SKIPPED. Continuing to overwrite while
+// collecting means later detections are computed against a tree already
+// corrupted — the enclosing loop's Object.entries snapshot still holds the
+// detached node, and its own children then hoist out of a subtree no longer
+// reachable.
+function hoistDualNodes(node, collisions, prefix = []) {
+  for (const [key, val] of Object.entries(node)) {
+    if (key.startsWith('$') || !val || typeof val !== 'object') continue;
+    hoistDualNodes(val, collisions, [...prefix, key]);
+    if ('$value' in val) {
+      for (const [childKey, childVal] of Object.entries(val)) {
+        if (childKey.startsWith('$') || !childVal || typeof childVal !== 'object') continue;
+        const hoisted = key + childKey[0].toUpperCase() + childKey.slice(1);
+        if (hoisted in node) {
+          collisions.push({
+            from: [...prefix, key, childKey].join('.'),
+            onto: [...prefix, hoisted].join('.'),
+            existing: node[hoisted].$value,
+          });
+          continue;
+        }
+        node[hoisted] = childVal;
+        delete val[childKey];
+      }
+    }
+  }
+  return node;
+}
+```
+
+- [ ] **Step 4: Throw once, from `preprocess`**
+
+Replace `preprocess` (line 121):
+
+```js
+export function preprocess(dict) {
+  const collisions = [];
+  const out = hoistDualNodes(
+    resolveInPlace(structuredClone(dict), flattenDtcg(dict)),
+    collisions,
+  );
+  if (collisions.length) {
+    const shown = collisions
+      .slice(0, 5)
+      .map((c) => `  ${c.from} -> ${c.onto}` + (c.existing === undefined ? ' (a group)' : ` (would overwrite ${JSON.stringify(c.existing)})`))
+      .join('\n');
+    const more = collisions.length > 5 ? `\n  ...and ${collisions.length - 5} more` : '';
+    throw new Error(
+      `${collisions.length} hoisted token name(s) collide with an existing sibling.\n` +
+        "A dual node's child is renamed to a camel-joined sibling, and that name is taken.\n" +
+        'Hoisting would silently discard one of the two. Rename the child or the sibling.\n' +
+        `${shown}${more}`,
+    );
+  }
+  return out;
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `node --test scripts/lib/sd-native.test.mjs`
+Expected: PASS. The pre-existing hoist tests and "does not mutate its input" must still pass untouched.
+
+- [ ] **Step 6: Full suite**
+
+Run: `node --test`
+Expected: 318 pass, 0 fail (312 + 6 new).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/lib/sd-native.mjs scripts/lib/sd-native.test.mjs
+git commit -m "fix: throw when a hoisted dual-node name collides instead of discarding a token (#55)"
+```
+
+---
+
+### Task 2: `$type` inheritance, with the reference exclusion
+
+**Files:**
+- Modify: `scripts/lib/sd-native.mjs` — `resolveInPlace` (line ~83), `hoistDualNodes`
+- Test: `scripts/lib/sd-native.test.mjs`
+
+**Interfaces:**
+- Consumes: `hoistDualNodes(node, collisions, prefix)` from Task 1.
+- Produces: a module-private `Symbol` tag on nodes whose authored `$value` was a whole-value reference.
+
+- [ ] **Step 1: Write the failing tests**
+
+```js
+test('a hoisted child inherits the dual node $type when it has none', () => {
+  const out = preprocess({
+    text: { sm: { $value: '14px', $type: 'dimension', lineHeight: { $value: '20px' } } },
+  });
+  assert.equal(out.text.smLineHeight.$type, 'dimension');
+});
+
+test('a hoisted child keeps its own $type', () => {
+  const out = preprocess({
+    text: {
+      sm: { $value: '14px', $type: 'dimension', family: { $value: 'Inter', $type: 'fontFamily' } },
+    },
+  });
+  assert.equal(out.text.smFamily.$type, 'fontFamily');
+});
+
+test('nothing is invented when the dual node has no $type', () => {
+  const out = preprocess({
+    text: { sm: { $value: '14px', lineHeight: { $value: '20px' } } },
+  });
+  assert.equal('$type' in out.text.smLineHeight, false);
+});
+
+// Depth-first recursion means the inner hoist completes first, so lineHeightTight
+// is a direct child of sm by the time sm hoists. This is the test that catches a
+// $type carry running in the wrong recursion frame — every single-level test
+// passes regardless.
+test('$type inheritance reaches a child hoisted through two levels', () => {
+  const out = preprocess({
+    text: {
+      sm: {
+        $value: '14px',
+        $type: 'dimension',
+        lineHeight: { $value: '20px', tight: { $value: '18px' } },
+      },
+    },
+  });
+  assert.equal(out.text.smLineHeight.$type, 'dimension');
+  assert.equal(out.text.smLineHeightTight.$type, 'dimension');
+});
+
+// DTCG 5.2.2 orders its rules: a reference-valued token takes the RESOLVED type
+// of its referent, and that outranks group inheritance. resolveInPlace flattens
+// the reference before the hoist runs, so without a tag the hoist cannot tell
+// and would stamp the parent's $type over the referent's.
+test('a child whose authored value was a reference does not inherit $type', () => {
+  const out = preprocess({
+    ratio: { normal: { $value: '1.5', $type: 'number' } },
+    text: {
+      sm: { $value: '14px', $type: 'dimension', lineHeight: { $value: '{ratio.normal}' } },
+    },
+  });
+  assert.equal(out.text.smLineHeight.$value, '1.5');
+  assert.equal('$type' in out.text.smLineHeight, false);
+});
+
+// The Symbol tag must not reach Style Dictionary or any serialized output.
+test('the reference tag does not leak into output', () => {
+  const out = preprocess({
+    ratio: { normal: { $value: '1.5', $type: 'number' } },
+    text: { sm: { $value: '14px', lineHeight: { $value: '{ratio.normal}' } } },
+  });
+  assert.deepEqual(Object.keys(out.text.smLineHeight), ['$value']);
+  assert.equal(JSON.stringify(out).includes('was-reference'), false);
+});
+
+// #55's fix widens #52 rather than masking it: an untyped unitless literal child
+// under a dimension-typed dual node now becomes dimension, which is exactly
+// #52's shape. Asserted so the widening is recorded, not discovered later.
+test('the $type rule widens #52 — recorded, not masked', () => {
+  const out = preprocess({
+    leading: { base: { $value: '16px', $type: 'dimension', normal: { $value: '1.5' } } },
+  });
+  assert.equal(out.leading.baseNormal.$type, 'dimension', '#52 shape, knowingly produced');
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `node --test scripts/lib/sd-native.test.mjs`
+Expected: the inheritance tests FAIL. "nothing is invented" and the leak test may already pass — that is fine.
+
+- [ ] **Step 3: Tag whole-value references in `resolveInPlace`**
+
+In `scripts/lib/sd-native.mjs`, inside the `preprocess` `@doc-section`, add above `const WHOLE_REF` (line 71):
+
+```js
+// Marks a node whose AUTHORED $value was a whole-value reference, so the hoist
+// can decline to override the type DTCG 5.2.2 rule 1 already determined from the
+// referent. A Symbol key is invisible to Object.entries, to JSON.stringify, and
+// to Style Dictionary, so it cannot leak into output.
+const WAS_REF = Symbol('dtcg/was-reference');
+```
+
+Then in `resolveInPlace`, replace the `WHOLE_REF` branch:
+
+```js
+      if (WHOLE_REF.test(val.$value)) {
+        val[WAS_REF] = true;
+        try {
+          val.$value = resolveValue(path.join('.'), flat);
+        } catch {
+          /* leave an unresolvable reference in place for SD to report */
+        }
+      } else {
+```
+
+The tag is set before the `try` deliberately: an unresolvable reference is still a reference and still must not inherit.
+
+- [ ] **Step 4: Carry `$type` on hoist**
+
+In `hoistDualNodes`, immediately before `node[hoisted] = childVal;`:
+
+```js
+        // The dual node is the child's closest $type-bearing ancestor as
+        // authored; after the hoist it is a sibling, so the type is lost unless
+        // it travels. Excluded for a reference-valued child — DTCG 5.2.2 gives
+        // it the referent's type, which outranks inheritance.
+        if (!('$type' in childVal) && '$type' in val && !childVal[WAS_REF]) {
+          childVal.$type = val.$type;
+        }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `node --test scripts/lib/sd-native.test.mjs`
+Expected: PASS.
+
+- [ ] **Step 6: Full suite**
+
+Run: `node --test`
+Expected: 325 pass, 0 fail (318 + 7 new).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/lib/sd-native.mjs scripts/lib/sd-native.test.mjs
+git commit -m "fix: carry \$type onto a hoisted dual-node child, except reference-valued ones (#55)"
+```
+
+---
+
+### Task 3: Correct the DTCG claim, regenerate, and prove nothing moved
+
+**Files:**
+- Modify: `scripts/lib/sd-native.mjs:61`
+- Modify: `scripts/build-native-adapter-config.mjs:102`
+- Regenerate: `references/native-adapter-config.md`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1 and 2.
+- Produces: no code.
+
+- [ ] **Step 1: Correct the module comment**
+
+`scripts/lib/sd-native.mjs:61` currently reads:
+
+```
+// children — legal DTCG, and common in Figma-derived sources, where text.sm
+```
+
+It is false. Replace that line and its neighbour so the sentence reads: the dual-node pattern is **invalid DTCG** — Design Tokens Format Module, 30 July 2026, §6.1, requires tools to report an object carrying both `$value` and children as an error, and §6.2's `$root` is the sanctioned way to express it — but Figma-derived sources emit it regardless, so this module handles it rather than rejecting it. Keep the existing `text.sm` example. Stay inside the `preprocess` `@doc-section` pair.
+
+- [ ] **Step 2: Correct the generator's narrative prose**
+
+`scripts/build-native-adapter-config.mjs:102` currently reads:
+
+```
+is legal DTCG and common in Figma-derived sources: \`text.sm\` holds
+```
+
+Make the same correction in the same terms. This string becomes `references/native-adapter-config.md:117`.
+
+- [ ] **Step 3: Regenerate and gate**
+
+```bash
+node scripts/build-native-adapter-config.mjs
+node scripts/build-native-adapter-config.mjs --check
+grep -c "legal DTCG" references/native-adapter-config.md
+```
+Expected: `--check` exits 0; the grep returns **0**.
+
+- [ ] **Step 4: Rebuild the e2e harness**
+
+No token source is vendored in this repo. Rebuild in the scratchpad:
+
+```bash
+E=<scratchpad>/e2e && mkdir -p $E/scripts && cd $E
+npm init -y >/dev/null && npm install style-dictionary@4.4.0 >/dev/null
+ln -sfn /Users/jordansstudio/Dev/throughline/scripts/lib $E/scripts/lib
+mkdir -p tokens && for f in color-primitives color-semantic.dark color-semantic.light \
+  leading-primitives radius-primitives radius-semantic spacing-primitives \
+  spacing-semantic.desktop spacing-semantic.mobile stroke-primitives stroke-semantic \
+  text-primitives typography-primitives typography-semantic.desktop typography-semantic.mobile; do
+  git -C ~/Dev/zygarden-frontend show \
+    feature/apply-brandguide-styles:libs/shared/util-tokens/src/tokens/$f.json > tokens/$f.json
+done
+```
+
+Symlinking `scripts/lib` to the repo means the build exercises shipping code, not a snapshot. Do **not** check out or modify the zygarden repo.
+
+Write `build.mjs` importing `registerNativeTransforms`, `nativePlatform`, `nativeSources` from `./scripts/lib/sd-native.mjs`, building `ios-swift` and `android-kotlin` × light/dark, with the mobile viewport axis and `packageName: 'com.zygarden.tokens'` for Kotlin.
+
+- [ ] **Step 5: Assert nothing moved**
+
+```bash
+cd $E && node build.mjs
+for f in out/*/ios/Tokens.swift out/*/android/Tokens.kt; do
+  printf "%-30s decls=%s broken=%s\n" "$f" \
+    "$(grep -cE '(static let|val) [A-Za-z_]' $f)" \
+    "$(grep -cE '= (Nunito Sans|linear-gradient)' $f)"
+done
+```
+
+Expected, all four: `decls=195 broken=0` — **identical to before this branch**.
+
+This is the whole assertion. Zygarden's `text.*` children each carry `$type: dimension` explicitly and no name collides, so neither defect is reachable there. **The e2e run does not validate either fix** — synthetic fixtures do. If any number differs, stop and report: it means the change altered output it should not have touched.
+
+- [ ] **Step 6: Full gate run**
+
+```bash
+cd /Users/jordansstudio/Dev/throughline
+node --test && node ci/validate-plugin.mjs && node ci/validate-skills.mjs \
+  && node scripts/adapters/generate.mjs --check \
+  && node scripts/build-doc-card-builder.mjs --check \
+  && node scripts/build-native-adapter-config.mjs --check && echo ALL GREEN
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/lib/sd-native.mjs scripts/build-native-adapter-config.mjs references/native-adapter-config.md
+git commit -m "docs: the dual-node pattern is invalid DTCG, not legal (#55)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec section | Task |
+|---|---|
+| Defect 2 — collision throws | 1 |
+| Collision: authored token / group / hoist-vs-hoist | 1, steps 1 & 3 |
+| Collision: identical values still throw | 1, step 1 |
+| Collision: detect, do not assign | 1, step 3 |
+| Collision: top frame throws | 1, step 4 |
+| Error shape mirrors `nativeSources` | 1, step 4 |
+| Idempotency test (missing, must be written) | 1, step 1 |
+| Defect 1 — carry `$type` | 2 |
+| Exclusion — reference-valued child | 2, steps 3 & 4 |
+| Symbol tag does not leak | 2, step 1 |
+| Two-level inheritance | 2, step 1 |
+| #52 widening recorded by test | 2, step 1 |
+| Two "legal DTCG" corrections | 3, steps 1 & 2 |
+| `dtcg.mjs` NOT touched | Global Constraints |
+| Doc regeneration, `@doc-section` | 3, step 3 |
+| E2E proves no change (195/0) | 3, step 5 |
+| Repo gates | 3, step 6 |
+
+No gaps.
+
+**Placeholder scan:** none. `<scratchpad>` in Task 3 step 4 is a path the executor substitutes, named as such.
+
+**Type consistency:** `hoistDualNodes(node, collisions, prefix)` is defined in Task 1 step 3 and extended in Task 2 step 4 with the same signature. `WAS_REF` is defined in Task 2 step 3 and used in step 4. `preprocess(dict)`'s external signature is unchanged throughout. Collision object keys (`from`, `onto`, `existing`) match between step 3 and step 4 of Task 1.

--- a/docs/superpowers/plans/2026-08-24-hoist-dual-nodes.md
+++ b/docs/superpowers/plans/2026-08-24-hoist-dual-nodes.md
@@ -238,10 +238,20 @@ Expected: PASS. The pre-existing hoist tests and "does not mutate its input" mus
 Run: `node --test`
 Expected: 318 pass, 0 fail (312 + 6 new).
 
-- [ ] **Step 7: Commit**
+- [ ] **Step 7: Regenerate the reference doc**
+
+`references/native-adapter-config.md` is generated from `sd-native.mjs` and a test asserts it is fresh, so it goes stale the moment the module changes. Regenerate at the end of **every** task that touches the module, not once at the end — a suite with a known-failing test is one a real regression can hide behind.
 
 ```bash
-git add scripts/lib/sd-native.mjs scripts/lib/sd-native.test.mjs
+node scripts/build-native-adapter-config.mjs
+node --test
+```
+Expected: 318 pass, **0 fail**.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add scripts/lib/sd-native.mjs scripts/lib/sd-native.test.mjs references/native-adapter-config.md
 git commit -m "fix: throw when a hoisted dual-node name collides instead of discarding a token (#55)"
 ```
 
@@ -393,10 +403,18 @@ Expected: PASS.
 Run: `node --test`
 Expected: 325 pass, 0 fail (318 + 7 new).
 
-- [ ] **Step 7: Commit**
+- [ ] **Step 7: Regenerate the reference doc**
 
 ```bash
-git add scripts/lib/sd-native.mjs scripts/lib/sd-native.test.mjs
+node scripts/build-native-adapter-config.mjs
+node --test
+```
+Expected: 325 pass, **0 fail**.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add scripts/lib/sd-native.mjs scripts/lib/sd-native.test.mjs references/native-adapter-config.md
 git commit -m "fix: carry \$type onto a hoisted dual-node child, except reference-valued ones (#55)"
 ```
 

--- a/docs/superpowers/specs/2026-08-23-hoist-dual-nodes-design.md
+++ b/docs/superpowers/specs/2026-08-23-hoist-dual-nodes-design.md
@@ -1,0 +1,149 @@
+# hoistDualNodes — `$type` inheritance and collision — design
+
+**Issue:** [#55](https://github.com/jrpease/throughline/issues/55)
+**Date:** 2026-08-23
+**Depends on:** [#56](https://github.com/jrpease/throughline/pull/56) (#53). Same file,
+and `references/native-adapter-config.md` is generated from the whole module, so
+this branch stacks rather than forking from `main`.
+
+## The two defects
+
+`scripts/lib/sd-native.mjs`'s `hoistDualNodes` moves a dual node's child to a
+camel-joined sibling: `text.sm.lineHeight` becomes `text.smLineHeight`, which
+`name/camel` renders to `textSmLineHeight` — the identical symbol the un-hoisted
+path would have produced. That part works and is tested.
+
+1. **`$type` does not travel with the hoisted child.** If the child has no
+   `$type` of its own and the enclosing group declares none, the hoisted token
+   arrives untyped, no size transform fires, and it emits as a bare `20px`.
+   Fails loudly — `no-bare-units` catches it.
+2. **A name collision overwrites with no diagnostic.** If `text.smLineHeight`
+   already exists as a sibling, the hoist silently replaces it. Fails silently.
+
+## What the issue got wrong, and why it matters
+
+The issue opens: *"DTCG permits a node carrying both a `$value` and children."*
+`scripts/lib/dtcg.mjs:9` says the same — *"legal DTCG, and common in
+Figma-derived sources."*
+
+**Both are false against the current specification.** Design Tokens Format
+Module, Draft Community Group Report of **30 July 2026**, §6.1 Group Structure:
+
+> **Important:** The presence of a `$value` property definitively identifies an
+> object as a token. If an object contains both `$value` and child tokens/groups,
+> this creates an invalid structure where the object cannot be both a token and a
+> group simultaneously. Tools *MUST* report this as an error.
+
+This does not change what throughline should *do*. Figma-derived sources emit
+dual nodes regardless, and refusing them would make the tool useless against its
+own validation target. `hoistDualNodes` stays.
+
+It changes two things that matter:
+
+- **The two "legal DTCG" comments are factual errors** and are corrected. This
+  repo demoted an adapter tier for overclaiming; a wrong citation of a spec is
+  the same defect in a different place.
+- **It settles defect 1.** The issue defers the fix pending a decision about
+  "DTCG type-inheritance semantics… the spec does not obviously address the
+  case." There is no such decision to make: the spec addresses the shape by
+  forbidding it, so no reading of §5.2.2's inheritance rule governs it. We are
+  defining behaviour for non-conforming input, and the deciding principle has to
+  come from what this function is for.
+
+## Decision — the hoist must be semantics-preserving
+
+`hoistDualNodes` exists to make the hoisted child produce *"the identical symbol
+the un-hoisted path would have produced."* That is a preservation guarantee, and
+the name is not the only thing it has to preserve.
+
+Apply DTCG's own inheritance rule (§5.2.2 — *"the token's type is inherited from
+the closest parent group with a `$type` property"*) to the tree as authored:
+
+| | closest ancestor carrying `$type` |
+|---|---|
+| before hoist | `text.sm` — the dual node itself |
+| after hoist | `text` — the dual node is no longer an ancestor |
+
+So the hoist **changes the token's resolved type** unless the type moves with it.
+That is a bug in the hoist, not an open question about the spec. Carrying `$type`
+onto the hoisted child restores exactly what the child would have resolved to in
+place — the same argument that justifies the rename, applied to the other half of
+the token's identity.
+
+**Rule.** On hoist, if the child has no `$type` of its own, and the dual node
+does, copy the dual node's `$type` onto the child. A child with its own `$type`
+is never overwritten. Nothing else inherits — this is not a general
+type-propagation pass.
+
+Consequence worth naming: a dual node typed `dimension` with a child that is
+genuinely something else, and that omits its own `$type`, now inherits
+`dimension` and is wrong. It was untyped and wrong before. Both fail — the
+difference is that the inherited case may fail *silently* where the untyped case
+failed loudly under `no-bare-units`. That is the one real cost, and it is
+accepted because the child omitting a `$type` under a differently-typed parent is
+already malformed in a way no reading rescues, whereas the same-type case is the
+overwhelmingly common one and is currently broken.
+
+## Decision — collision throws
+
+There is no reading under which silently discarding an authored token is
+correct, and this project already holds that position in code: `nativeSources`
+throws on mode collisions precisely because *"a token quietly disappearing
+because two things resolved to one name"* is the worst failure in this pipeline.
+This path is the same class with no equivalent guard.
+
+Throw, naming both paths and the value being lost, in the shape `nativeSources`
+already uses. Report **all** collisions in one error rather than the first —
+`findModeCollisions` sets that precedent, and one-at-a-time errors make a
+malformed source a repeated-run slog.
+
+The check must catch a collision against **either** an authored sibling or an
+earlier hoist in the same pass, since both lose a token.
+
+## Changes
+
+| File | Change |
+|---|---|
+| `scripts/lib/sd-native.mjs` | `hoistDualNodes`: carry `$type`; collect and throw on collisions. Must stay inside the `preprocess` `@doc-section` pair. |
+| `scripts/lib/sd-native.test.mjs` | Fixtures for both defects. |
+| `scripts/lib/dtcg.mjs` | Correct the "legal DTCG" comment. |
+| `references/native-adapter-config.md` | Regenerate — CI-gated by `--check`. |
+
+`preprocess`'s signature does not change. `flattenDtcg` is untouched: it descends
+into dual nodes and yields both the parent value and the child, which is correct
+regardless of the spec's view, because it reads what is actually there.
+
+## Testing
+
+1. **`$type` inheritance** — dual node typed `dimension`, child untyped: hoisted
+   child arrives typed `dimension`. Child with its own `$type`: not overwritten.
+   Dual node with no `$type`: child stays untyped (no invention).
+2. **Collision** — camel-joined name already present as an authored sibling:
+   throws, and the message names both paths.
+3. **Collision between two hoists** in one pass: throws.
+4. **Multiple collisions**: one error listing all of them.
+5. **Regression** — the existing hoist tests pass unchanged; `preprocess` is
+   still idempotent.
+6. **End to end** — rebuild the four real outputs. **Expect no change:** 195
+   declarations, 0 broken, `value-verified` 107. Zygarden's `text.*` children
+   each carry `$type: dimension` and no name collides, so neither defect is
+   reachable there. Confirming *nothing moved* is the actual assertion.
+7. **Repo gates** — all six.
+
+## Limitations
+
+- **The real source cannot exercise either fix.** Both defects are unreachable in
+  zygarden, which is why #50 did not hit them. Coverage is synthetic fixtures
+  plus an end-to-end run that proves no regression. Stating this because the
+  alternative — implying the e2e run validates the fix — is the overclaim this
+  repo has been bitten by before.
+- **Throwing is a breaking change** for any consumer whose source has a
+  colliding name today. Their build currently succeeds and silently drops a
+  token, so the break surfaces existing data loss rather than causing it.
+- **Dual nodes remain unreported as invalid DTCG.** Detecting and warning on the
+  shape itself is a separate question, and arguably belongs in a validator rather
+  than a preprocessor. Out of scope; worth an issue.
+
+## Out of scope
+
+#51, #52, #54. This change must neither fix nor mask them.

--- a/docs/superpowers/specs/2026-08-23-hoist-dual-nodes-design.md
+++ b/docs/superpowers/specs/2026-08-23-hoist-dual-nodes-design.md
@@ -2,8 +2,8 @@
 
 **Issue:** [#55](https://github.com/jrpease/throughline/issues/55)
 **Date:** 2026-08-23
-**Revision:** 3 — the reference tag became a `WeakSet`, and the blast-radius
-section now records that #51 is widened alongside #52. See
+**Revision:** 4 — the accepted-cost section now records the *correct becomes
+wrong* sub-case alongside *loud becomes silent*. See
 [Revision history](#revision-history).
 **Depends on:** [#56](https://github.com/jrpease/throughline/pull/56) (#53). Same
 file, and `references/native-adapter-config.md` is generated from the whole
@@ -196,6 +196,31 @@ Revision 2 wrote "a *differently-typed* parent" there, which was too narrow —
 see the #51 case below, where the parent's type is `dimension` and so is the
 child's, and the emitted unit is still wrong.
 
+**And "loud becomes silent" does not cover every case either.** One sub-case is
+*correct becomes wrong*. When an enclosing **group** carries a `$type` that does
+describe the child, the carry shadows it — DTCG §5.2.2 inherits from the closest
+parent *group*, and the dual node is a token, not a group, so before this change
+the group's type was the one that applied. Measured against `main`:
+
+```
+in   : { text: { $type: "dimension",
+                 sm: { $value: "#fff", $type: "color",
+                       lineHeight: { $value: "20px" } } } }
+main : text.smLineHeight = { $value: "20px" }                  -> inherits dimension from the group: RIGHT
+HEAD : text.smLineHeight = { $value: "20px", $type: "color" }  -> WRONG
+```
+
+There was no loud failure here and no malformed input by the standard the
+sentence above uses — there was a right answer, and the carry replaces it.
+
+Not fixed, deliberately. The rule that would fix it — carry the dual node's
+`$type` only when no enclosing group supplies one — means threading the ancestor
+group chain through the recursion for a shape that requires a dual node typed
+differently from both its parent group and its own child. Unreachable in
+zygarden, and the added machinery is a worse trade than the defect. Recorded
+here so the residual is described accurately rather than flatteringly, which is
+the whole point of this section.
+
 ### Blast radius — two open issues, both widened, both recorded
 
 The rule converts a loud failure into a silent one in two measured cases. Both
@@ -336,6 +361,19 @@ wrong recursion frame passes every single-level test.
 records the one place it widens #52 rather than leaving the claim unexamined.
 
 ## Revision history
+
+**Revision 4 (2026-08-24)** — the final whole-branch review. One correction,
+again to a claim rather than the decision: the accepted-cost section framed the
+residual entirely as *loud becomes silent*, and one sub-case is *correct becomes
+wrong*. Where an enclosing group carries a `$type` that describes the child, the
+carry shadows it — and DTCG §5.2.2 inherits from the closest parent *group*, so
+the group's type is the one that applied before. Measured and recorded above,
+with the reason it is not fixed.
+
+The same review found two things outside this document, both fixed rather than
+recorded: the collision error message described only the authored-sibling case
+and misdirected on the hoist-vs-hoist variant, and `CHANGELOG.md` had no entry
+for a change that makes a consumer's build throw.
 
 **Revision 3 (2026-08-24)** — Task 2's review, during execution. Two
 corrections, both to claims this document made rather than to the decision:

--- a/docs/superpowers/specs/2026-08-23-hoist-dual-nodes-design.md
+++ b/docs/superpowers/specs/2026-08-23-hoist-dual-nodes-design.md
@@ -2,9 +2,11 @@
 
 **Issue:** [#55](https://github.com/jrpease/throughline/issues/55)
 **Date:** 2026-08-23
-**Depends on:** [#56](https://github.com/jrpease/throughline/pull/56) (#53). Same file,
-and `references/native-adapter-config.md` is generated from the whole module, so
-this branch stacks rather than forking from `main`.
+**Revision:** 2 — review found a mis-citation, an unsound argument, and a real
+hazard the rule created. See [Revision history](#revision-history).
+**Depends on:** [#56](https://github.com/jrpease/throughline/pull/56) (#53). Same
+file, and `references/native-adapter-config.md` is generated from the whole
+module, so this branch stacks rather than forking from `main`.
 
 ## The two defects
 
@@ -13,137 +15,314 @@ camel-joined sibling: `text.sm.lineHeight` becomes `text.smLineHeight`, which
 `name/camel` renders to `textSmLineHeight` — the identical symbol the un-hoisted
 path would have produced. That part works and is tested.
 
-1. **`$type` does not travel with the hoisted child.** If the child has no
-   `$type` of its own and the enclosing group declares none, the hoisted token
-   arrives untyped, no size transform fires, and it emits as a bare `20px`.
-   Fails loudly — `no-bare-units` catches it.
-2. **A name collision overwrites with no diagnostic.** If `text.smLineHeight`
-   already exists as a sibling, the hoist silently replaces it. Fails silently.
+Both defects reproduce against the shipped function:
+
+```
+A. $type does not travel
+   in : {"text":{"sm":{"$value":"14px","$type":"dimension","lineHeight":{"$value":"20px"}}}}
+   out: {"text":{"sm":{"$value":"14px","$type":"dimension"},"smLineHeight":{"$value":"20px"}}}
+                                                             ^ untyped
+
+B. collision with an authored sibling
+   in : {"text":{"sm":{"$value":"14px","lineHeight":{"$value":"20px"}},"smLineHeight":{"$value":"28px"}}}
+   out: {"text":{"sm":{"$value":"14px"},"smLineHeight":{"$value":"20px"}}}
+                                                        ^ authored 28px is gone
+```
+
+**A third variant the issue does not name, also measured:** two *hoists* can
+collide with each other, with no authored sibling involved.
+
+```
+D. in : {"t":{"a":{"$value":"1px","bC":{"$value":"2px"}},"aB":{"$value":"3px","c":{"$value":"4px"}}}}
+   out: {"t":{"a":{"$value":"1px"},"aB":{"$value":"3px"},"aBC":{"$value":"4px"}}}
+                                                          ^ a.bC's 2px is gone
+```
+
+`t.a.bC` and `t.aB.c` both camel-join to `t.aBC`. Any collision guard has to
+cover this, not only collisions against authored siblings.
 
 ## What the issue got wrong, and why it matters
 
 The issue opens: *"DTCG permits a node carrying both a `$value` and children."*
-`scripts/lib/dtcg.mjs:9` says the same — *"legal DTCG, and common in
-Figma-derived sources."*
 
-**Both are false against the current specification.** Design Tokens Format
-Module, Draft Community Group Report of **30 July 2026**, §6.1 Group Structure:
+**That is false against the current specification.** Design Tokens Format Module,
+Draft Community Group Report of **30 July 2026**, §6.1 Group Structure:
 
 > **Important:** The presence of a `$value` property definitively identifies an
 > object as a token. If an object contains both `$value` and child tokens/groups,
 > this creates an invalid structure where the object cannot be both a token and a
 > group simultaneously. Tools *MUST* report this as an error.
 
+Normative, not a note. And the prohibition is deliberate rather than an
+oversight: §6.2 defines `$root` as the sanctioned way to express exactly what a
+dual node is reaching for — *"Groups MAY contain a root token alongside child
+tokens and nested groups. A root token provides a base value for the group while
+allowing for variants or extensions."* The shape has a blessed spelling; the
+dual node is not it.
+
 This does not change what throughline should *do*. Figma-derived sources emit
 dual nodes regardless, and refusing them would make the tool useless against its
 own validation target. `hoistDualNodes` stays.
 
-It changes two things that matter:
+It changes two things:
 
-- **The two "legal DTCG" comments are factual errors** and are corrected. This
-  repo demoted an adapter tier for overclaiming; a wrong citation of a spec is
-  the same defect in a different place.
-- **It settles defect 1.** The issue defers the fix pending a decision about
-  "DTCG type-inheritance semantics… the spec does not obviously address the
-  case." There is no such decision to make: the spec addresses the shape by
-  forbidding it, so no reading of §5.2.2's inheritance rule governs it. We are
-  defining behaviour for non-conforming input, and the deciding principle has to
-  come from what this function is for.
+- **Two comments in this repo state the falsehood** and are corrected:
+  - `scripts/lib/sd-native.mjs:61` — *"legal DTCG, and common in Figma-derived
+    sources"*, inside the `preprocess` `@doc-section`, so it flows into
+    `references/native-adapter-config.md:128`.
+  - `scripts/build-native-adapter-config.mjs:102` — hand-written narrative prose,
+    *"The dual-node pattern is legal DTCG and common in Figma-derived sources"*,
+    which becomes `references/native-adapter-config.md:117`.
 
-## Decision — the hoist must be semantics-preserving
+  Revision 1 of this spec cited `scripts/lib/dtcg.mjs:9` for this. **That was
+  wrong** — `dtcg.mjs` describes the traversal behaviour and makes no legality
+  claim at all. Correcting it would have left both real claims standing, and
+  `--check` would still pass, since the generator was unchanged. A wrong citation
+  in the paragraph arguing that wrong citations are defects.
+- **It removes the question the issue defers on.** The issue holds defect 1
+  pending a decision about *"DTCG type-inheritance semantics… the spec does not
+  obviously address the case."* The spec addresses the shape by forbidding it, so
+  there is no conforming reading to discover. What remains is a judgment call
+  about non-conforming input — which is a different and smaller thing than a spec
+  interpretation, and should not be dressed up as one.
 
-`hoistDualNodes` exists to make the hoisted child produce *"the identical symbol
-the un-hoisted path would have produced."* That is a preservation guarantee, and
-the name is not the only thing it has to preserve.
+## Decision — carry `$type`, as a judgment about malformed input
 
-Apply DTCG's own inheritance rule (§5.2.2 — *"the token's type is inherited from
-the closest parent group with a `$type` property"*) to the tree as authored:
+**Carry it.** On hoist, if the child has no `$type` of its own and the dual node
+does, copy the dual node's `$type` onto the child.
 
-| | closest ancestor carrying `$type` |
-|---|---|
-| before hoist | `text.sm` — the dual node itself |
-| after hoist | `text` — the dual node is no longer an ancestor |
+The grounds are pragmatic, and stating them as anything stronger would be
+overclaiming:
 
-So the hoist **changes the token's resolved type** unless the type moves with it.
-That is a bug in the hoist, not an open question about the spec. Carrying `$type`
-onto the hoisted child restores exactly what the child would have resolved to in
-place — the same argument that justifies the rename, applied to the other half of
-the token's identity.
+1. **It is what the author meant.** A dual node typed `dimension` with a
+   `lineHeight` child is one concept; the type describes the family.
+2. **It is what the real producer emits.** In zygarden every `text.*` child
+   already carries `$type: dimension` explicitly — the same answer the
+   inheritance would give.
+3. **The alternative is worse in the common case.** Untyped means no size
+   transform fires and the token emits as a bare literal.
 
-**Rule.** On hoist, if the child has no `$type` of its own, and the dual node
-does, copy the dual node's `$type` onto the child. A child with its own `$type`
-is never overwritten. Nothing else inherits — this is not a general
-type-propagation pass.
+**What this argument is not.** Revision 1 presented this as a deduction from
+DTCG §5.2.2 — *"the token's type is inherited from the closest parent group with
+a `$type` property"* — claiming the hoist changes the child's resolved type from
+`text.sm` to `text` and so must preserve it. That argument does not survive
+contact with the text it cites, in two ways:
 
-Consequence worth naming: a dual node typed `dimension` with a child that is
-genuinely something else, and that omits its own `$type`, now inherits
-`dimension` and is wrong. It was untyped and wrong before. Both fail — the
-difference is that the inherited case may fail *silently* where the untyped case
-failed loudly under `no-bare-units`. That is the one real cost, and it is
-accepted because the child omitting a `$type` under a differently-typed parent is
-already malformed in a way no reading rescues, whereas the same-type case is the
-overwhelmingly common one and is currently broken.
+- §5.2.2 and §6.7.3 both say **parent *group***. §6.1, quoted above, says a node
+  with `$value` is *definitively a token*. So the dual node is not a group, and
+  the rule does not name it as an inheritance source. Under a strict reading both
+  the before and after columns resolve to `text`, and there is nothing to
+  preserve.
+- Nothing in this pipeline resolves the child's type pre-hoist anyway. Style
+  Dictionary's collector never reaches it — that is the whole reason the hoist
+  exists — and `flattenDtcg` carries values, not types. The "before" state
+  described a resolution no consumer performs.
+
+It was also self-contradictory: the preceding section disqualified §5.2.2 as
+governing, and the next paragraph decided by §5.2.2. Recorded here rather than
+quietly deleted, because this repo's failure mode is confident wrong reasoning
+surviving into architecture.
+
+### Exclusion — a child whose authored value was a whole-value reference
+
+§5.2.2 orders its rules: **(1)** if the value is a reference, the type is the
+*resolved type of the referent*; **(2)** *otherwise* inherit from the closest
+parent group. Rule 1 outranks rule 2. Stamping the dual node's `$type` over a
+reference-valued child inverts that precedence.
+
+This is not hypothetical, and it manufactures an instance of an open issue.
+Measured:
+
+```
+authored : text.sm  { $value "14px", $type "dimension",
+                      lineHeight: { $value "{ratio.normal}" } }     ratio.normal is $type number
+after preprocess : { "$value": "1.5" }        <- resolveInPlace already flattened the reference
+naive rule gives : { "$value": "1.5", "$type": "dimension" }   -> emits 1.50.dp  (a new #52)
+5.2.2 rule 1 says: { "$value": "1.5", "$type": "number" }
+```
+
+`preprocess` is `hoistDualNodes(resolveInPlace(...))`, so by the time the hoist
+runs every whole-value reference is already a literal and the hoist cannot tell
+the two apart.
+
+**Rule.** A child whose *authored* `$value` was a whole-value reference does not
+inherit. It keeps whatever it has, which is today's behaviour — no regression,
+and no new #52 instances.
+
+**Mechanism.** `resolveInPlace` already tests `WHOLE_REF` and is the only place
+that still knows. It tags such a node with a module-private `Symbol`; the hoist
+reads the tag and skips inheritance. A `Symbol` key is invisible to
+`Object.entries`, to `JSON.stringify`, and to Style Dictionary, so it cannot leak
+into output. The tag is set on the clone `preprocess` already makes, after
+`structuredClone`, so clone semantics are not involved.
+
+Reordering the pipeline to hoist before resolving is **not** the fix: aliases
+elsewhere in the source point at the pre-hoist path (`{text.sm.lineHeight}`), and
+renaming first would break them.
+
+### The accepted cost, stated accurately
+
+A dual node typed `dimension`, with a child that is genuinely something else,
+that omits its own `$type`, and whose value is a literal, now inherits
+`dimension` and is wrong.
+
+Revision 1 claimed this trades a loud failure for a silent one, and that the
+shape is "malformed in a way no reading rescues." Both parts were wrong:
+
+- **`no-bare-units` is narrower than claimed.** `BARE_UNIT` is
+  `/^-?(?:\d+(?:\.\d+)?|\.\d+)(?:px|rem|em|%)$/` — it fires only on a
+  *unit-suffixed* literal. Verified: `20px` caught, `1.5` not. The archetypal
+  wrongly-typed child is a unitless ratio, so the "loud before" baseline holds
+  for `20px` and fails for the case most likely to occur.
+- **"No reading rescues it" is false.** §5.2.2 rule 1 rescues a reference-valued
+  child exactly, which is why the exclusion above exists.
+
+The honest statement of the residual cost: *a child with a **literal** value, no
+`$type`, and a differently-typed parent is malformed, and is accepted as newly
+silent.* That is narrow, and it is the price of fixing the common case.
+
+**#52 blast radius.** The rule takes an untyped unitless literal child under a
+`dimension`-typed dual node and makes it `dimension` — precisely #52's shape, in
+a source where it did not exist before. That is not *masking* #52 (no existing
+instance is hidden) but it does widen it, and the widening must be demonstrated
+by test rather than asserted away.
 
 ## Decision — collision throws
 
 There is no reading under which silently discarding an authored token is
 correct, and this project already holds that position in code: `nativeSources`
-throws on mode collisions precisely because *"a token quietly disappearing
-because two things resolved to one name"* is the worst failure in this pipeline.
-This path is the same class with no equivalent guard.
+throws on mode collisions precisely because a token quietly disappearing because
+two names resolved to one is the worst failure in this pipeline. This path is the
+same class with no equivalent guard.
 
-Throw, naming both paths and the value being lost, in the shape `nativeSources`
-already uses. Report **all** collisions in one error rather than the first —
-`findModeCollisions` sets that precedent, and one-at-a-time errors make a
-malformed source a repeated-run slog.
+Fully specified, because four things about "throw" are underdetermined:
 
-The check must catch a collision against **either** an authored sibling or an
-earlier hoist in the same pass, since both lose a token.
+1. **What counts as a collision.** The camel-joined name is already present on
+   the destination node — as an authored token, as an authored **group** (which
+   would destroy a whole subtree), or as a name already claimed by an earlier
+   hoist in the same pass (case D above). All three are collisions.
+2. **Identical values still throw.** `findModeCollisions` exempts identical
+   values (`defs.length > 1 && distinct.size > 1`), and revision 1 cited it as
+   precedent without noting the divergence. We diverge deliberately: a mode
+   collision is a *dedupe* across files where identical definitions are
+   genuinely redundant, whereas this is two distinct authored tokens landing on
+   one name. Even with equal `$value`, they may differ in `$type` or
+   `$description`, and the source is malformed either way. Throw regardless of
+   value.
+3. **Detect, do not assign.** To report every collision the pass must continue
+   past the first, and continuing while still performing the overwriting
+   assignment means later detections are computed against an already-corrupted
+   tree. Confirmed: with `{ text: { sm: {…lineHeight}, smLineHeight: {…bold} } }`,
+   `sm`'s hoist replaces `smLineHeight` while the enclosing loop's
+   `Object.entries` snapshot still holds the detached old object, so
+   `smLineHeightBold` is emitted from a node no longer in the tree. On collision:
+   record it, claim the name, and skip the assignment.
+4. **The top frame throws, not the deepest.** `hoistDualNodes` is self-recursive.
+   An accumulator must be threaded through the recursion and the throw must
+   happen once, after the whole tree is walked. An implementation that throws at
+   the end of each frame reports one subtree and stops. The recursion is
+   depth-first (`hoistDualNodes(val)` runs before the parent hoists its own
+   children), so the deepest frame finishes first — this is the natural mistake
+   to make.
+
+Error shape mirrors `nativeSources`: count, cause, then up to five collisions
+naming both paths and the value at risk, with an "…and N more" tail.
 
 ## Changes
 
 | File | Change |
 |---|---|
-| `scripts/lib/sd-native.mjs` | `hoistDualNodes`: carry `$type`; collect and throw on collisions. Must stay inside the `preprocess` `@doc-section` pair. |
-| `scripts/lib/sd-native.test.mjs` | Fixtures for both defects. |
-| `scripts/lib/dtcg.mjs` | Correct the "legal DTCG" comment. |
+| `scripts/lib/sd-native.mjs` | `hoistDualNodes`: carry `$type` with the reference exclusion; thread a collision accumulator; throw from the top frame. `resolveInPlace`: tag whole-value references. Both must stay inside the `preprocess` `@doc-section` pair. |
+| `scripts/lib/sd-native.test.mjs` | Fixtures for both defects, the third collision variant, and the exclusion. |
+| `scripts/build-native-adapter-config.mjs` | Correct the "legal DTCG" narrative prose at :102. |
 | `references/native-adapter-config.md` | Regenerate — CI-gated by `--check`. |
 
-`preprocess`'s signature does not change. `flattenDtcg` is untouched: it descends
-into dual nodes and yields both the parent value and the child, which is correct
+`preprocess`'s signature does not change. `scripts/lib/dtcg.mjs` is **not**
+touched — revision 1 listed it in error. `flattenDtcg` stays as is: it descends
+into dual nodes and yields both the parent value and the child, which is right
 regardless of the spec's view, because it reads what is actually there.
 
 ## Testing
 
-1. **`$type` inheritance** — dual node typed `dimension`, child untyped: hoisted
-   child arrives typed `dimension`. Child with its own `$type`: not overwritten.
-   Dual node with no `$type`: child stays untyped (no invention).
-2. **Collision** — camel-joined name already present as an authored sibling:
-   throws, and the message names both paths.
-3. **Collision between two hoists** in one pass: throws.
-4. **Multiple collisions**: one error listing all of them.
-5. **Regression** — the existing hoist tests pass unchanged; `preprocess` is
-   still idempotent.
-6. **End to end** — rebuild the four real outputs. **Expect no change:** 195
-   declarations, 0 broken, `value-verified` 107. Zygarden's `text.*` children
-   each carry `$type: dimension` and no name collides, so neither defect is
-   reachable there. Confirming *nothing moved* is the actual assertion.
-7. **Repo gates** — all six.
+Each item names the depth it exercises, because a `$type` carry that runs in the
+wrong recursion frame passes every single-level test.
+
+1. **`$type` inheritance, one level** — dual node typed `dimension`, child
+   untyped → child arrives typed. Child with its own `$type` → not overwritten.
+   Dual node with no `$type` → child stays untyped, nothing invented.
+2. **`$type` inheritance, two levels** — `text.sm` typed, `lineHeight` untyped
+   and itself dual with a `tight` child. Both `smLineHeight` and
+   `smLineHeightTight` arrive typed. This is the test that catches a wrong
+   recursion frame. (The current depth-first order already produces both names
+   correctly; the assertion is that the types follow.)
+3. **Reference exclusion** — child whose authored `$value` is `{ratio.normal}`
+   where `ratio.normal` is `$type: number`, under a `dimension` dual node: the
+   child does **not** become `dimension`.
+4. **Collision, authored token sibling** — throws; message names both paths.
+5. **Collision, authored *group* sibling** — throws rather than destroying the
+   subtree.
+6. **Collision between two hoists** (case D) — throws.
+7. **Collision with identical values** — throws anyway.
+8. **Multiple collisions at different depths** — one error listing all of them.
+   Different depths specifically, to catch a throw from the wrong frame.
+9. **Idempotency** — `preprocess(preprocess(x))` equals `preprocess(x)`.
+   `sd-native.mjs:246` asserts idempotency in prose and real builds rely on it,
+   but **no such test exists today** — revision 1 wrongly described this as a
+   regression test to preserve. It has to be written.
+10. **Regression** — the existing hoist and "does not mutate its input" tests
+    pass unchanged.
+11. **#52 widening** — a demonstration that an untyped unitless literal child now
+    inherits `dimension`. Asserted so the widening is recorded, not discovered
+    later.
+12. **Repo gates** — all six.
 
 ## Limitations
 
 - **The real source cannot exercise either fix.** Both defects are unreachable in
-  zygarden, which is why #50 did not hit them. Coverage is synthetic fixtures
-  plus an end-to-end run that proves no regression. Stating this because the
-  alternative — implying the e2e run validates the fix — is the overclaim this
-  repo has been bitten by before.
-- **Throwing is a breaking change** for any consumer whose source has a
-  colliding name today. Their build currently succeeds and silently drops a
-  token, so the break surfaces existing data loss rather than causing it.
-- **Dual nodes remain unreported as invalid DTCG.** Detecting and warning on the
-  shape itself is a separate question, and arguably belongs in a validator rather
-  than a preprocessor. Out of scope; worth an issue.
+  zygarden — its `text.*` children each carry `$type: dimension` and no name
+  collides — which is why #50 did not hit them. Coverage is synthetic fixtures
+  plus an end-to-end run proving no regression.
+- **The end-to-end run is not reproducible by a reviewer or by CI.** No token
+  source is vendored in this repo; zygarden is external, read from
+  `~/Dev/zygarden-frontend` at branch `feature/apply-brandguide-styles`, through
+  a scratch harness with style-dictionary installed. The expected result is *no
+  change*: 195 declarations, 0 broken, `value-verified` 107. Confirming nothing
+  moved is the whole assertion, and it is an author-run check.
+- **Throwing is a breaking change** for any consumer whose source has a colliding
+  name today. Their build currently succeeds and silently drops a token, so the
+  break surfaces existing data loss rather than causing it.
+- **Dual nodes remain unreported as invalid DTCG.** Now that the shape is known
+  to be non-conforming, detecting and reporting it is a real option — but it
+  belongs in a validator, not a preprocessor whose job is to make the build work.
+  Out of scope; worth its own issue.
 
 ## Out of scope
 
-#51, #52, #54. This change must neither fix nor mask them.
+#51, #52, #54. This change must neither fix nor mask them — see test 11, which
+records the one place it widens #52 rather than leaving the claim unexamined.
+
+## Revision history
+
+**Revision 2 (2026-08-23)** — `/review-spec` returned "needs revision" and was
+right on every count that mattered. Four corrections:
+
+1. **Mis-citation.** Revision 1 attributed the "legal DTCG" claim to
+   `scripts/lib/dtcg.mjs:9`, which does not make it. The real sites are
+   `sd-native.mjs:61` and `build-native-adapter-config.mjs:102`. Following
+   revision 1's Changes table would have edited an innocent comment and left both
+   falsehoods in place.
+2. **The defect-1 argument was unsound and self-contradictory** — it disqualified
+   §5.2.2 and then reasoned from it, and it read "parent group" as "ancestor"
+   when §6.1 says a dual node is definitively a token. Restated as the judgment
+   about malformed input that it actually is.
+3. **A real hazard the rule created**: reference-valued children. `resolveInPlace`
+   flattens references before the hoist, so the naive rule stamps the parent's
+   `$type` over the referent's, inverting §5.2.2's own precedence and
+   manufacturing a new #52 instance. Exclusion added.
+4. **The accepted-cost paragraph flattered the decision** — `no-bare-units` does
+   not catch a unitless ratio, so the "loud before" baseline was false for the
+   likeliest case, and "no reading rescues it" was contradicted by §5.2.2 rule 1.
+
+Also: collision behaviour fully specified (four underdetermined points), the
+idempotency test identified as missing rather than existing, test depths named,
+and the e2e run marked as author-run and not CI-reproducible.

--- a/docs/superpowers/specs/2026-08-23-hoist-dual-nodes-design.md
+++ b/docs/superpowers/specs/2026-08-23-hoist-dual-nodes-design.md
@@ -221,6 +221,16 @@ zygarden, and the added machinery is a worse trade than the defect. Recorded
 here so the residual is described accurately rather than flatteringly, which is
 the whole point of this section.
 
+**This is the one residual not pinned by a test**, and the asymmetry is worth
+naming, because the blast-radius section immediately below insists that a
+widening be "demonstrated by test rather than asserted away." That standard is
+met for #52 and #51 and not for this. The reason is that a test would pin
+behaviour we have judged wrong rather than behaviour we have judged acceptable
+— the other two record a bad-but-accepted *output*, whereas this records a
+*regression* from a correct answer. Pinning it would read as endorsement.
+Reproduced above from a real run against `main` and `HEAD`; that transcript is
+the evidence, and it is weaker than a test, deliberately.
+
 ### Blast radius — two open issues, both widened, both recorded
 
 The rule converts a loud failure into a silent one in two measured cases. Both

--- a/docs/superpowers/specs/2026-08-23-hoist-dual-nodes-design.md
+++ b/docs/superpowers/specs/2026-08-23-hoist-dual-nodes-design.md
@@ -2,8 +2,9 @@
 
 **Issue:** [#55](https://github.com/jrpease/throughline/issues/55)
 **Date:** 2026-08-23
-**Revision:** 2 — review found a mis-citation, an unsound argument, and a real
-hazard the rule created. See [Revision history](#revision-history).
+**Revision:** 3 — the reference tag became a `WeakSet`, and the blast-radius
+section now records that #51 is widened alongside #52. See
+[Revision history](#revision-history).
 **Depends on:** [#56](https://github.com/jrpease/throughline/pull/56) (#53). Same
 file, and `references/native-adapter-config.md` is generated from the whole
 module, so this branch stacks rather than forking from `main`.
@@ -150,11 +151,20 @@ inherit. It keeps whatever it has, which is today's behaviour — no regression,
 and no new #52 instances.
 
 **Mechanism.** `resolveInPlace` already tests `WHOLE_REF` and is the only place
-that still knows. It tags such a node with a module-private `Symbol`; the hoist
-reads the tag and skips inheritance. A `Symbol` key is invisible to
-`Object.entries`, to `JSON.stringify`, and to Style Dictionary, so it cannot leak
-into output. The tag is set on the clone `preprocess` already makes, after
-`structuredClone`, so clone semantics are not involved.
+that still knows. It records such a node in a **module-level `WeakSet`**; the
+hoist checks membership and skips inheritance.
+
+A `Symbol` property was tried first and rejected on review. It is invisible to
+`Object.entries` and `JSON.stringify`, and real Style Dictionary (4.4.0 and
+5.5.2) tolerates it — but `assert.deepEqual` under `node:assert/strict`
+**does** compare own symbol properties, and `structuredClone` drops them. So
+`preprocess(preprocess(x))` differed structurally from `preprocess(x)` whenever
+a reference was present, breaking the idempotency this module documents at
+`sd-native.mjs:308` and relies on in real builds. The shipped idempotency test
+passed only because its fixture contained no alias — a trap for whoever edited
+that fixture next. A `WeakSet` writes nothing to the object, so the property
+holds exactly rather than being managed, and entries are collected with the
+clone.
 
 Reordering the pipeline to hoist before resolving is **not** the fix: aliases
 elsewhere in the source point at the pre-hoist path (`{text.sm.lineHeight}`), and
@@ -178,14 +188,38 @@ shape is "malformed in a way no reading rescues." Both parts were wrong:
   child exactly, which is why the exclusion above exists.
 
 The honest statement of the residual cost: *a child with a **literal** value, no
-`$type`, and a differently-typed parent is malformed, and is accepted as newly
-silent.* That is narrow, and it is the price of fixing the common case.
+`$type`, and a parent whose type does not describe it is malformed, and is
+accepted as newly silent.* That is narrow, and it is the price of fixing the
+common case.
 
-**#52 blast radius.** The rule takes an untyped unitless literal child under a
-`dimension`-typed dual node and makes it `dimension` — precisely #52's shape, in
-a source where it did not exist before. That is not *masking* #52 (no existing
-instance is hidden) but it does widen it, and the widening must be demonstrated
-by test rather than asserted away.
+Revision 2 wrote "a *differently-typed* parent" there, which was too narrow —
+see the #51 case below, where the parent's type is `dimension` and so is the
+child's, and the emitted unit is still wrong.
+
+### Blast radius — two open issues, both widened, both recorded
+
+The rule converts a loud failure into a silent one in two measured cases. Both
+are the *same mechanism*, and both are demonstrated by test rather than
+asserted away, because "this change must neither fix nor mask them" is worth
+nothing if the widening is simply not looked for.
+
+| Issue | Shape the rule now produces | Before | After |
+|---|---|---|---|
+| **#52** | untyped **unitless** literal child under a `dimension` dual node | `1.5` | `1.50.dp` — a ratio in density-independent pixels |
+| **#51** | untyped **fontSize** child under a `dimension` dual node | `18px` bare, caught by `no-bare-units` | `18.00.dp` — compiles, wrong unit, defeats the user's font-scale setting |
+
+Neither is *masked* — no existing instance is hidden, and the test asserting
+`1.50.dp` still validates keeps #52 reachable. Both are widened: the rule
+manufactures the shape in sources where it did not occur.
+
+**Not fixed here, deliberately.** The mechanism is the one this section already
+accepts, and the only way to exempt #51's case would be to special-case a child
+*named* `fontSize` — a name-based heuristic, which is the precise thing #51
+exists to complain about. Fixing it properly means deciding how DTCG font sizes
+are identified, which is #51's own open question.
+
+Neither instance is reachable in zygarden: every `text.*` and
+`typography.textStyle.*` child carries an explicit `$type`, so nothing inherits.
 
 ## Decision — collision throws
 
@@ -302,6 +336,20 @@ wrong recursion frame passes every single-level test.
 records the one place it widens #52 rather than leaving the claim unexamined.
 
 ## Revision history
+
+**Revision 3 (2026-08-24)** — Task 2's review, during execution. Two
+corrections, both to claims this document made rather than to the decision:
+
+1. **The mechanism changed from a `Symbol` property to a `WeakSet`.** The symbol
+   was compared by `assert.deepEqual` and dropped by `structuredClone`, so it
+   broke structural idempotency — and the test meant to catch that passed only
+   because its fixture had no alias.
+2. **The blast-radius section named only #52; the rule widens #51 by the
+   identical mechanism.** An untyped `fontSize` child under a `dimension` dual
+   node becomes `dimension`, so `18px` (bare, caught loudly) becomes `18.00.dp`
+   (compiles, wrong unit). The accepted-cost sentence said "a *differently-typed*
+   parent," which does not describe that case at all. Both widenings are now
+   tabulated and each has its own test.
 
 **Revision 2 (2026-08-23)** — `/review-spec` returned "needs revision" and was
 right on every count that mattered. Four corrections:

--- a/docs/superpowers/specs/2026-08-23-hoist-dual-nodes-design.md
+++ b/docs/superpowers/specs/2026-08-23-hoist-dual-nodes-design.md
@@ -294,7 +294,7 @@ wrong recursion frame passes every single-level test.
 - **Dual nodes remain unreported as invalid DTCG.** Now that the shape is known
   to be non-conforming, detecting and reporting it is a real option — but it
   belongs in a validator, not a preprocessor whose job is to make the build work.
-  Out of scope; worth its own issue.
+  Out of scope; filed as #58.
 
 ## Out of scope
 

--- a/references/native-adapter-config.md
+++ b/references/native-adapter-config.md
@@ -199,6 +199,12 @@ function resolveInPlace(node, flat, prefix = []) {
 // collision against a sibling that does not exist. Object.hasOwn checks the
 // tree's own keys only.
 function hoistDualNodes(node, collisions, prefix = []) {
+  // Which hoisted names THIS pass has already claimed, and the authored path
+  // of the child that claimed each one — a collision here is a second hoist
+  // landing on a name no sibling ever authored. Local to this frame: node is
+  // fixed per invocation, so collisions are always within one parent's key
+  // space.
+  const claimedBy = new Map();
   for (const [key, val] of Object.entries(node)) {
     if (key.startsWith('$') || !val || typeof val !== 'object') continue;
     hoistDualNodes(val, collisions, [...prefix, key]);
@@ -206,13 +212,15 @@ function hoistDualNodes(node, collisions, prefix = []) {
       for (const [childKey, childVal] of Object.entries(val)) {
         if (childKey.startsWith('$') || !childVal || typeof childVal !== 'object') continue;
         const hoisted = key + childKey[0].toUpperCase() + childKey.slice(1);
+        const from = [...prefix, key, childKey].join('.');
         if (Object.hasOwn(node, hoisted)) {
           const existingNode = node[hoisted];
           const isGroup = existingNode !== null && typeof existingNode === 'object' && !('$value' in existingNode);
           collisions.push({
-            from: [...prefix, key, childKey].join('.'),
+            from,
             onto: [...prefix, hoisted].join('.'),
             isGroup,
+            claimant: claimedBy.get(hoisted),
             existing: isGroup
               ? undefined
               : existingNode && typeof existingNode === 'object'
@@ -230,6 +238,7 @@ function hoistDualNodes(node, collisions, prefix = []) {
         }
         node[hoisted] = childVal;
         delete val[childKey];
+        claimedBy.set(hoisted, from);
       }
     }
   }
@@ -245,13 +254,21 @@ export function preprocess(dict) {
   if (collisions.length) {
     const shown = collisions
       .slice(0, 5)
-      .map((c) => `  ${c.from} -> ${c.onto}` + (c.isGroup ? ' (a group)' : ` (would overwrite ${JSON.stringify(c.existing)})`))
+      .map((c) => {
+        const line = `  ${c.from} -> ${c.onto}`;
+        if (c.isGroup) {
+          return line + (c.claimant ? ` (a group, already claimed by the hoist of ${c.claimant})` : ' (a group)');
+        }
+        return c.claimant
+          ? `${line} (already claimed by the hoist of ${c.claimant}, value ${JSON.stringify(c.existing)})`
+          : `${line} (would overwrite ${JSON.stringify(c.existing)})`;
+      })
       .join('\n');
     const more = collisions.length > 5 ? `\n  ...and ${collisions.length - 5} more` : '';
     throw new Error(
-      `${collisions.length} hoisted token name(s) collide with an existing sibling.\n` +
-        "A dual node's child is renamed to a camel-joined sibling, and that name is taken.\n" +
-        'Hoisting would silently discard one of the two. Rename the child or the sibling.\n' +
+      `${collisions.length} hoisted token name(s) collide with an existing sibling or with a name an earlier hoist already claimed.\n` +
+        "A dual node's child is renamed to a camel-joined sibling, and that name may already be taken — by an authored token or group, or by another dual node's child hoisted earlier in the same pass.\n" +
+        'Hoisting would silently discard one of the two. Rename the child, the sibling, or whichever colliding child should keep the name.\n' +
         `${shown}${more}`,
     );
   }

--- a/references/native-adapter-config.md
+++ b/references/native-adapter-config.md
@@ -135,11 +135,14 @@ Both are fixed before Style Dictionary sees the tree.
 // Resolving here also handles references embedded inside an expression, which
 // SD's whole-value matcher misses. Pre-resolving costs nothing on native
 // targets: they set outputReferences: false, so references flatten regardless.
+//
 // Marks a node whose AUTHORED $value was a whole-value reference, so the hoist
 // can decline to override the type DTCG 5.2.2 rule 1 already determined from the
-// referent. A Symbol key is invisible to Object.entries, to JSON.stringify, and
-// to Style Dictionary, so it cannot leak into output.
-const WAS_REF = Symbol('dtcg/was-reference');
+// referent. A WeakSet keyed on the node object, rather than a property written
+// onto it, holds structural idempotency exactly: structuredClone drops the
+// membership along with the rest of the identity, so preprocess(preprocess(x))
+// is deepEqual to preprocess(x) with no leak question to manage.
+const WAS_REF = new WeakSet();
 const WHOLE_REF = /^\{[^}]+\}$/;
 
 function interpolate(value, flat) {
@@ -159,7 +162,7 @@ function resolveInPlace(node, flat, prefix = []) {
     const path = [...prefix, key];
     if ('$value' in val && typeof val.$value === 'string') {
       if (WHOLE_REF.test(val.$value)) {
-        val[WAS_REF] = true;
+        WAS_REF.add(val);
         try {
           val.$value = resolveValue(path.join('.'), flat);
         } catch {
@@ -218,7 +221,7 @@ function hoistDualNodes(node, collisions, prefix = []) {
         // authored; after the hoist it is a sibling, so the type is lost unless
         // it travels. Excluded for a reference-valued child — DTCG 5.2.2 gives
         // it the referent's type, which outranks inheritance.
-        if (!('$type' in childVal) && '$type' in val && !childVal[WAS_REF]) {
+        if (!('$type' in childVal) && '$type' in val && !WAS_REF.has(childVal)) {
           childVal.$type = val.$type;
         }
         node[hoisted] = childVal;

--- a/references/native-adapter-config.md
+++ b/references/native-adapter-config.md
@@ -180,6 +180,11 @@ function resolveInPlace(node, flat, prefix = []) {
 // corrupted — the enclosing loop's Object.entries snapshot still holds the
 // detached node, and its own children then hoist out of a subtree no longer
 // reachable.
+//
+// hoisted in node walks the prototype chain, so a camel-joined name matching
+// an inherited Object.prototype member (toString, valueOf, ...) reported a
+// collision against a sibling that does not exist. Object.hasOwn checks the
+// tree's own keys only.
 function hoistDualNodes(node, collisions, prefix = []) {
   for (const [key, val] of Object.entries(node)) {
     if (key.startsWith('$') || !val || typeof val !== 'object') continue;
@@ -188,11 +193,18 @@ function hoistDualNodes(node, collisions, prefix = []) {
       for (const [childKey, childVal] of Object.entries(val)) {
         if (childKey.startsWith('$') || !childVal || typeof childVal !== 'object') continue;
         const hoisted = key + childKey[0].toUpperCase() + childKey.slice(1);
-        if (hoisted in node) {
+        if (Object.hasOwn(node, hoisted)) {
+          const existingNode = node[hoisted];
+          const isGroup = existingNode !== null && typeof existingNode === 'object' && !('$value' in existingNode);
           collisions.push({
             from: [...prefix, key, childKey].join('.'),
             onto: [...prefix, hoisted].join('.'),
-            existing: node[hoisted].$value,
+            isGroup,
+            existing: isGroup
+              ? undefined
+              : existingNode && typeof existingNode === 'object'
+                ? existingNode.$value
+                : existingNode,
           });
           continue;
         }
@@ -213,7 +225,7 @@ export function preprocess(dict) {
   if (collisions.length) {
     const shown = collisions
       .slice(0, 5)
-      .map((c) => `  ${c.from} -> ${c.onto}` + (c.existing === undefined ? ' (a group)' : ` (would overwrite ${JSON.stringify(c.existing)})`))
+      .map((c) => `  ${c.from} -> ${c.onto}` + (c.isGroup ? ' (a group)' : ` (would overwrite ${JSON.stringify(c.existing)})`))
       .join('\n');
     const more = collisions.length > 5 ? `\n  ...and ${collisions.length - 5} more` : '';
     throw new Error(

--- a/references/native-adapter-config.md
+++ b/references/native-adapter-config.md
@@ -135,6 +135,11 @@ Both are fixed before Style Dictionary sees the tree.
 // Resolving here also handles references embedded inside an expression, which
 // SD's whole-value matcher misses. Pre-resolving costs nothing on native
 // targets: they set outputReferences: false, so references flatten regardless.
+// Marks a node whose AUTHORED $value was a whole-value reference, so the hoist
+// can decline to override the type DTCG 5.2.2 rule 1 already determined from the
+// referent. A Symbol key is invisible to Object.entries, to JSON.stringify, and
+// to Style Dictionary, so it cannot leak into output.
+const WAS_REF = Symbol('dtcg/was-reference');
 const WHOLE_REF = /^\{[^}]+\}$/;
 
 function interpolate(value, flat) {
@@ -154,6 +159,7 @@ function resolveInPlace(node, flat, prefix = []) {
     const path = [...prefix, key];
     if ('$value' in val && typeof val.$value === 'string') {
       if (WHOLE_REF.test(val.$value)) {
+        val[WAS_REF] = true;
         try {
           val.$value = resolveValue(path.join('.'), flat);
         } catch {
@@ -207,6 +213,13 @@ function hoistDualNodes(node, collisions, prefix = []) {
                 : existingNode,
           });
           continue;
+        }
+        // The dual node is the child's closest $type-bearing ancestor as
+        // authored; after the hoist it is a sibling, so the type is lost unless
+        // it travels. Excluded for a reference-valued child — DTCG 5.2.2 gives
+        // it the referent's type, which outranks inheritance.
+        if (!('$type' in childVal) && '$type' in val && !childVal[WAS_REF]) {
+          childVal.$type = val.$type;
         }
         node[hoisted] = childVal;
         delete val[childKey];

--- a/references/native-adapter-config.md
+++ b/references/native-adapter-config.md
@@ -170,14 +170,33 @@ function resolveInPlace(node, flat, prefix = []) {
 
 // text.sm.lineHeight becomes text.smLineHeight, which name/camel renders as
 // textSmLineHeight — the identical symbol the un-hoisted path would produce.
-function hoistDualNodes(node) {
+//
+// Collisions are COLLECTED, not thrown here: the walk has to continue to report
+// every one, and the recursion is depth-first, so throwing from a frame would
+// report one subtree. preprocess throws once, after the whole tree is walked.
+//
+// On collision the assignment is SKIPPED. Continuing to overwrite while
+// collecting means later detections are computed against a tree already
+// corrupted — the enclosing loop's Object.entries snapshot still holds the
+// detached node, and its own children then hoist out of a subtree no longer
+// reachable.
+function hoistDualNodes(node, collisions, prefix = []) {
   for (const [key, val] of Object.entries(node)) {
     if (key.startsWith('$') || !val || typeof val !== 'object') continue;
-    hoistDualNodes(val);
+    hoistDualNodes(val, collisions, [...prefix, key]);
     if ('$value' in val) {
       for (const [childKey, childVal] of Object.entries(val)) {
         if (childKey.startsWith('$') || !childVal || typeof childVal !== 'object') continue;
-        node[key + childKey[0].toUpperCase() + childKey.slice(1)] = childVal;
+        const hoisted = key + childKey[0].toUpperCase() + childKey.slice(1);
+        if (hoisted in node) {
+          collisions.push({
+            from: [...prefix, key, childKey].join('.'),
+            onto: [...prefix, hoisted].join('.'),
+            existing: node[hoisted].$value,
+          });
+          continue;
+        }
+        node[hoisted] = childVal;
         delete val[childKey];
       }
     }
@@ -186,7 +205,25 @@ function hoistDualNodes(node) {
 }
 
 export function preprocess(dict) {
-  return hoistDualNodes(resolveInPlace(structuredClone(dict), flattenDtcg(dict)));
+  const collisions = [];
+  const out = hoistDualNodes(
+    resolveInPlace(structuredClone(dict), flattenDtcg(dict)),
+    collisions,
+  );
+  if (collisions.length) {
+    const shown = collisions
+      .slice(0, 5)
+      .map((c) => `  ${c.from} -> ${c.onto}` + (c.existing === undefined ? ' (a group)' : ` (would overwrite ${JSON.stringify(c.existing)})`))
+      .join('\n');
+    const more = collisions.length > 5 ? `\n  ...and ${collisions.length - 5} more` : '';
+    throw new Error(
+      `${collisions.length} hoisted token name(s) collide with an existing sibling.\n` +
+        "A dual node's child is renamed to a camel-joined sibling, and that name is taken.\n" +
+        'Hoisting would silently discard one of the two. Rename the child or the sibling.\n' +
+        `${shown}${more}`,
+    );
+  }
+  return out;
 }
 ```
 

--- a/references/native-adapter-config.md
+++ b/references/native-adapter-config.md
@@ -114,9 +114,11 @@ export function colorMixToHex8(value) {
 
 Style Dictionary's resolver will not traverse into a node that carries both a
 `$value` and children, and its collector stops there too. The dual-node pattern
-is legal DTCG and common in Figma-derived sources: `text.sm` holds
-`$value: "14px"` *and* a `text.sm.lineHeight` child. So every alias to such a
-child fails to resolve, and the child is never emitted at all.
+is invalid DTCG — the Design Tokens Format Module's 30 July 2026 draft, §6.1,
+requires tools to report it as an error, and §6.2's `$root` is the sanctioned
+way to pair a value with children. Figma-derived sources emit it anyway:
+`text.sm` holds `$value: "14px"` *and* a `text.sm.lineHeight` child. So every
+alias to such a child fails to resolve, and the child is never emitted at all.
 
 Both are fixed before Style Dictionary sees the tree.
 
@@ -125,8 +127,10 @@ Both are fixed before Style Dictionary sees the tree.
 // the tree.
 //
 // Two distinct SD limitations, both caused by a node carrying BOTH a $value and
-// children — legal DTCG, and common in Figma-derived sources, where text.sm
-// holds $value "14px" plus a text.sm.lineHeight child:
+// children — invalid DTCG: the Format Module's 30 July 2026 draft, §6.1,
+// requires tools to report this as an error; §6.2's $root is the sanctioned
+// way to pair a value with children. Common in Figma-derived sources anyway,
+// where text.sm holds $value "14px" plus a text.sm.lineHeight child:
 //
 //   1. The resolver will not traverse into such a node, so every alias to the
 //      child fails to resolve and emits as a bare literal.

--- a/scripts/build-native-adapter-config.mjs
+++ b/scripts/build-native-adapter-config.mjs
@@ -99,9 +99,11 @@ function.`],
 
 Style Dictionary's resolver will not traverse into a node that carries both a
 \`$value\` and children, and its collector stops there too. The dual-node pattern
-is legal DTCG and common in Figma-derived sources: \`text.sm\` holds
-\`$value: "14px"\` *and* a \`text.sm.lineHeight\` child. So every alias to such a
-child fails to resolve, and the child is never emitted at all.
+is invalid DTCG — the Design Tokens Format Module's 30 July 2026 draft, §6.1,
+requires tools to report it as an error, and §6.2's \`$root\` is the sanctioned
+way to pair a value with children. Figma-derived sources emit it anyway:
+\`text.sm\` holds \`$value: "14px"\` *and* a \`text.sm.lineHeight\` child. So every
+alias to such a child fails to resolve, and the child is never emitted at all.
 
 Both are fixed before Style Dictionary sees the tree.`],
   ['platform', `## 4. Assemble the platform from the stock list

--- a/scripts/lib/sd-native.mjs
+++ b/scripts/lib/sd-native.mjs
@@ -58,8 +58,10 @@ export function colorMixToHex8(value) {
 // the tree.
 //
 // Two distinct SD limitations, both caused by a node carrying BOTH a $value and
-// children — legal DTCG, and common in Figma-derived sources, where text.sm
-// holds $value "14px" plus a text.sm.lineHeight child:
+// children — invalid DTCG: the Format Module's 30 July 2026 draft, §6.1,
+// requires tools to report this as an error; §6.2's $root is the sanctioned
+// way to pair a value with children. Common in Figma-derived sources anyway,
+// where text.sm holds $value "14px" plus a text.sm.lineHeight child:
 //
 //   1. The resolver will not traverse into such a node, so every alias to the
 //      child fails to resolve and emits as a bare literal.

--- a/scripts/lib/sd-native.mjs
+++ b/scripts/lib/sd-native.mjs
@@ -68,11 +68,14 @@ export function colorMixToHex8(value) {
 // Resolving here also handles references embedded inside an expression, which
 // SD's whole-value matcher misses. Pre-resolving costs nothing on native
 // targets: they set outputReferences: false, so references flatten regardless.
+//
 // Marks a node whose AUTHORED $value was a whole-value reference, so the hoist
 // can decline to override the type DTCG 5.2.2 rule 1 already determined from the
-// referent. A Symbol key is invisible to Object.entries, to JSON.stringify, and
-// to Style Dictionary, so it cannot leak into output.
-const WAS_REF = Symbol('dtcg/was-reference');
+// referent. A WeakSet keyed on the node object, rather than a property written
+// onto it, holds structural idempotency exactly: structuredClone drops the
+// membership along with the rest of the identity, so preprocess(preprocess(x))
+// is deepEqual to preprocess(x) with no leak question to manage.
+const WAS_REF = new WeakSet();
 const WHOLE_REF = /^\{[^}]+\}$/;
 
 function interpolate(value, flat) {
@@ -92,7 +95,7 @@ function resolveInPlace(node, flat, prefix = []) {
     const path = [...prefix, key];
     if ('$value' in val && typeof val.$value === 'string') {
       if (WHOLE_REF.test(val.$value)) {
-        val[WAS_REF] = true;
+        WAS_REF.add(val);
         try {
           val.$value = resolveValue(path.join('.'), flat);
         } catch {
@@ -151,7 +154,7 @@ function hoistDualNodes(node, collisions, prefix = []) {
         // authored; after the hoist it is a sibling, so the type is lost unless
         // it travels. Excluded for a reference-valued child — DTCG 5.2.2 gives
         // it the referent's type, which outranks inheritance.
-        if (!('$type' in childVal) && '$type' in val && !childVal[WAS_REF]) {
+        if (!('$type' in childVal) && '$type' in val && !WAS_REF.has(childVal)) {
           childVal.$type = val.$type;
         }
         node[hoisted] = childVal;

--- a/scripts/lib/sd-native.mjs
+++ b/scripts/lib/sd-native.mjs
@@ -103,14 +103,33 @@ function resolveInPlace(node, flat, prefix = []) {
 
 // text.sm.lineHeight becomes text.smLineHeight, which name/camel renders as
 // textSmLineHeight — the identical symbol the un-hoisted path would produce.
-function hoistDualNodes(node) {
+//
+// Collisions are COLLECTED, not thrown here: the walk has to continue to report
+// every one, and the recursion is depth-first, so throwing from a frame would
+// report one subtree. preprocess throws once, after the whole tree is walked.
+//
+// On collision the assignment is SKIPPED. Continuing to overwrite while
+// collecting means later detections are computed against a tree already
+// corrupted — the enclosing loop's Object.entries snapshot still holds the
+// detached node, and its own children then hoist out of a subtree no longer
+// reachable.
+function hoistDualNodes(node, collisions, prefix = []) {
   for (const [key, val] of Object.entries(node)) {
     if (key.startsWith('$') || !val || typeof val !== 'object') continue;
-    hoistDualNodes(val);
+    hoistDualNodes(val, collisions, [...prefix, key]);
     if ('$value' in val) {
       for (const [childKey, childVal] of Object.entries(val)) {
         if (childKey.startsWith('$') || !childVal || typeof childVal !== 'object') continue;
-        node[key + childKey[0].toUpperCase() + childKey.slice(1)] = childVal;
+        const hoisted = key + childKey[0].toUpperCase() + childKey.slice(1);
+        if (hoisted in node) {
+          collisions.push({
+            from: [...prefix, key, childKey].join('.'),
+            onto: [...prefix, hoisted].join('.'),
+            existing: node[hoisted].$value,
+          });
+          continue;
+        }
+        node[hoisted] = childVal;
         delete val[childKey];
       }
     }
@@ -119,7 +138,25 @@ function hoistDualNodes(node) {
 }
 
 export function preprocess(dict) {
-  return hoistDualNodes(resolveInPlace(structuredClone(dict), flattenDtcg(dict)));
+  const collisions = [];
+  const out = hoistDualNodes(
+    resolveInPlace(structuredClone(dict), flattenDtcg(dict)),
+    collisions,
+  );
+  if (collisions.length) {
+    const shown = collisions
+      .slice(0, 5)
+      .map((c) => `  ${c.from} -> ${c.onto}` + (c.existing === undefined ? ' (a group)' : ` (would overwrite ${JSON.stringify(c.existing)})`))
+      .join('\n');
+    const more = collisions.length > 5 ? `\n  ...and ${collisions.length - 5} more` : '';
+    throw new Error(
+      `${collisions.length} hoisted token name(s) collide with an existing sibling.\n` +
+        "A dual node's child is renamed to a camel-joined sibling, and that name is taken.\n" +
+        'Hoisting would silently discard one of the two. Rename the child or the sibling.\n' +
+        `${shown}${more}`,
+    );
+  }
+  return out;
 }
 // @doc-section-end preprocess
 

--- a/scripts/lib/sd-native.mjs
+++ b/scripts/lib/sd-native.mjs
@@ -113,6 +113,11 @@ function resolveInPlace(node, flat, prefix = []) {
 // corrupted — the enclosing loop's Object.entries snapshot still holds the
 // detached node, and its own children then hoist out of a subtree no longer
 // reachable.
+//
+// hoisted in node walks the prototype chain, so a camel-joined name matching
+// an inherited Object.prototype member (toString, valueOf, ...) reported a
+// collision against a sibling that does not exist. Object.hasOwn checks the
+// tree's own keys only.
 function hoistDualNodes(node, collisions, prefix = []) {
   for (const [key, val] of Object.entries(node)) {
     if (key.startsWith('$') || !val || typeof val !== 'object') continue;
@@ -121,11 +126,18 @@ function hoistDualNodes(node, collisions, prefix = []) {
       for (const [childKey, childVal] of Object.entries(val)) {
         if (childKey.startsWith('$') || !childVal || typeof childVal !== 'object') continue;
         const hoisted = key + childKey[0].toUpperCase() + childKey.slice(1);
-        if (hoisted in node) {
+        if (Object.hasOwn(node, hoisted)) {
+          const existingNode = node[hoisted];
+          const isGroup = existingNode !== null && typeof existingNode === 'object' && !('$value' in existingNode);
           collisions.push({
             from: [...prefix, key, childKey].join('.'),
             onto: [...prefix, hoisted].join('.'),
-            existing: node[hoisted].$value,
+            isGroup,
+            existing: isGroup
+              ? undefined
+              : existingNode && typeof existingNode === 'object'
+                ? existingNode.$value
+                : existingNode,
           });
           continue;
         }
@@ -146,7 +158,7 @@ export function preprocess(dict) {
   if (collisions.length) {
     const shown = collisions
       .slice(0, 5)
-      .map((c) => `  ${c.from} -> ${c.onto}` + (c.existing === undefined ? ' (a group)' : ` (would overwrite ${JSON.stringify(c.existing)})`))
+      .map((c) => `  ${c.from} -> ${c.onto}` + (c.isGroup ? ' (a group)' : ` (would overwrite ${JSON.stringify(c.existing)})`))
       .join('\n');
     const more = collisions.length > 5 ? `\n  ...and ${collisions.length - 5} more` : '';
     throw new Error(

--- a/scripts/lib/sd-native.mjs
+++ b/scripts/lib/sd-native.mjs
@@ -130,6 +130,12 @@ function resolveInPlace(node, flat, prefix = []) {
 // collision against a sibling that does not exist. Object.hasOwn checks the
 // tree's own keys only.
 function hoistDualNodes(node, collisions, prefix = []) {
+  // Which hoisted names THIS pass has already claimed, and the authored path
+  // of the child that claimed each one — a collision here is a second hoist
+  // landing on a name no sibling ever authored. Local to this frame: node is
+  // fixed per invocation, so collisions are always within one parent's key
+  // space.
+  const claimedBy = new Map();
   for (const [key, val] of Object.entries(node)) {
     if (key.startsWith('$') || !val || typeof val !== 'object') continue;
     hoistDualNodes(val, collisions, [...prefix, key]);
@@ -137,13 +143,15 @@ function hoistDualNodes(node, collisions, prefix = []) {
       for (const [childKey, childVal] of Object.entries(val)) {
         if (childKey.startsWith('$') || !childVal || typeof childVal !== 'object') continue;
         const hoisted = key + childKey[0].toUpperCase() + childKey.slice(1);
+        const from = [...prefix, key, childKey].join('.');
         if (Object.hasOwn(node, hoisted)) {
           const existingNode = node[hoisted];
           const isGroup = existingNode !== null && typeof existingNode === 'object' && !('$value' in existingNode);
           collisions.push({
-            from: [...prefix, key, childKey].join('.'),
+            from,
             onto: [...prefix, hoisted].join('.'),
             isGroup,
+            claimant: claimedBy.get(hoisted),
             existing: isGroup
               ? undefined
               : existingNode && typeof existingNode === 'object'
@@ -161,6 +169,7 @@ function hoistDualNodes(node, collisions, prefix = []) {
         }
         node[hoisted] = childVal;
         delete val[childKey];
+        claimedBy.set(hoisted, from);
       }
     }
   }
@@ -176,13 +185,21 @@ export function preprocess(dict) {
   if (collisions.length) {
     const shown = collisions
       .slice(0, 5)
-      .map((c) => `  ${c.from} -> ${c.onto}` + (c.isGroup ? ' (a group)' : ` (would overwrite ${JSON.stringify(c.existing)})`))
+      .map((c) => {
+        const line = `  ${c.from} -> ${c.onto}`;
+        if (c.isGroup) {
+          return line + (c.claimant ? ` (a group, already claimed by the hoist of ${c.claimant})` : ' (a group)');
+        }
+        return c.claimant
+          ? `${line} (already claimed by the hoist of ${c.claimant}, value ${JSON.stringify(c.existing)})`
+          : `${line} (would overwrite ${JSON.stringify(c.existing)})`;
+      })
       .join('\n');
     const more = collisions.length > 5 ? `\n  ...and ${collisions.length - 5} more` : '';
     throw new Error(
-      `${collisions.length} hoisted token name(s) collide with an existing sibling.\n` +
-        "A dual node's child is renamed to a camel-joined sibling, and that name is taken.\n" +
-        'Hoisting would silently discard one of the two. Rename the child or the sibling.\n' +
+      `${collisions.length} hoisted token name(s) collide with an existing sibling or with a name an earlier hoist already claimed.\n` +
+        "A dual node's child is renamed to a camel-joined sibling, and that name may already be taken — by an authored token or group, or by another dual node's child hoisted earlier in the same pass.\n" +
+        'Hoisting would silently discard one of the two. Rename the child, the sibling, or whichever colliding child should keep the name.\n' +
         `${shown}${more}`,
     );
   }

--- a/scripts/lib/sd-native.mjs
+++ b/scripts/lib/sd-native.mjs
@@ -68,6 +68,11 @@ export function colorMixToHex8(value) {
 // Resolving here also handles references embedded inside an expression, which
 // SD's whole-value matcher misses. Pre-resolving costs nothing on native
 // targets: they set outputReferences: false, so references flatten regardless.
+// Marks a node whose AUTHORED $value was a whole-value reference, so the hoist
+// can decline to override the type DTCG 5.2.2 rule 1 already determined from the
+// referent. A Symbol key is invisible to Object.entries, to JSON.stringify, and
+// to Style Dictionary, so it cannot leak into output.
+const WAS_REF = Symbol('dtcg/was-reference');
 const WHOLE_REF = /^\{[^}]+\}$/;
 
 function interpolate(value, flat) {
@@ -87,6 +92,7 @@ function resolveInPlace(node, flat, prefix = []) {
     const path = [...prefix, key];
     if ('$value' in val && typeof val.$value === 'string') {
       if (WHOLE_REF.test(val.$value)) {
+        val[WAS_REF] = true;
         try {
           val.$value = resolveValue(path.join('.'), flat);
         } catch {
@@ -140,6 +146,13 @@ function hoistDualNodes(node, collisions, prefix = []) {
                 : existingNode,
           });
           continue;
+        }
+        // The dual node is the child's closest $type-bearing ancestor as
+        // authored; after the hoist it is a sibling, so the type is lost unless
+        // it travels. Excluded for a reference-valued child — DTCG 5.2.2 gives
+        // it the referent's type, which outranks inheritance.
+        if (!('$type' in childVal) && '$type' in val && !childVal[WAS_REF]) {
+          childVal.$type = val.$type;
         }
         node[hoisted] = childVal;
         delete val[childKey];

--- a/scripts/lib/sd-native.test.mjs
+++ b/scripts/lib/sd-native.test.mjs
@@ -496,6 +496,7 @@ test('preprocess throws when a hoisted name collides with an authored token', ()
       assert.match(err.message, /text\.sm\.lineHeight/);
       assert.match(err.message, /text\.smLineHeight/);
       assert.match(err.message, /28px/);
+      assert.doesNotMatch(err.message, /claimed by/);
       return true;
     },
   );
@@ -520,7 +521,9 @@ test('preprocess throws when a hoisted name collides with an authored group', ()
 });
 
 // Neither name is authored: t.a.bC and t.aB.c both camel-join to t.aBC.
-// The issue does not name this variant; it was found by probing.
+// The issue does not name this variant; it was found by probing. Both halves
+// of the collision must be named — t.a.bC is the only path the author could
+// act on, and there is no sibling t.aBC in the source to blame instead.
 test('preprocess throws when two hoists collide with each other', () => {
   assert.throws(
     () =>
@@ -530,7 +533,13 @@ test('preprocess throws when two hoists collide with each other', () => {
           aB: { $value: '3px', c: { $value: '4px' } },
         },
       }),
-    /collide/i,
+    (err) => {
+      assert.match(err.message, /collide/i);
+      assert.match(err.message, /t\.a\.bC/);
+      assert.match(err.message, /t\.aB\.c/);
+      assert.match(err.message, /claimed by/);
+      return true;
+    },
   );
 });
 

--- a/scripts/lib/sd-native.test.mjs
+++ b/scripts/lib/sd-native.test.mjs
@@ -618,3 +618,79 @@ test('preprocess is idempotent', () => {
   const twice = preprocess(once);
   assert.deepEqual(twice, once);
 });
+
+test('a hoisted child inherits the dual node $type when it has none', () => {
+  const out = preprocess({
+    text: { sm: { $value: '14px', $type: 'dimension', lineHeight: { $value: '20px' } } },
+  });
+  assert.equal(out.text.smLineHeight.$type, 'dimension');
+});
+
+test('a hoisted child keeps its own $type', () => {
+  const out = preprocess({
+    text: {
+      sm: { $value: '14px', $type: 'dimension', family: { $value: 'Inter', $type: 'fontFamily' } },
+    },
+  });
+  assert.equal(out.text.smFamily.$type, 'fontFamily');
+});
+
+test('nothing is invented when the dual node has no $type', () => {
+  const out = preprocess({
+    text: { sm: { $value: '14px', lineHeight: { $value: '20px' } } },
+  });
+  assert.equal('$type' in out.text.smLineHeight, false);
+});
+
+// Depth-first recursion means the inner hoist completes first, so lineHeightTight
+// is a direct child of sm by the time sm hoists. This is the test that catches a
+// $type carry running in the wrong recursion frame — every single-level test
+// passes regardless.
+test('$type inheritance reaches a child hoisted through two levels', () => {
+  const out = preprocess({
+    text: {
+      sm: {
+        $value: '14px',
+        $type: 'dimension',
+        lineHeight: { $value: '20px', tight: { $value: '18px' } },
+      },
+    },
+  });
+  assert.equal(out.text.smLineHeight.$type, 'dimension');
+  assert.equal(out.text.smLineHeightTight.$type, 'dimension');
+});
+
+// DTCG 5.2.2 orders its rules: a reference-valued token takes the RESOLVED type
+// of its referent, and that outranks group inheritance. resolveInPlace flattens
+// the reference before the hoist runs, so without a tag the hoist cannot tell
+// and would stamp the parent's $type over the referent's.
+test('a child whose authored value was a reference does not inherit $type', () => {
+  const out = preprocess({
+    ratio: { normal: { $value: '1.5', $type: 'number' } },
+    text: {
+      sm: { $value: '14px', $type: 'dimension', lineHeight: { $value: '{ratio.normal}' } },
+    },
+  });
+  assert.equal(out.text.smLineHeight.$value, '1.5');
+  assert.equal('$type' in out.text.smLineHeight, false);
+});
+
+// The Symbol tag must not reach Style Dictionary or any serialized output.
+test('the reference tag does not leak into output', () => {
+  const out = preprocess({
+    ratio: { normal: { $value: '1.5', $type: 'number' } },
+    text: { sm: { $value: '14px', lineHeight: { $value: '{ratio.normal}' } } },
+  });
+  assert.deepEqual(Object.keys(out.text.smLineHeight), ['$value']);
+  assert.equal(JSON.stringify(out).includes('was-reference'), false);
+});
+
+// #55's fix widens #52 rather than masking it: an untyped unitless literal child
+// under a dimension-typed dual node now becomes dimension, which is exactly
+// #52's shape. Asserted so the widening is recorded, not discovered later.
+test('the $type rule widens #52 — recorded, not masked', () => {
+  const out = preprocess({
+    leading: { base: { $value: '16px', $type: 'dimension', normal: { $value: '1.5' } } },
+  });
+  assert.equal(out.leading.baseNormal.$type, 'dimension', '#52 shape, knowingly produced');
+});

--- a/scripts/lib/sd-native.test.mjs
+++ b/scripts/lib/sd-native.test.mjs
@@ -478,3 +478,107 @@ test('a fontFamily containing a parenthesized suffix is quoted and kept, not mis
     true,
   );
 });
+
+// A dual node's child is renamed to a camel-joined sibling. If that name is
+// already taken, the pre-fix code overwrote it and a token vanished with no
+// diagnostic — the same class as the mode collision nativeSources guards.
+test('preprocess throws when a hoisted name collides with an authored token', () => {
+  assert.throws(
+    () =>
+      preprocess({
+        text: {
+          sm: { $value: '14px', lineHeight: { $value: '20px' } },
+          smLineHeight: { $value: '28px' },
+        },
+      }),
+    (err) => {
+      assert.match(err.message, /collide/i);
+      assert.match(err.message, /text\.sm\.lineHeight/);
+      assert.match(err.message, /text\.smLineHeight/);
+      return true;
+    },
+  );
+});
+
+// A group, not a token — hoisting onto it would destroy a whole subtree.
+test('preprocess throws when a hoisted name collides with an authored group', () => {
+  assert.throws(
+    () =>
+      preprocess({
+        text: {
+          sm: { $value: '14px', lineHeight: { $value: '20px' } },
+          smLineHeight: { bold: { $value: '28px' } },
+        },
+      }),
+    /collide/i,
+  );
+});
+
+// Neither name is authored: t.a.bC and t.aB.c both camel-join to t.aBC.
+// The issue does not name this variant; it was found by probing.
+test('preprocess throws when two hoists collide with each other', () => {
+  assert.throws(
+    () =>
+      preprocess({
+        t: {
+          a: { $value: '1px', bC: { $value: '2px' } },
+          aB: { $value: '3px', c: { $value: '4px' } },
+        },
+      }),
+    /collide/i,
+  );
+});
+
+// findModeCollisions exempts identical values because it is deduping across
+// files. This is not a dedupe — two distinct authored tokens land on one name,
+// and they may differ in $type or $description even with equal $value.
+test('preprocess throws on collision even when the values are identical', () => {
+  assert.throws(
+    () =>
+      preprocess({
+        text: {
+          sm: { $value: '14px', lineHeight: { $value: '20px' } },
+          smLineHeight: { $value: '20px' },
+        },
+      }),
+    /collide/i,
+  );
+});
+
+// The recursion is depth-first, so the deepest frame finishes first. An
+// implementation that throws per-frame reports one subtree and stops.
+test('preprocess reports every collision, across depths, in one error', () => {
+  assert.throws(
+    () =>
+      preprocess({
+        outer: {
+          a: { $value: '1px', b: { $value: '2px' } },
+          aB: { $value: '3px' },
+          nested: {
+            c: { $value: '4px', d: { $value: '5px' } },
+            cD: { $value: '6px' },
+          },
+        },
+      }),
+    (err) => {
+      assert.match(err.message, /outer\.a\.b/);
+      assert.match(err.message, /outer\.nested\.c\.d/);
+      assert.match(err.message, /^2 hoisted token name/m);
+      return true;
+    },
+  );
+});
+
+// sd-native.mjs states in prose that preprocess is idempotent, and real builds
+// rely on it (a project may declare the preprocessor at top level as well as on
+// the platform). No test asserted it before this one.
+test('preprocess is idempotent', () => {
+  const input = {
+    text: {
+      sm: { $value: '14px', $type: 'dimension', lineHeight: { $value: '20px', $type: 'dimension' } },
+    },
+  };
+  const once = preprocess(input);
+  const twice = preprocess(once);
+  assert.deepEqual(twice, once);
+});

--- a/scripts/lib/sd-native.test.mjs
+++ b/scripts/lib/sd-native.test.mjs
@@ -495,6 +495,7 @@ test('preprocess throws when a hoisted name collides with an authored token', ()
       assert.match(err.message, /collide/i);
       assert.match(err.message, /text\.sm\.lineHeight/);
       assert.match(err.message, /text\.smLineHeight/);
+      assert.match(err.message, /28px/);
       return true;
     },
   );
@@ -510,7 +511,11 @@ test('preprocess throws when a hoisted name collides with an authored group', ()
           smLineHeight: { bold: { $value: '28px' } },
         },
       }),
-    /collide/i,
+    (err) => {
+      assert.match(err.message, /collide/i);
+      assert.match(err.message, /\(a group\)/);
+      return true;
+    },
   );
 });
 
@@ -567,6 +572,37 @@ test('preprocess reports every collision, across depths, in one error', () => {
       return true;
     },
   );
+});
+
+// The message truncates the shown list at 5 and tails with a count of the
+// rest. Seven collisions is the smallest case that exercises the tail.
+test('preprocess truncates a long collision list and reports the remainder', () => {
+  const dict = {};
+  for (let i = 0; i < 7; i++) {
+    const letter = String.fromCharCode(97 + i);
+    dict[`g${i}`] = { $value: '1px', [letter]: { $value: '2px' } };
+    dict[`g${i}${letter.toUpperCase()}`] = { $value: '3px' };
+  }
+  assert.throws(
+    () => preprocess(dict),
+    (err) => {
+      assert.match(err.message, /^7 hoisted token name/m);
+      assert.match(err.message, /\.\.\.and 2 more/);
+      return true;
+    },
+  );
+});
+
+// Regression: hoisted in node walked the prototype chain, so a camel-joined
+// name matching an inherited Object.prototype member (toString, valueOf, ...)
+// reported a collision against a sibling that does not exist.
+test('a hoisted name matching an inherited Object.prototype member does not collide', () => {
+  const out = preprocess({
+    g: { to: { $value: '1px', string: { $value: '2px' } } },
+  });
+  assert.deepEqual(out, {
+    g: { to: { $value: '1px' }, toString: { $value: '2px' } },
+  });
 });
 
 // sd-native.mjs states in prose that preprocess is idempotent, and real builds

--- a/scripts/lib/sd-native.test.mjs
+++ b/scripts/lib/sd-native.test.mjs
@@ -608,10 +608,20 @@ test('a hoisted name matching an inherited Object.prototype member does not coll
 // sd-native.mjs states in prose that preprocess is idempotent, and real builds
 // rely on it (a project may declare the preprocessor at top level as well as on
 // the platform). No test asserted it before this one.
+//
+// The alias is deliberate: it is the only fixture shape that exercises the
+// WAS_REF membership, so a regression that leaked identity onto the cloned
+// tree (rather than tracking it in the WeakSet) would fail here.
 test('preprocess is idempotent', () => {
   const input = {
+    ratio: { normal: { $value: '1.5', $type: 'number' } },
     text: {
-      sm: { $value: '14px', $type: 'dimension', lineHeight: { $value: '20px', $type: 'dimension' } },
+      sm: {
+        $value: '14px',
+        $type: 'dimension',
+        lineHeight: { $value: '20px', $type: 'dimension' },
+        tracking: { $value: '{ratio.normal}' },
+      },
     },
   };
   const once = preprocess(input);
@@ -675,7 +685,7 @@ test('a child whose authored value was a reference does not inherit $type', () =
   assert.equal('$type' in out.text.smLineHeight, false);
 });
 
-// The Symbol tag must not reach Style Dictionary or any serialized output.
+// The reference tag must not reach Style Dictionary or any serialized output.
 test('the reference tag does not leak into output', () => {
   const out = preprocess({
     ratio: { normal: { $value: '1.5', $type: 'number' } },
@@ -693,4 +703,40 @@ test('the $type rule widens #52 — recorded, not masked', () => {
     leading: { base: { $value: '16px', $type: 'dimension', normal: { $value: '1.5' } } },
   });
   assert.equal(out.leading.baseNormal.$type, 'dimension', '#52 shape, knowingly produced');
+});
+
+// Same mechanism as the #52 widening above, and worth recording separately: an
+// untyped fontSize child under a dimension-typed dual node now inherits
+// dimension, which routes it to .dp rather than .sp. That is #51's shape — a
+// loud `18px` becomes a silent `18.00.dp`. Recorded, not masked.
+test('the $type rule widens #51 — recorded, not masked', () => {
+  const out = preprocess({
+    typography: { body: { $value: '16px', $type: 'dimension', fontSize: { $value: '18px' } } },
+  });
+  assert.equal(out.typography.bodyFontSize.$type, 'dimension', '#51 shape, knowingly produced');
+});
+
+// WAS_REF is set before the resolveValue try, not after: an unresolvable
+// reference is still a reference and must not inherit $type from the dual
+// node, even though it is left in place, unresolved, for SD to report.
+test('an unresolvable whole-value reference still does not inherit $type', () => {
+  const out = preprocess({
+    text: {
+      sm: { $value: '14px', $type: 'dimension', lineHeight: { $value: '{nope.missing}' } },
+    },
+  });
+  assert.equal('$type' in out.text.smLineHeight, false);
+});
+
+// DTCG 5.2.2 rule 1 governs whole-value aliases only; a reference embedded
+// inside an expression is resolved by interpolate, never tagged WAS_REF, and
+// so correctly inherits the dual node's $type like any other literal child.
+test('a reference embedded inside an expression still inherits $type', () => {
+  const out = preprocess({
+    ratio: { normal: { $value: '1.5', $type: 'number' } },
+    text: {
+      sm: { $value: '14px', $type: 'dimension', tracking: { $value: 'calc({ratio.normal} * 2)' } },
+    },
+  });
+  assert.equal(out.text.smTracking.$type, 'dimension');
 });

--- a/scripts/lib/sd-native.test.mjs
+++ b/scripts/lib/sd-native.test.mjs
@@ -543,6 +543,32 @@ test('preprocess throws when two hoists collide with each other', () => {
   );
 });
 
+// The collision message has a fourth branch: the name was already claimed by
+// an earlier hoist, and that hoisted child was itself a group. The existing
+// group test above only matches /\(a group\)/, which this branch does not —
+// its text is "(a group, already claimed by the hoist of ...)" — so that test
+// does not cover it. t.a.bC has no $value of its own, so it hoists to t.aBC
+// as a group; t.aB.c then collides with that claimed name.
+test('preprocess throws when a hoisted name collides with a hoisted group', () => {
+  assert.throws(
+    () =>
+      preprocess({
+        t: {
+          a: { $value: '1px', bC: { x: { $value: '2px' } } },
+          aB: { $value: '3px', c: { $value: '4px' } },
+        },
+      }),
+    (err) => {
+      assert.match(err.message, /collide/i);
+      assert.match(err.message, /t\.a\.bC/);
+      assert.match(err.message, /t\.aB\.c/);
+      assert.match(err.message, /a group/);
+      assert.match(err.message, /claimed by/);
+      return true;
+    },
+  );
+});
+
 // findModeCollisions exempts identical values because it is deduping across
 // files. This is not a dedupe — two distinct authored tokens land on one name,
 // and they may differ in $type or $description even with equal $value.

--- a/skills/token-sync-layer/SKILL.md
+++ b/skills/token-sync-layer/SKILL.md
@@ -178,9 +178,11 @@ for (const mode of MODES) {                     // e.g. ['light', 'dark']
 by dot-path, so a single build over the whole token directory collapses light
 and dark into whichever file sorted last, silently dropping a mode. Passing each
 mode's sources through `nativeSources` turns that into a thrown error naming the
-colliding paths. Then run `tokens:validate-output` against each generated file
-with that same source list. See
-`${CLAUDE_PLUGIN_ROOT}/references/native-adapter-config.md`.
+colliding paths. The `dtcg/resolve-dual-node` preprocessor throws too, on its
+own collision: a dual node's hoisted child renamed to a camel-joined name that
+an existing sibling or an earlier hoist in the same pass already has. Then run
+`tokens:validate-output` against each generated file with that same source
+list. See `${CLAUDE_PLUGIN_ROOT}/references/native-adapter-config.md`.
 
 **Execution model — subagent dispatch with model routing.** Generating each
 platform's output is independent and verifiable. If your host supports subagent


### PR DESCRIPTION
Closes #55.

## The two defects

`hoistDualNodes` moves a dual node's child to a camel-joined sibling — `text.sm.lineHeight` becomes `text.smLineHeight`, which `name/camel` renders to the identical symbol the un-hoisted path would have produced. Both defects reproduce against the shipped function:

```
A. $type does not travel
   in : {"text":{"sm":{"$value":"14px","$type":"dimension","lineHeight":{"$value":"20px"}}}}
   out: {"text":{"sm":{...}},"smLineHeight":{"$value":"20px"}}          <- untyped, emits bare

B. collision overwrites silently
   in : {"text":{"sm":{"$value":"14px","lineHeight":{...}},"smLineHeight":{"$value":"28px"}}}
   out: {"text":{"sm":{...}},"smLineHeight":{"$value":"20px"}}          <- authored 28px is gone
```

**A third variant the issue does not name**, found by probing: two *hoists* can collide with each other, no authored sibling involved. `t.a.bC` and `t.aB.c` both camel-join to `t.aBC`, and one token vanishes.

## The issue's premise was wrong, and it mattered

#55 opens *"DTCG permits a node carrying both a `$value` and children."* It does not. Design Tokens Format Module, Draft Community Group Report of **30 July 2026**, §6.1, normative:

> The presence of a `$value` property definitively identifies an object as a token. If an object contains both `$value` and child tokens/groups, this creates an invalid structure … Tools *MUST* report this as an error.

The prohibition is deliberate: **§6.2's `$root`** is the sanctioned way for a group to carry a base value alongside children. Two comments in this repo said the opposite; both are corrected.

This does not change what throughline *does* — Figma emits dual nodes and `hoistDualNodes` stays. It removes the question #55 was blocked on. The issue defers defect 1 pending a decision about "DTCG type-inheritance semantics"; there is no conforming reading to discover, so the behaviour is a judgment about malformed input and is argued that way rather than dressed up as spec interpretation.

## What ships

**Collision throws.** All three occupancy cases — authored token, authored group, and a name an earlier hoist claimed — are detected. Collisions are *collected* through the recursion and thrown once from `preprocess`; the recursion is depth-first, so a per-frame throw would report one subtree. On collision the assignment is **skipped**, because overwriting while collecting corrupts the tree for later detections.

**`$type` carries onto an untyped hoisted child** — with one exclusion. DTCG §5.2.2 orders type resolution: a reference-valued token takes its *referent's* type, outranking group inheritance. But `preprocess` runs `resolveInPlace` before the hoist, so every whole-value reference is already a literal and the hoist cannot tell. Without the exclusion the rule stamps `dimension` over a referent's `number` and emits `1.50.dp` — manufacturing an instance of open #52. A module-level `WeakSet` records such nodes while the reference is still visible.

## Verification

The strongest available assertion, since neither defect is reachable from the real source:

> Building zygarden's 322-token source through Style Dictionary 4.4.0 at `main` and at this branch produces **byte-identical output** — `diff -r` empty, four artefacts, 195 declarations and 0 broken symbols each.

**331 tests**, six gates green. Evidence in `docs/superpowers/notes/2026-08-24-hoist-dual-nodes-e2e.md`.

**The e2e run does not validate either fix.** Zygarden's `text.*` children each carry an explicit `$type` and no name collides, so neither defect can fire there — synthetic fixtures carry that weight, and proving *nothing moved* is the run's entire job. Nothing was compiled.

## Behaviour change for consumers

**A build that previously succeeded may now throw.** In almost every case that surfaces a token the build was already losing silently. One exception, verified against `main`: when the colliding nodes are deeply identical the old overwrite was lossless, and such a build now throws having lost nothing.

**Three accepted consequences of the `$type` carry**, all in `CHANGELOG.md`: an untyped `fontSize` child now emits `.dp` not `.sp` (#51's shape — this defeats the font-scale accessibility setting, and the gate that caught it no longer fires); an untyped unitless child emits as a dimension (#52's shape); and where an enclosing *group* carries a `$type` that correctly describes the child, the dual node's type shadows it — the one case that turns right into wrong rather than loud into silent.

## Four spec revisions, all corrections to my own reasoning

Recorded rather than quietly amended, because confident wrong reasoning surviving into architecture is this area's failure mode.

- **r2** — I cited `dtcg.mjs:9` for a claim it never made; following my own change list would have edited an innocent comment and left both real falsehoods standing. I also argued from DTCG §5.2.2 one paragraph after disqualifying it, and read "parent *group*" as "ancestor".
- **r3** — the `Symbol` tag broke structural idempotency (`assert.deepEqual` compares symbols; `structuredClone` drops them), and the test meant to catch that passed only because its fixture had no alias. Replaced with a `WeakSet`. Also: the rule widens #51, not just #52.
- **r4** — the accepted-cost section framed the residual entirely as loud→silent; one sub-case is correct→wrong.

## Out of scope

#51, #52, #54 are untouched and unmasked. Tests assert `1.50.dp` still validates, and both widenings are asserted rather than left to be discovered. The deferred question of whether throughline should *report* dual nodes as invalid DTCG went to #58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6zsxr3abwpVMhYh7cNdB1
