### PR TITLE
fix: Compose font sizes and line heights emit as sp, not dp (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,18 @@ to [Semantic Versioning](https://semver.org).
   spec-compliant source the branch never fired and every dimension emitted as
   `dp`. Measured on a real 322-token source: zero `.sp` in the Kotlin output.
   The role now comes from the member names DTCG §9.8 fixes for the typography
-  composite: a `dimension` token named `fontSize`, `letterSpacing` or
-  `lineHeight` whose resolved value carries a `px` or `rem` unit is stamped
+  composite: a token whose own `$type` is `dimension`, named `fontSize`,
+  `letterSpacing` or `lineHeight`, and whose resolved value carries a `px` or
+  `rem` unit, is stamped
   `$extensions["com.radicool.throughline"].nativeUnit = "text"` during
   preprocessing, and the Compose transforms partition on that stamp. Style
   Dictionary's own `$type: "fontSize"` convention still works, so the change
   is additive. A source can set the extension itself to override the rule, or
-  set it to `"device"` to opt a token out. Three limits remain and are
-  documented: a bare scale primitive (`text.base`) carries no role and stays
+  set it to `"device"` to opt a token out. The `$type` check reads the token's
+  own key, so a dual-node child that carries no `$type` of its own — and would
+  inherit `dimension` from its parent during hoisting — is not stamped and
+  still emits `dp`. Three limits remain and are documented: a bare scale
+  primitive (`text.base`) carries no role and stays
   `dp`, an `em` letterSpacing is still filtered out of native output, and a
   unitless ratio still emits as `dp` — deliberately, since `1.50.sp` would
   compile and render 1.5sp text.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ to [Semantic Versioning](https://semver.org).
 ## [Unreleased]
 
 ### Fixed
+- **Compose font sizes and line heights emit as `sp` rather than `dp`.**
+  `size/unit-aware/compose-sp` gated on `$type === "fontSize"`, which DTCG
+  does not define — it types font sizes as `dimension` — so on a
+  spec-compliant source the branch never fired and every dimension emitted as
+  `dp`. Measured on a real 322-token source: zero `.sp` in the Kotlin output.
+  The role now comes from the member names DTCG §9.8 fixes for the typography
+  composite: a `dimension` token named `fontSize`, `letterSpacing` or
+  `lineHeight` whose resolved value carries a `px` or `rem` unit is stamped
+  `$extensions["com.radicool.throughline"].nativeUnit = "text"` during
+  preprocessing, and the Compose transforms partition on that stamp. Style
+  Dictionary's own `$type: "fontSize"` convention still works, so the change
+  is additive. A source can set the extension itself to override the rule, or
+  set it to `"device"` to opt a token out. Three limits remain and are
+  documented: a bare scale primitive (`text.base`) carries no role and stays
+  `dp`, an `em` letterSpacing is still filtered out of native output, and a
+  unitless ratio still emits as `dp` — deliberately, since `1.50.sp` would
+  compile and render 1.5sp text.
 - **`preprocess` throws on a dual-node hoist collision instead of silently
   discarding a token.** `hoistDualNodes` renames a dual node's child to a
   camel-joined sibling (`text.sm.lineHeight` becomes `text.smLineHeight`).

--- a/docs/superpowers/plans/2026-08-24-compose-text-units.md
+++ b/docs/superpowers/plans/2026-08-24-compose-text-units.md
@@ -1,0 +1,696 @@
+# Compose Text Units Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Compose font sizes and line heights emit as `.sp` rather than
+`.dp`, by sourcing the typographic role from DTCG §9.8's member names instead
+of from a `$type` that DTCG does not define.
+
+**Architecture:** A classification pass inside `preprocess`, running after
+`resolveInPlace` and before `hoistDualNodes`, stamps
+`$extensions["com.radicool.throughline"].nativeUnit = "text"` onto dimension
+tokens named `fontSize`, `letterSpacing`, or `lineHeight` whose resolved value
+carries an absolute unit. The two Compose size transforms then partition on
+that stamp instead of on `$type === 'fontSize'`, which DTCG never produces.
+
+**Tech Stack:** Node ≥20, ESM, zero runtime dependencies. Style Dictionary
+4.4.0 is a *parameter*, never an import. Tests are `node:test` + `node:assert/strict`.
+
+**Spec:** `docs/superpowers/specs/2026-08-24-compose-text-unit-design.md`
+
+## Global Constraints
+
+- **Zero dependencies in `scripts/lib/`.** It is installed into consumer repos.
+  Never `import` Style Dictionary; it arrives as a function parameter.
+- **Every code line must sit inside an `@doc-section <name>` /
+  `@doc-section-end <name>` comment pair.** Only blank lines and `//` comments
+  may sit outside one. `scripts/build-native-adapter-config.mjs` throws
+  otherwise and `--check` gates it in CI.
+- **Regenerate the reference doc at the end of EVERY task** that edits
+  `scripts/lib/sd-native.mjs`: `node scripts/build-native-adapter-config.mjs`.
+  A freshness test goes red the moment the module changes; deferring the
+  regeneration leaves a known-failing suite that a real regression can hide
+  behind.
+- **`preprocess` must stay structurally idempotent.**
+  `assert.deepEqual(preprocess(preprocess(x)), preprocess(x))` is an existing
+  test at `scripts/lib/sd-native.test.mjs:650`.
+- **`preprocess` must not mutate its input** — existing test at
+  `scripts/lib/sd-native.test.mjs:97`. It clones with `structuredClone` first.
+- **The extension namespace string is exactly `com.radicool.throughline`** and
+  the key inside it is exactly `nativeUnit`, value exactly `"text"`.
+- **The three role names are exactly `fontSize`, `letterSpacing`, `lineHeight`**
+  — matched against the token's own key, case-sensitive, exact equality.
+- **Run the full suite with `node --test` from the repo root.** Do not add a
+  test runner, a config file, or a dependency.
+- **Do not change `size/unit-aware/swift`.** iOS is already correct.
+
+---
+
+## File Structure
+
+| File | Responsibility in this change |
+|---|---|
+| `scripts/lib/sd-native.mjs` | All behaviour. Task 1 adds `classifyTextUnits` + `EXT_NS` to the `preprocess` doc-section; Task 2 changes two transform filters and the `platform` doc-section comment. |
+| `scripts/lib/sd-native.test.mjs` | All tests. Append to the end; do not reorder existing tests. |
+| `references/native-adapter-config.md` | **Generated.** Never hand-edit. Regenerate at the end of Tasks 1 and 2. |
+| `references/sync-adapters.md` | Hand-written. Task 3 corrects the paragraph citing this defect. |
+| `CHANGELOG.md` | Task 3 adds one `[Unreleased] / Fixed` entry. |
+
+---
+
+### Task 1: Classify text-unit roles in `preprocess`
+
+**Files:**
+- Modify: `scripts/lib/sd-native.mjs` — add code inside the existing
+  `// @doc-section preprocess` / `// @doc-section-end preprocess` pair
+  (currently lines 56–208), and change the `preprocess` function body.
+- Test: `scripts/lib/sd-native.test.mjs` — append at end of file.
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `export const EXT_NS = 'com.radicool.throughline'` — Task 2's
+  `isTextUnit` helper and its tests import this by name from
+  `./sd-native.mjs`. Also produces the stamp shape
+  `token.$extensions['com.radicool.throughline'].nativeUnit === 'text'`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/lib/sd-native.test.mjs`. Add `EXT_NS` to the existing
+import block at the top of the file (the one importing `magnitude`,
+`colorMixToHex8`, `preprocess`, …).
+
+```js
+// #51. DTCG has no fontSize type, so the role cannot come from $type. It comes
+// from the member names the Format Module's 30 July 2026 draft §9.8 fixes at
+// MUST level for the typography composite.
+const roleOf = (token) => token?.$extensions?.[EXT_NS]?.nativeUnit;
+
+test('preprocess stamps a dimension named fontSize as a text unit', () => {
+  const out = preprocess({
+    typography: { h1: { fontSize: { $value: '30px', $type: 'dimension' } } },
+  });
+  assert.equal(roleOf(out.typography.h1.fontSize), 'text');
+});
+
+test('preprocess stamps letterSpacing and lineHeight, not fontFamily or fontWeight', () => {
+  const out = preprocess({
+    t: {
+      letterSpacing: { $value: '0.5px', $type: 'dimension' },
+      lineHeight: { $value: '24px', $type: 'dimension' },
+      fontFamily: { $value: 'Nunito Sans', $type: 'fontFamily' },
+      fontWeight: { $value: '700', $type: 'fontWeight' },
+    },
+  });
+  assert.equal(roleOf(out.t.letterSpacing), 'text');
+  assert.equal(roleOf(out.t.lineHeight), 'text');
+  assert.equal(roleOf(out.t.fontFamily), undefined);
+  assert.equal(roleOf(out.t.fontWeight), undefined);
+});
+
+// The load-bearing case, and the one the spec review caught. Every semantic
+// font size in a real source is authored as a REFERENCE — "{text.3xl}" — and
+// carries no unit at all. Classifying on the authored string would stamp only
+// the px-authored primitives and miss two thirds of the fix.
+test('preprocess stamps a fontSize authored as a reference, using the resolved value', () => {
+  const out = preprocess({
+    text: { '3xl': { $value: '30px', $type: 'dimension' } },
+    typography: { h1: { fontSize: { $value: '{text.3xl}', $type: 'dimension' } } },
+  });
+  assert.equal(out.typography.h1.fontSize.$value, '30px');
+  assert.equal(roleOf(out.typography.h1.fontSize), 'text');
+});
+
+// The hoist renames text.xs.lineHeight to text.xsLineHeight, consuming the
+// leaf name the rule matches on. Classification must run first.
+test('preprocess stamps a dual-node child before the hoist consumes its name', () => {
+  const out = preprocess({
+    text: { xs: { $value: '12px', $type: 'dimension', lineHeight: { $value: '16px', $type: 'dimension' } } },
+  });
+  assert.equal(out.text.xsLineHeight.$value, '16px');
+  assert.equal(roleOf(out.text.xsLineHeight), 'text');
+  assert.equal(roleOf(out.text.xs), undefined);
+});
+
+// magnitude() reads a bare number as a ratio. Stamping one would emit
+// 1.50.sp — which compiles and renders 1.5sp text, trading a loud failure for
+// a silent one. leading.normal stays the separate defect it already is.
+test('preprocess does not stamp a unitless ratio named lineHeight', () => {
+  const out = preprocess({
+    t: { lineHeight: { $value: '1.5', $type: 'dimension' } },
+  });
+  assert.equal(roleOf(out.t.lineHeight), undefined);
+});
+
+test('preprocess does not stamp an em or percentage value', () => {
+  const out = preprocess({
+    t: {
+      letterSpacing: { $value: '-0.03em', $type: 'dimension' },
+      lineHeight: { $value: '150%', $type: 'dimension' },
+    },
+  });
+  assert.equal(roleOf(out.t.letterSpacing), undefined);
+  assert.equal(roleOf(out.t.lineHeight), undefined);
+});
+
+test('preprocess stamps rem as well as px', () => {
+  const out = preprocess({ t: { fontSize: { $value: '1.5rem', $type: 'dimension' } } });
+  assert.equal(roleOf(out.t.fontSize), 'text');
+});
+
+// The $type check reads the token's OWN key, so a fontSize typed something
+// else is not swept in.
+test('preprocess does not stamp a fontSize that is not dimension-typed', () => {
+  const out = preprocess({ t: { fontSize: { $value: '30px', $type: 'string' } } });
+  assert.equal(roleOf(out.t.fontSize), undefined);
+});
+
+// The override, and the reason this design needs no new config parameter.
+test('preprocess honours a nativeUnit the source already set', () => {
+  const out = preprocess({
+    t: {
+      lineHeight: {
+        $value: '24px',
+        $type: 'dimension',
+        $extensions: { 'com.radicool.throughline': { nativeUnit: 'device' } },
+      },
+      size: {
+        $value: '30px',
+        $type: 'dimension',
+        $extensions: { 'com.radicool.throughline': { nativeUnit: 'text' } },
+      },
+    },
+  });
+  assert.equal(roleOf(out.t.lineHeight), 'device');
+  assert.equal(roleOf(out.t.size), 'text');
+});
+
+test('preprocess leaves an unrelated $extensions namespace untouched', () => {
+  const out = preprocess({
+    t: {
+      fontSize: {
+        $value: '30px',
+        $type: 'dimension',
+        $extensions: { 'org.example.other': { hint: 'keep me' } },
+      },
+    },
+  });
+  assert.equal(out.t.fontSize.$extensions['org.example.other'].hint, 'keep me');
+  assert.equal(roleOf(out.t.fontSize), 'text');
+});
+
+test('preprocess does not stamp the caller input', () => {
+  const input = { t: { fontSize: { $value: '30px', $type: 'dimension' } } };
+  preprocess(input);
+  assert.equal(input.t.fontSize.$extensions, undefined);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `node --test scripts/lib/sd-native.test.mjs`
+
+Expected: FAIL. The import of `EXT_NS` fails first with
+`SyntaxError: The requested module './sd-native.mjs' does not provide an export named 'EXT_NS'`.
+
+- [ ] **Step 3: Add the classifier to the `preprocess` doc-section**
+
+In `scripts/lib/sd-native.mjs`, insert immediately **before** the line
+`export function preprocess(dict) {` (currently line 179) and **inside** the
+`@doc-section preprocess` pair:
+
+```js
+// Which native unit a dimension belongs in: Compose's Dp, or its TextUnit.
+//
+// $type cannot answer this. DTCG's type set has no fontSize — font sizes are
+// dimension, and so are spacing, radius and stroke widths — so the stock
+// size/compose/remToSp filter on $type === 'fontSize' never fires on a
+// spec-compliant source and every font size falls through to dp.
+//
+// The role therefore comes from the one place a DTCG source states it: the
+// member names the Format Module's 30 July 2026 draft, §9.8, fixes at MUST
+// level for the typography composite. Three of the five are dimension-valued,
+// and Compose's TextStyle takes TextUnit for all three with no Dp overload.
+//
+// The limit, stated rather than hidden: §9.8 puts those names inside a
+// composite token's $value object, while Figma-derived sources put them as
+// sibling tokens in a group. Reading them there mirrors the spec's vocabulary;
+// it is not a guarantee the spec makes. A source naming its font size
+// typography.body.size sets $extensions itself and is honoured below.
+const TEXT_UNIT_NAMES = new Set(['fontSize', 'letterSpacing', 'lineHeight']);
+
+// Reverse-DNS, per DTCG's $extensions convention. Exported because the
+// transforms and their tests address the same key.
+export const EXT_NS = 'com.radicool.throughline';
+
+// px and rem only. magnitude() reads a bare number as an unscaled ratio, so a
+// lineHeight authored "1.5" would otherwise be stamped and emit 1.50.sp —
+// which compiles and renders 1.5sp text. That trades a loud failure (a Dp
+// where a TextUnit is required) for a silent one, which is the failure class
+// this module exists to prevent. A ratio keeps today's behaviour and stays the
+// separate defect it already is.
+const ABSOLUTE_UNIT = /^-?(?:\d+(?:\.\d+)?|\.\d+)(?:px|rem)$/;
+
+// Runs AFTER resolveInPlace and BEFORE hoistDualNodes. Both halves matter.
+//
+// After resolution, because the unit is not in the authored text: a semantic
+// font size is authored "{text.3xl}" and carries no unit at all. Reading the
+// authored string would classify only the px-authored primitives — 13 of 39
+// on a real source.
+//
+// Before the hoist, because the hoist consumes the leaf name:
+// text.xs.lineHeight becomes text.xsLineHeight, and the name this rule matches
+// on is gone. Matching a suffix against the camel-joined name instead would
+// couple the rule to the hoist's naming scheme, and case-insensitively it
+// false-positives on names like baselineHeight.
+function classifyTextUnits(node) {
+  for (const [key, val] of Object.entries(node)) {
+    if (key.startsWith('$') || !val || typeof val !== 'object') continue;
+    if (
+      TEXT_UNIT_NAMES.has(key) &&
+      '$value' in val &&
+      val.$type === 'dimension' &&
+      ABSOLUTE_UNIT.test(String(val.$value).trim())
+    ) {
+      val.$extensions ??= {};
+      val.$extensions[EXT_NS] ??= {};
+      const ns = val.$extensions[EXT_NS];
+      // A source that states the role itself wins. This is the override, and
+      // it costs no configuration parameter: declining to overwrite IS the
+      // feature. It is also what makes the pass idempotent.
+      if (!('nativeUnit' in ns)) ns.nativeUnit = 'text';
+    }
+    classifyTextUnits(val);
+  }
+  return node;
+}
+```
+
+- [ ] **Step 4: Wire it into `preprocess`**
+
+In the same file, in `export function preprocess(dict)`, replace:
+
+```js
+  const out = hoistDualNodes(
+    resolveInPlace(structuredClone(dict), flattenDtcg(dict)),
+    collisions,
+  );
+```
+
+with:
+
+```js
+  const out = hoistDualNodes(
+    classifyTextUnits(resolveInPlace(structuredClone(dict), flattenDtcg(dict))),
+    collisions,
+  );
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `node --test scripts/lib/sd-native.test.mjs`
+
+Expected: PASS, including the pre-existing `preprocess is idempotent` and
+`preprocess does not mutate its input` tests. If `preprocess is idempotent`
+fails, the cause is the stamp being rewritten rather than declined — re-check
+the `if (!('nativeUnit' in ns))` guard.
+
+- [ ] **Step 6: Regenerate the reference doc**
+
+Run: `node scripts/build-native-adapter-config.mjs`
+
+Then confirm it is self-consistent: `node scripts/build-native-adapter-config.mjs --check`
+Expected: exit 0.
+
+- [ ] **Step 7: Run the full suite**
+
+Run: `node --test`
+Expected: 0 failures.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add scripts/lib/sd-native.mjs scripts/lib/sd-native.test.mjs references/native-adapter-config.md
+git commit -m "feat: classify DTCG typography members as Compose text units (#51)
+
+Stamps \$extensions[com.radicool.throughline].nativeUnit on dimension tokens
+named fontSize, letterSpacing or lineHeight, between alias resolution and the
+dual-node hoist. No output change yet — the transforms read the stamp in the
+next commit."
+```
+
+---
+
+### Task 2: Partition the Compose size transforms on the stamp
+
+**Files:**
+- Modify: `scripts/lib/sd-native.mjs` — the `@doc-section register` pair
+  (currently 397–500): add one helper, change two transform filters. Also the
+  `@doc-section platform` comment block (currently 210–230), which currently
+  documents the sp branch as unreachable.
+- Test: `scripts/lib/sd-native.test.mjs` — append at end; also update one
+  existing test named exactly
+  `'the registered compose transforms split sp from dp by $type'`.
+
+**Interfaces:**
+- Consumes: `EXT_NS` from Task 1, and the stamp shape
+  `token.$extensions[EXT_NS].nativeUnit === 'text'`.
+- Produces: no new exports. Changes the observable output of
+  `size/unit-aware/compose-sp` and `size/unit-aware/compose-dp`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/lib/sd-native.test.mjs`:
+
+```js
+// #51. The sp branch used to gate on $type === 'fontSize', which DTCG never
+// produces. It now gates on the role stamped in preprocess.
+const stamped = (value) => ({
+  $type: 'dimension',
+  $value: value,
+  original: { $value: value },
+  $extensions: { [EXT_NS]: { nativeUnit: 'text' } },
+});
+
+test('the compose transforms split sp from dp by the text-unit stamp', () => {
+  const t = collectTransforms();
+  const dp = t.get('size/unit-aware/compose-dp');
+  const sp = t.get('size/unit-aware/compose-sp');
+
+  const textUnit = stamped('30px');
+  const device = { $type: 'dimension', $value: '16px', original: { $value: '16px' } };
+
+  assert.equal(sp.filter(textUnit), true);
+  assert.equal(dp.filter(textUnit), false);
+  assert.equal(sp.transform(textUnit), '30.00.sp');
+
+  assert.equal(dp.filter(device), true);
+  assert.equal(sp.filter(device), false);
+  assert.equal(dp.transform(device), '16.00.dp');
+});
+
+// The partition must be disjoint: no token may be transformed by both, and
+// none may fall through neither.
+test('no dimension token matches both compose transforms', () => {
+  const t = collectTransforms();
+  const dp = t.get('size/unit-aware/compose-dp');
+  const sp = t.get('size/unit-aware/compose-sp');
+  for (const token of [
+    stamped('30px'),
+    { $type: 'dimension', $value: '16px', original: { $value: '16px' } },
+    { $type: 'fontSize', $value: '14px', original: { $value: '14px' } },
+  ]) {
+    assert.equal(dp.filter(token) && sp.filter(token), false);
+  }
+});
+
+// The override invites a source to stamp any token it likes, so the sp filter
+// needs the same hasMagnitude guard both size transforms already carry.
+// Without it this reaches authored(token).toFixed(2) on null.
+test('the sp transform skips a stamped token with no build-time magnitude', () => {
+  const sp = collectTransforms().get('size/unit-aware/compose-sp');
+  assert.equal(sp.filter(stamped('-0.03em')), false);
+  assert.equal(sp.filter(stamped('Nunito Sans')), false);
+});
+
+// Style Dictionary's own convention keeps working: this change is additive.
+test('the sp transform still fires on a Style Dictionary $type fontSize', () => {
+  const sp = collectTransforms().get('size/unit-aware/compose-sp');
+  const token = { $type: 'fontSize', $value: '14px', original: { $value: '14px' } };
+  assert.equal(sp.filter(token), true);
+  assert.equal(sp.transform(token), '14.00.sp');
+});
+
+// End to end through preprocess: the shape a real source actually has.
+test('a resolved semantic fontSize reaches the sp transform', () => {
+  const out = preprocess({
+    text: { '3xl': { $value: '30px', $type: 'dimension' } },
+    typography: { h1: { fontSize: { $value: '{text.3xl}', $type: 'dimension' } } },
+  });
+  const token = out.typography.h1.fontSize;
+  token.original = { $value: token.$value };
+  const sp = collectTransforms().get('size/unit-aware/compose-sp');
+  assert.equal(sp.filter(token), true);
+  assert.equal(sp.transform(token), '30.00.sp');
+});
+```
+
+- [ ] **Step 2: Update the one existing test that asserts the old gate**
+
+Find the test named exactly
+`'the registered compose transforms split sp from dp by $type'` (currently at
+`scripts/lib/sd-native.test.mjs:281`). Rename it and add the stamped case, so
+it documents both gates rather than only the legacy one. Replace the whole
+test with:
+
+```js
+test('the registered compose transforms split sp from dp by $type or stamp', () => {
+  const transforms = [];
+  registerNativeTransforms({ registerPreprocessor: () => {}, registerTransform: (t) => transforms.push(t) });
+  const dp = transforms.find((t) => t.name === 'size/unit-aware/compose-dp');
+  const sp = transforms.find((t) => t.name === 'size/unit-aware/compose-sp');
+
+  const dimension = { $type: 'dimension', $value: '16px', original: { $value: '16px' } };
+  const fontSize = { $type: 'fontSize', $value: '14px', original: { $value: '14px' } };
+
+  assert.equal(dp.filter(dimension), true);
+  assert.equal(dp.filter(fontSize), false);
+  assert.equal(dp.transform(dimension), '16.00.dp');
+
+  assert.equal(sp.filter(fontSize), true);
+  assert.equal(sp.filter(dimension), false);
+  assert.equal(sp.transform(fontSize), '14.00.sp');
+});
+```
+
+(The only change is the test name; the body still guards the legacy gate, and
+the new tests from Step 1 cover the stamp.)
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `node --test scripts/lib/sd-native.test.mjs`
+
+Expected: FAIL on `the compose transforms split sp from dp by the text-unit stamp`
+with `sp.filter(textUnit)` returning `false` and `dp.filter(textUnit)`
+returning `true` — the current filters ignore the stamp.
+
+- [ ] **Step 4: Add the helper and change the two filters**
+
+In `scripts/lib/sd-native.mjs`, inside the `@doc-section register` pair, add
+beside the existing `isDimension` / `isFontSize` / `hasMagnitude` consts
+(currently lines 400–403):
+
+```js
+// The role preprocess stamped. $type cannot carry it — see classifyTextUnits.
+const isTextUnit = (token) => token.$extensions?.[EXT_NS]?.nativeUnit === 'text';
+```
+
+Replace the `size/unit-aware/compose-dp` filter:
+
+```js
+    filter: (token) => isDimension(token) && hasMagnitude(token),
+```
+
+with:
+
+```js
+    filter: (token) => isDimension(token) && !isTextUnit(token) && hasMagnitude(token),
+```
+
+Replace the `size/unit-aware/compose-sp` filter:
+
+```js
+    filter: (token) => isFontSize(token) && hasMagnitude(token),
+```
+
+with:
+
+```js
+    filter: (token) => (isTextUnit(token) || isFontSize(token)) && hasMagnitude(token),
+```
+
+Leave both `transform` functions and `size/unit-aware/swift` untouched.
+
+- [ ] **Step 5: Replace the stale comment in the `platform` doc-section**
+
+In the `// @doc-section platform` block, delete this paragraph (currently
+lines 217–224):
+
+```
+// That last one is only half fixed, and the half that remains is load-bearing:
+// the sp transform below gates on $type === 'fontSize', but DTCG has no
+// fontSize type — it types font sizes as dimension — so on a spec-compliant
+// source the sp branch never fires and Android font sizes still emit as dp.
+// Android-only; size/unit-aware/swift filters dimension || fontSize and is
+// correct. Same class as a unitless ratio (leading.normal: "1.5") emitting as
+// 1.50.dp. Both are measured, not theoretical — see
+// docs/superpowers/notes/2026-08-21-native-config-e2e-results.md.
+```
+
+and put this in its place:
+
+```
+// That last one is fixed for tokens whose role a DTCG source actually states:
+// classifyTextUnits stamps fontSize, letterSpacing and lineHeight members, and
+// the sp transform gates on the stamp rather than on a $type DTCG never emits.
+// Three limits remain, all Android-only and all measured rather than
+// theoretical — see docs/superpowers/notes/2026-08-21-native-config-e2e-results.md:
+//
+//   - A scale primitive carries no role. text.base: "16px" is a font size only
+//     to a human, so it emits as dp. The semantic tokens referencing it are
+//     correct, and those are what a consumer should reach for.
+//   - An em-valued letterSpacing is filtered out of native output entirely,
+//     rather than emitted as Compose's .em TextUnit.
+//   - A unitless ratio (leading.normal: "1.5") emits as 1.50.dp. It is
+//     deliberately NOT stamped: 1.50.sp would compile and render 1.5sp text,
+//     turning a loud failure into a silent one.
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `node --test scripts/lib/sd-native.test.mjs`
+Expected: PASS, all tests including the two updated ones.
+
+- [ ] **Step 7: Regenerate the reference doc and run the full suite**
+
+```bash
+node scripts/build-native-adapter-config.mjs
+node scripts/build-native-adapter-config.mjs --check
+node --test
+```
+Expected: exit 0 from the `--check`, 0 test failures.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add scripts/lib/sd-native.mjs scripts/lib/sd-native.test.mjs references/native-adapter-config.md
+git commit -m "fix: Compose font sizes and line heights emit as sp, not dp (#51)
+
+compose-sp now gates on the text-unit stamp as well as Style Dictionary's
+\$type: fontSize, and compose-dp excludes stamped tokens. The partition is
+disjoint. Compose TextStyle takes TextUnit for fontSize, lineHeight and
+letterSpacing with no Dp overload, so the previous output did not compile at
+the use site."
+```
+
+---
+
+### Task 3: Correct the prose docs and record the changelog
+
+**Files:**
+- Modify: `references/sync-adapters.md` — the `android-kotlin` Tier 2
+  paragraph (currently lines 73–82).
+- Modify: `CHANGELOG.md` — the `## [Unreleased]` / `### Fixed` list.
+- Do NOT modify `references/native-adapter-config.md` by hand; Task 2
+  regenerated it.
+
+**Interfaces:**
+- Consumes: the behaviour Tasks 1 and 2 shipped.
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Correct the `sync-adapters.md` Tier 2 paragraph**
+
+Replace this sentence inside the `android-kotlin` paragraph:
+
+```
+Concretely, DTCG has no `fontSize` type — it types font sizes as
+`dimension` — and the `sp` transform gates on `$type === 'fontSize'`, so on
+spec-compliant input Android font sizes currently emit as `dp`, not `sp`; the
+Swift transform filters `dimension || fontSize` and is unaffected.
+```
+
+with:
+
+```
+The `dp`/`sp` split itself is no longer among them: font sizes and line
+heights whose role a DTCG source states — the `fontSize`, `letterSpacing` and
+`lineHeight` member names of §9.8's typography composite — now emit as `sp`.
+What remains is narrower and documented in
+`${CLAUDE_PLUGIN_ROOT}/references/native-adapter-config.md`: a bare scale
+primitive carries no role and stays `dp`, an `em` letterSpacing is filtered
+out rather than emitted as `.em`, and a unitless ratio still emits as `dp`.
+```
+
+Leave the rest of the paragraph — including "stays Tier 2" — unchanged. The
+tier does not move: the stated reason is consumption-side behaviour against a
+real Compose app, which building tokens does not exercise.
+
+- [ ] **Step 2: Add the changelog entry**
+
+In `CHANGELOG.md`, add as the FIRST bullet under `## [Unreleased]` →
+`### Fixed`:
+
+```markdown
+- **Compose font sizes and line heights emit as `sp` rather than `dp`.**
+  `size/unit-aware/compose-sp` gated on `$type === "fontSize"`, which DTCG
+  does not define — it types font sizes as `dimension` — so on a
+  spec-compliant source the branch never fired and every dimension emitted as
+  `dp`. Measured on a real 322-token source: zero `.sp` in the Kotlin output.
+  The role now comes from the member names DTCG §9.8 fixes for the typography
+  composite: a `dimension` token named `fontSize`, `letterSpacing` or
+  `lineHeight` whose resolved value carries a `px` or `rem` unit is stamped
+  `$extensions["com.radicool.throughline"].nativeUnit = "text"` during
+  preprocessing, and the Compose transforms partition on that stamp. Style
+  Dictionary's own `$type: "fontSize"` convention still works, so the change
+  is additive. A source can set the extension itself to override the rule, or
+  set it to `"device"` to opt a token out. Three limits remain and are
+  documented: a bare scale primitive (`text.base`) carries no role and stays
+  `dp`, an `em` letterSpacing is still filtered out of native output, and a
+  unitless ratio still emits as `dp` — deliberately, since `1.50.sp` would
+  compile and render 1.5sp text.
+```
+
+- [ ] **Step 3: Verify the six repo gates**
+
+```bash
+node --test
+node ci/validate-plugin.mjs
+node ci/validate-skills.mjs
+node scripts/adapters/generate.mjs --check
+node scripts/build-doc-card-builder.mjs --check
+node scripts/build-native-adapter-config.mjs --check
+```
+Expected: every one exits 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add references/sync-adapters.md CHANGELOG.md
+git commit -m "docs: record the Compose text-unit fix and correct the tier rationale (#51)"
+```
+
+---
+
+## Verification (controller, after Task 3)
+
+Not a subagent task — the controller runs this, because it needs the external
+zygarden source and a scratch Style Dictionary install.
+
+The spec's §7.1 prediction is falsifiable and must be checked by building at
+the base commit and at HEAD and diffing, **not** by counting declarations.
+Counting cannot see compensating changes.
+
+Expected, against the zygarden light+mobile build:
+
+- exactly **39** Kotlin declarations change, all `.dp` → `.sp`
+  (13 `typography.textStyle.*.fontSize`, 13 `typography.textStyle.*.lineHeight`,
+  13 hoisted `text.*LineHeight`)
+- the other **156** are byte-identical
+- declaration count stays **195**
+- `Tokens.swift` is **byte-identical**
+- `validate-token-output.mjs` exits 0 on both platforms, still 195/195 matched
+
+Any deviation is a finding, not a rounding error.
+
+## Follow-ups to file (controller, at PR time)
+
+Spec §10. These are deliberately out of scope here and must be filed rather
+than absorbed:
+
+1. **A scale primitive carries no role.** `text.base: "16px"` emits as `dp`;
+   no nominal or structural signal identifies it as typographic. Reference-graph
+   inference — a dimension referenced by a `fontSize`-named token is itself a
+   font size — is the candidate, and is the only option that reaches all 52.
+2. **An `em`-valued `letterSpacing` is dropped rather than emitted as Compose
+   `.em`.** A filter gap, not a dp/sp gap. Whoever fixes it must also revisit
+   `ABSOLUTE_UNIT` in `classifyTextUnits`, since the two are coupled: today
+   those tokens are not stamped.

--- a/docs/superpowers/plans/2026-08-24-compose-text-units.md
+++ b/docs/superpowers/plans/2026-08-24-compose-text-units.md
@@ -587,6 +587,15 @@ the use site."
 - Consumes: the behaviour Tasks 1 and 2 shipped.
 - Produces: nothing consumed by later tasks.
 
+> **Amended after Task 2's review.** Two defects in this plan's own text were
+> found and are fixed in this task: the ratio example in Task 2 Step 5's
+> comment is excluded by two gates rather than the one it illustrates, and the
+> test renamed in Task 2 Step 2 has a title its body does not match. Both are
+> written out as Steps 0a/0b in
+> `.superpowers/sdd/2026-08-24-compose-text-units/task-3-brief.md`, with a
+> Step 0c regenerating the reference doc — required, because 0a edits
+> `scripts/lib/sd-native.mjs`.
+
 - [ ] **Step 1: Correct the `sync-adapters.md` Tier 2 paragraph**
 
 Replace this sentence inside the `android-kotlin` paragraph:

--- a/docs/superpowers/specs/2026-08-24-compose-text-unit-design.md
+++ b/docs/superpowers/specs/2026-08-24-compose-text-unit-design.md
@@ -115,16 +115,26 @@ gives it an override.
 | Reference-graph inference (`text.5xl` is referenced by a `fontSize`, so it is one) | The only option that reaches all 52. Rejected for now: aliases are resolved in place by this module's own preprocessor before Style Dictionary sees them, so the graph must be captured separately, and a token referenced by two different roles has no defined answer. Recorded as the option to revisit if §6.1 proves painful. |
 | A new `nativePlatform({ textUnits: [...] })` parameter | New public API surface for a need no consumer has stated. §5.3 gets the same override for free. |
 
-## 4. Where classification runs: before the hoist
+## 4. Where classification runs: between resolution and the hoist
 
-`preprocess` already does two things in order — `resolveInPlace`, then
-`hoistDualNodes`. Classification is inserted **before the hoist**.
+`preprocess` does two things in order — `resolveInPlace`, then
+`hoistDualNodes`. Classification is inserted **between them**: after aliases
+resolve, before children are renamed. Both halves are load-bearing, and
+neither is a stylistic choice.
 
-This is not a stylistic choice. `hoistDualNodes` renames
-`text.xs.lineHeight` to `text.xsLineHeight`; the leaf name is consumed by the
-rename. Measured: of the 39 tokens this change fixes, **13 are hoisted
-children**, so classifying after the hoist would silently miss a third of
-them.
+**After `resolveInPlace`, because the unit is not in the authored text.** All
+26 semantic tokens this change fixes are authored as references —
+`typography.textStyle.h1.fontSize` is `"{text.3xl}"` in the source, carrying
+no unit at all. A rule that reads the *authored* string finds no `px`, stamps
+nothing, and fixes 13 tokens instead of 39. Classification therefore reads the
+token's `$value` **as it stands after resolution**, when the reference has
+already become `30px`. The word "authored" must not appear in the rule; it
+names the wrong string.
+
+**Before `hoistDualNodes`, because the hoist consumes the leaf name.** It
+renames `text.xs.lineHeight` to `text.xsLineHeight`. Measured: of the 39
+tokens this change fixes, **13 are hoisted children**, so classifying after
+the hoist would silently miss a third of them.
 
 Matching a suffix against the hoisted camelCase name (`…LineHeight`) was
 considered and rejected: it couples the role rule to the hoist's naming
@@ -142,6 +152,9 @@ Verified by direct probe against Style Dictionary 4.4.0: a token carrying
 FILTER a | $ext: {"com.throughline.native":{"unit":"text"}} | keys: $type,$value,$extensions
 FILTER b | $ext: undefined                                 | keys: $type,$value
 ```
+
+(The probe predates §5.2's naming decision and exercises Style Dictionary's
+behaviour, not the key name. The names this spec adopts are in §5.2.)
 
 A `WeakSet` — the mechanism #55 used to carry `WAS_REF` — is **not** an option
 here. It works inside `preprocess` because the marking and the reading happen
@@ -194,14 +207,24 @@ Documented as a known limit. Filed as a follow-up, not guessed at.
 
 ### 6.2 The 13 `letterSpacing` tokens stay dropped
 
-They resolve to `em` values (`-0.03em`), and `nativeFilter`'s `WEB_ONLY_UNIT`
-removes them before any transform runs — so they appear in neither the Kotlin
-nor the Swift output today. Compose has a real `.em` `TextUnit`, so this is a
-genuine gap, but it is a *filter* gap, not a dp/sp gap. Different fix, filed
-separately.
+They resolve to `em` values (`-0.03em`). `nativeFilter`'s `WEB_ONLY_UNIT`
+removes them, so they appear in neither the Kotlin nor the Swift output today.
+Compose has a real `.em` `TextUnit`, so this is a genuine gap — but it is a
+*filter* gap, not a dp/sp gap. Different fix, filed separately.
 
-They are still classified by §3.2 — the stamp is cheap and correct — and simply
-never reach a transform. If §6.2 is fixed later, the role is already there.
+Two precise points, because an earlier draft of this spec got both wrong:
+
+- **`nativeFilter` is the file filter, not a transform filter.** Style
+  Dictionary applies it at *format* time, after every transform has run. So
+  these tokens do reach the size transforms today. Nothing breaks, but only
+  because `magnitude('-0.03em')` returns null and `hasMagnitude` gates both
+  transforms — which is the same guard finding 1 of the spec review requires
+  on the sp filter (§7).
+- **They are NOT stamped.** §7's absolute-unit gate admits `px` and `rem`
+  only, and `em` is neither. The role is therefore *not* pre-recorded for a
+  later fix. Whoever fixes the `em` gap must revisit §7's unit gate in the
+  same change; the two are coupled, and this spec does not leave a
+  half-finished hook behind pretending otherwise.
 
 ### 6.3 The 5 `leading.*` unitless ratios stay `.dp`
 
@@ -222,14 +245,56 @@ one, which is precisely the failure class this module exists to prevent.
 
 The rule, in full:
 
-> During `preprocess`, before hoisting: a token whose `$type` is `dimension`,
-> whose leaf name is `fontSize`, `letterSpacing`, or `lineHeight`, and whose
-> authored `$value` carries an absolute unit (`px` or `rem`), is stamped
-> `$extensions["com.radicool.throughline"].nativeUnit = "text"` — unless that
-> key is already set, in which case the source's value stands.
+> **Classification** — in `preprocess`, after `resolveInPlace` and before
+> `hoistDualNodes`. A token is stamped
+> `$extensions["com.radicool.throughline"].nativeUnit = "text"` when all four
+> hold:
 >
-> `size/unit-aware/compose-sp` filters on `nativeUnit === "text"`.
-> `size/unit-aware/compose-dp` filters `dimension` **and not** `nativeUnit === "text"`.
+> 1. its own `$type` key is `"dimension"` (see the limit below);
+> 2. its leaf name is exactly `fontSize`, `letterSpacing`, or `lineHeight`;
+> 3. its **resolved** `$value` — the string as it stands at this point in
+>    `preprocess`, not the authored text — carries an absolute unit, `px` or
+>    `rem`;
+> 4. the key is not already set, in which case the source's value stands
+>    untouched (§5.3).
+>
+> **Transforms.**
+>
+> - `size/unit-aware/compose-sp` filters
+>   `(isTextUnit(token) || isFontSize(token)) && hasMagnitude(token)`.
+> - `size/unit-aware/compose-dp` filters
+>   `isDimension(token) && !isTextUnit(token) && hasMagnitude(token)`.
+
+**`hasMagnitude` on the sp filter is load-bearing, not defensive.** Both
+existing size transforms carry it. Without it, a source that uses §5.3's
+override to stamp a token with no build-time magnitude reaches
+`authored(token).toFixed(2)` with `authored()` returning null — a bare
+`TypeError` mid-build rather than a clean skip.
+
+**`$type === 'fontSize'` is kept alongside the stamp.** Style Dictionary's own
+convention still works, `size/unit-aware/swift` already matches stock by
+filtering `dimension || fontSize`, and keeping it makes this change purely
+additive: no source that builds today builds differently unless it has a
+dimension token named for a DTCG typography member.
+
+**The two filters are disjoint by construction**, so no token is transformed
+twice and none falls through the partition. Transitive re-runs are harmless
+regardless, because `authored()` reads `original.$value` rather than the
+running value.
+
+**Stated limit — the `$type` check reads the token's own key.** A typeless
+child that would inherit `dimension` from its parent is not classified,
+because `hoistDualNodes` copies the parent's `$type` down *after*
+classification has run. §4 puts classification before the hoist for an
+unrelated and stronger reason — the leaf name — and this limit is the price of
+that ordering. zygarden's dual-node children all carry their own `$type`, so
+the §7.1 prediction is unaffected. This is the same class of limit as §3.2's naming
+caveat: narrow, real, and documented rather than papered over.
+
+**The override is trusted but guarded.** Requirement 1 applies to
+*classification* only. A source that sets `nativeUnit` itself is making a
+deliberate declaration and is not required to be `dimension`-typed —
+`hasMagnitude` is what keeps that safe.
 
 `ios-swift` is unchanged. `size/unit-aware/swift` filters `dimension ||
 fontSize` and emits `CGFloat` for both; iOS handles Dynamic Type at the use

--- a/docs/superpowers/specs/2026-08-24-compose-text-unit-design.md
+++ b/docs/superpowers/specs/2026-08-24-compose-text-unit-design.md
@@ -1,0 +1,296 @@
+# Compose text units — design
+
+**Issue:** [#51](https://github.com/jrpease/throughline/issues/51) — Compose
+sp/dp split never fires on spec-compliant DTCG
+**Date:** 2026-08-24
+**Base branch:** `fix/55-hoist-dual-nodes` (PR #59), not `main` — see §8
+
+## 1. The measured problem
+
+Built zygarden's real DTCG source through the live module (Style Dictionary
+4.4.0, scratch harness, `libs/shared/util-tokens/src/tokens`, light + mobile
+axes, 214 `$value` entries):
+
+| | |
+|---|---|
+| Kotlin declarations emitted | 195 |
+| Containing `.sp` | **0** |
+| Dimension-typed source tokens | 106 |
+| Of those, typographic by role | 52 |
+
+`size/unit-aware/compose-sp` filters `$type === 'fontSize'`. DTCG defines no
+`fontSize` type, so the branch is unreachable and every dimension falls through
+to `size/unit-aware/compose-dp`.
+
+## 2. Two corrections to the issue's own text
+
+Both verified, both change what this spec must do.
+
+**2.1 The severity mechanism stated in #51 is wrong.** The issue says this is
+"an accessibility regression that compiles, renders, and looks correct to a
+sighted developer." It does not compile. From the androidx source
+(`compose/ui/ui-text/src/commonMain/kotlin/androidx/compose/ui/text/TextStyle.kt`),
+every `TextStyle` constructor overload declares:
+
+```kotlin
+fontSize: TextUnit = TextUnit.Unspecified,
+letterSpacing: TextUnit = TextUnit.Unspecified,
+lineHeight: TextUnit = TextUnit.Unspecified,
+```
+
+`Dp` and `TextUnit` are distinct value classes with no implicit conversion and
+no `Dp` overload. `fontSize = Tokens.typographyTextStyleH1FontSize` is a
+compile error.
+
+The bug is still real and still an accessibility bug, but it arrives one step
+later: the developer hits the compile error and repairs it. The idiomatic-
+looking repair is `Dp.toSp()`, which divides by `fontScale` and therefore
+renders at exactly the authored dp size no matter what the user set. That
+compiles, renders, and looks correct — the claim #51 makes about the output is
+true of the workaround instead.
+
+This matters for scope, not just for accuracy: because the failure is a
+use-site type error, a *partial* fix is worth much less than it looks. A
+`TextStyle` needs all of its text-unit members to be `TextUnit` before it
+compiles at all.
+
+**2.2 The problem is three roles, not one.** `fontSize` is the smallest of the
+three groups.
+
+| Role | Source tokens | Emitted today |
+|---|---|---|
+| `lineHeight` | 26 | `.dp` |
+| `fontSize` | 13 | `.dp` |
+| `letterSpacing` | 13 | dropped before transforms (§6.2) |
+
+## 3. The identification rule
+
+### 3.1 Why `$type` cannot carry this
+
+DTCG's type set is `color`, `dimension`, `fontFamily`, `fontWeight`,
+`duration`, `cubicBezier`, `number`, `strokeStyle`, `border`, `transition`,
+`shadow`, `gradient`, `typography`. There is no `fontSize`. Font sizes are
+`dimension`, which is also what spacing, radius, and stroke widths are. No
+amount of `$type` inspection separates them. The fix must source the role from
+somewhere else.
+
+### 3.2 The signal: DTCG §9.8's own member names
+
+The Format Module 2025.10 draft (30 July 2026), §9.8, specifies the typography
+composite at MUST level:
+
+> The `$type` property MUST be set to the string `typography`. The value MUST
+> be an object with the following properties:
+>
+> - **fontFamily**: … MUST be a valid font family value or a reference to a
+>   font family token.
+> - **fontSize**: … MUST be a valid dimension value or a reference to a
+>   dimension token.
+> - **fontWeight**: … MUST be a valid font weight or a reference to a font
+>   weight token.
+> - **letterSpacing**: The horizontal spacing between characters. … MUST be a
+>   valid dimension value or a reference to a dimension token.
+> - **lineHeight**: The vertical spacing between lines of typography. … MUST
+>   be a valid number value or a reference to a number token. The number
+>   SHOULD be interpreted as a multiplier of the fontSize.
+
+So `fontSize`, `letterSpacing`, and `lineHeight` are **the specification's own
+names** for these roles. Matching on them is not a heuristic this project
+invented; it is reading DTCG's vocabulary.
+
+**State the limit honestly.** The spec puts those names inside a composite
+token's `$value` object. zygarden — and every Figma-derived source of this
+shape — puts them as sibling *token* names inside a group. Recognising them
+there is a convention that mirrors the spec, not a guarantee the spec makes.
+A source naming its font size `typography.body.size` is not covered, and §7
+gives it an override.
+
+### 3.3 Rejected alternatives
+
+| Alternative | Why not |
+|---|---|
+| Require `$type: "fontSize"` in the source | Style Dictionary's pre-DTCG convention. Asking sources to be non-conformant to fix a conformant-source bug inverts the problem. |
+| Detect the real DTCG `typography` composite | Correct where it applies and needs no convention — but zero occurrences in the real source, and Style Dictionary does not expand composite `$value` objects into member tokens. Fixes nothing measurable today. |
+| Sibling-anchored: a `dimension` in a group that also holds a `fontFamily`-typed token | Genuinely structural. Covers the same 39 tokens and no more, at higher complexity, and breaks on a group holding only sizes. No coverage gain for the cost. |
+| Reference-graph inference (`text.5xl` is referenced by a `fontSize`, so it is one) | The only option that reaches all 52. Rejected for now: aliases are resolved in place by this module's own preprocessor before Style Dictionary sees them, so the graph must be captured separately, and a token referenced by two different roles has no defined answer. Recorded as the option to revisit if §6.1 proves painful. |
+| A new `nativePlatform({ textUnits: [...] })` parameter | New public API surface for a need no consumer has stated. §5.3 gets the same override for free. |
+
+## 4. Where classification runs: before the hoist
+
+`preprocess` already does two things in order — `resolveInPlace`, then
+`hoistDualNodes`. Classification is inserted **before the hoist**.
+
+This is not a stylistic choice. `hoistDualNodes` renames
+`text.xs.lineHeight` to `text.xsLineHeight`; the leaf name is consumed by the
+rename. Measured: of the 39 tokens this change fixes, **13 are hoisted
+children**, so classifying after the hoist would silently miss a third of
+them.
+
+Matching a suffix against the hoisted camelCase name (`…LineHeight`) was
+considered and rejected: it couples the role rule to the hoist's naming
+scheme, and a case-insensitive form false-positives on names like
+`baselineHeight`.
+
+## 5. The carrier: `$extensions`
+
+### 5.1 It survives to transform time
+
+Verified by direct probe against Style Dictionary 4.4.0: a token carrying
+`$extensions` reaches a transform's `filter` with the object intact.
+
+```
+FILTER a | $ext: {"com.throughline.native":{"unit":"text"}} | keys: $type,$value,$extensions
+FILTER b | $ext: undefined                                 | keys: $type,$value
+```
+
+A `WeakSet` — the mechanism #55 used to carry `WAS_REF` — is **not** an option
+here. It works inside `preprocess` because the marking and the reading happen
+in the same tick on the same objects. A transform filter runs after Style
+Dictionary has ingested the tree, and the membership does not survive.
+
+### 5.2 Why `$extensions` rather than a plain property
+
+`$extensions` is DTCG's sanctioned place for tool-specific metadata, so the
+stamp is legal in the tree rather than a private prop riding along. A plain
+property would work mechanically; this one is also *addressable by a source*,
+which §5.3 depends on.
+
+Namespace: `com.radicool.throughline` (package is `@radicool/throughline`).
+Shape:
+
+```json
+"$extensions": { "com.radicool.throughline": { "nativeUnit": "text" } }
+```
+
+### 5.3 The override is free
+
+Classification **must not overwrite an existing
+`$extensions["com.radicool.throughline"].nativeUnit`.** A source that names its
+font size something else declares the role itself and is honoured, with no new
+configuration parameter and no new code path — just an assignment that declines
+when the key is already set. `"device"` is the explicit opt-out for a
+`lineHeight`-named token that really is a `Dp`.
+
+## 6. Scope boundaries
+
+Three neighbouring defects are deliberately left alone.
+
+### 6.1 The 13 `text.*` scale primitives stay `.dp`
+
+`text.base = 16px`, `text.3xl = 30px` — the ramp the semantic tokens reference.
+No signal identifies these as typographic: not nominal, not structural. A
+`text.*` prefix rule would catch them here and misfire on a source using
+`text.*` for copy strings, and it has no spec backing whatsoever.
+
+The mitigating fact is that every semantic token that references them **is**
+fixed, so the tokens a consumer should reach for are correct:
+
+```kotlin
+val textBase = 16.00.dp                             // raw scale, role unknown
+val typographyTextStyleBodyLgFontSize = 16.00.sp    // use this
+```
+
+Documented as a known limit. Filed as a follow-up, not guessed at.
+
+### 6.2 The 13 `letterSpacing` tokens stay dropped
+
+They resolve to `em` values (`-0.03em`), and `nativeFilter`'s `WEB_ONLY_UNIT`
+removes them before any transform runs — so they appear in neither the Kotlin
+nor the Swift output today. Compose has a real `.em` `TextUnit`, so this is a
+genuine gap, but it is a *filter* gap, not a dp/sp gap. Different fix, filed
+separately.
+
+They are still classified by §3.2 — the stamp is cheap and correct — and simply
+never reach a transform. If §6.2 is fixed later, the role is already there.
+
+### 6.3 The 5 `leading.*` unitless ratios stay `.dp`
+
+`leading.normal: "1.5"` typed `dimension` emits `1.50.dp`. This is the sibling
+defect #51 cross-references and `references/native-adapter-config.md` §4
+already documents. Not touched.
+
+**It does, however, constrain this design.** `magnitude()` accepts a bare
+number as a ratio, so a token *named* `lineHeight` and *valued* `"1.5"` would
+be stamped and emit `1.50.sp` — which compiles and renders 1.5sp text. That
+converts a loud failure (a `Dp` where a `TextUnit` is required) into a silent
+one, which is precisely the failure class this module exists to prevent.
+
+**Therefore: stamp only when the authored value carries an absolute unit**
+(`px` or `rem`). A bare number is not classified and keeps today's behaviour.
+
+## 7. Behaviour change
+
+The rule, in full:
+
+> During `preprocess`, before hoisting: a token whose `$type` is `dimension`,
+> whose leaf name is `fontSize`, `letterSpacing`, or `lineHeight`, and whose
+> authored `$value` carries an absolute unit (`px` or `rem`), is stamped
+> `$extensions["com.radicool.throughline"].nativeUnit = "text"` — unless that
+> key is already set, in which case the source's value stands.
+>
+> `size/unit-aware/compose-sp` filters on `nativeUnit === "text"`.
+> `size/unit-aware/compose-dp` filters `dimension` **and not** `nativeUnit === "text"`.
+
+`ios-swift` is unchanged. `size/unit-aware/swift` filters `dimension ||
+fontSize` and emits `CGFloat` for both; iOS handles Dynamic Type at the use
+site via `UIFontMetrics`, not in the token file. Measured: the Swift output is
+already correct.
+
+### 7.1 Falsifiable prediction
+
+Against the zygarden light+mobile build:
+
+- **Exactly 39 Kotlin declarations flip `.dp` → `.sp`**
+  (13 `typography.textStyle.*.fontSize`, 13 `typography.textStyle.*.lineHeight`,
+  13 hoisted `text.*LineHeight`).
+- **The other 156 are byte-identical.**
+- **The declaration count stays 195.**
+- **`Tokens.swift` is byte-identical.**
+
+Verified by building at base and at HEAD into separate directories and running
+`diff -r` — not by counting declarations, which cannot see compensating
+changes.
+
+## 8. Constraints
+
+- **Zero dependencies.** `scripts/lib/` is installed into consumer repos.
+  Style Dictionary stays a parameter, never an import.
+- **Branch off `fix/55-hoist-dual-nodes`, not `main`.**
+  `references/native-adapter-config.md` is generated from the *whole body* of
+  `scripts/lib/sd-native.mjs`, so two branches off `main` that both touch it
+  conflict guaranteed.
+- **Every code line must sit inside an `@doc-section` / `@doc-section-end`
+  pair.** Only blank lines and `//` comments may sit outside one; the generator
+  throws otherwise and `--check` gates it in CI.
+- **Regenerate the reference doc at the end of every task**, not once at the
+  end. A freshness test goes red the moment the module changes, and a suite
+  with a known failure is one a real regression hides behind.
+- **`preprocess` must stay structurally idempotent.** `deepEqual(preprocess(preprocess(x)), preprocess(x))`
+  is an existing test. Stamping is idempotent by construction; the second pass
+  finds the key already set and declines.
+- **Six gates must stay green:** `node --test`, `ci/validate-plugin.mjs`,
+  `ci/validate-skills.mjs`, `scripts/adapters/generate.mjs --check`,
+  `scripts/build-doc-card-builder.mjs --check`,
+  `scripts/build-native-adapter-config.mjs --check`.
+
+## 9. Documentation to update
+
+- `scripts/lib/sd-native.mjs` — the `@doc-section platform` comment block
+  currently describes the sp branch as unreachable. It becomes a description of
+  the rule plus the §6 limits.
+- `references/native-adapter-config.md` §4 — generated; regenerating covers it.
+  The "Font sizes emit as `dp`, not `sp`" bullet must go, replaced by the
+  narrower `text.*` and `letterSpacing` limits.
+- `references/sync-adapters.md` — states `android-kotlin` stays Tier 2 and
+  cites this defect as the concrete reason. The citation must be corrected.
+  **The tier does not change**: §6.3's unitless ratio remains, and the stated
+  Tier 2 reason is consumption-side unknowns that building tokens does not
+  exercise.
+- `CHANGELOG.md` — `[Unreleased]`.
+
+## 10. Follow-ups to file
+
+1. `text.*` scale primitives have no role signal (§6.1) — reference-graph
+   inference is the candidate.
+2. `em`-valued `letterSpacing` is dropped rather than emitted as Compose `.em`
+   (§6.2).

--- a/docs/superpowers/specs/2026-08-24-compose-text-unit-design.md
+++ b/docs/superpowers/specs/2026-08-24-compose-text-unit-design.md
@@ -291,10 +291,17 @@ that ordering. zygarden's dual-node children all carry their own `$type`, so
 the §7.1 prediction is unaffected. This is the same class of limit as §3.2's naming
 caveat: narrow, real, and documented rather than papered over.
 
-**The override is trusted but guarded.** Requirement 1 applies to
+**The override is trusted, and only partly guarded.** Requirement 1 applies to
 *classification* only. A source that sets `nativeUnit` itself is making a
-deliberate declaration and is not required to be `dimension`-typed —
-`hasMagnitude` is what keeps that safe.
+deliberate declaration and is not required to be `dimension`-typed.
+`hasMagnitude` stops the crash — a value with no build-time magnitude is
+skipped rather than reaching `.toFixed(2)` on null — but it does **not** stop a
+bad unit: an override on `{ $type: "number", $value: "1.5" }` passes
+`hasMagnitude` and emits `1.50.sp`, the exact silent render §6.3's
+absolute-unit gate exists to prevent. That is accepted: the override is an
+explicit declaration by the source, and a tool that second-guesses an explicit
+declaration has no override at all. Stated here so the guard is not read as
+broader than it is.
 
 `ios-swift` is unchanged. `size/unit-aware/swift` filters `dimension ||
 fontSize` and emits `CGFloat` for both; iOS handles Dynamic Type at the use

--- a/references/native-adapter-config.md
+++ b/references/native-adapter-config.md
@@ -254,8 +254,14 @@ function hoistDualNodes(node, collisions, prefix = []) {
 //
 // The role therefore comes from the one place a DTCG source states it: the
 // member names the Format Module's 30 July 2026 draft, §9.8, fixes at MUST
-// level for the typography composite. Three of the five are dimension-valued,
-// and Compose's TextStyle takes TextUnit for all three with no Dp overload.
+// level for the typography composite. Two of the five are dimension-valued:
+// fontSize and letterSpacing. §9.8 types lineHeight as a NUMBER multiplier, so
+// a source following the spec exactly emits no dimension-typed lineHeight and
+// this rule never fires on one. Figma-derived sources — what this module
+// targets — emit px line heights typed dimension, and those are the majority of
+// the tokens the rule fixes on a real source. lineHeight is named here anyway
+// because Compose's TextStyle takes TextUnit for all three, with no Dp
+// overload, so a px line height must reach the sp branch to be usable at all.
 //
 // The limit, stated rather than hidden: §9.8 puts those names inside a
 // composite token's $value object, while Figma-derived sources put them as
@@ -347,24 +353,34 @@ Build the transform list from Style Dictionary's **stock group**, replacing only
 the rem-assuming size transforms. A hand-picked list silently drops whatever it
 forgets — three real defects arose exactly that way.
 
-**Two Android-only unit limitations remain, and are not fixed here.** Style
-Dictionary's Compose transforms select on `$type`, and DTCG's type set does not
-line up with what they expect:
+**The `dp`/`sp` split is fixed here; three narrower Android-only limits remain.**
+Style Dictionary's Compose transforms select on `$type`, and DTCG's type set
+does not line up with what they expect — there is no `fontSize` type, because
+DTCG types font sizes as `dimension`. So the role is taken instead from the
+member names DTCG §9.8 fixes for the typography composite, stamped onto
+`$extensions` during preprocessing, and the two Compose transforms partition on
+that stamp. Measured against a real source: 39 declarations that emitted `dp`
+now emit `sp`, with the Swift output byte-identical.
 
-- **Font sizes emit as `dp`, not `sp`.** DTCG has no `fontSize` type — it types
-  font sizes as `dimension` — while `size/unit-aware/compose-sp` filters on
-  `$type === "fontSize"`. On spec-compliant input it never fires and every font
-  size falls through to `dp`, which does not respect the user's font-scale
-  accessibility setting. Measured on a real 322-token source: zero `.sp` in the
-  Kotlin output.
+What remains:
+
+- **A bare scale primitive emits as `dp`.** `text.base: "16px"` is a font size
+  only to a human — no nominal or structural signal marks it — so it is not
+  stamped. The semantic tokens that reference it are, and those are what a
+  consumer should reach for.
+- **An `em`-valued `letterSpacing` is dropped from native output entirely**
+  rather than emitted as Compose's `.em` TextUnit. A filter gap, not a
+  `dp`/`sp` gap.
 - **A unitless ratio emits as `dp`.** `leading.normal: "1.5"`, typed
   `dimension`, emits `1.50.dp`. The magnitude is faithful; the unit is
-  semantically wrong.
+  semantically wrong. It is deliberately not stamped — `1.50.sp` would compile
+  and render 1.5sp text, turning a loud failure into a silent one.
 
-Both are Android-only. `size/unit-aware/swift` filters `dimension || fontSize`,
-so iOS handles dimension-typed font sizes correctly, and `CGFloat(1.50)` carries
-no unit to be wrong about. `tokens:validate-output` passes in both cases: it
-checks magnitude, not unit.
+All three are Android-only. `size/unit-aware/swift` filters
+`dimension || fontSize` and emits `CGFloat`, which carries no unit to be wrong
+about; iOS handles Dynamic Type at the use site via `UIFontMetrics`.
+`tokens:validate-output` passes in all three cases: it checks magnitude, not
+unit.
 
 ```js
 // Build each platform's transform list from Style Dictionary's STOCK group,
@@ -641,9 +657,12 @@ export function registerNativeTransforms(StyleDictionary) {
     transform: (token) => `CGFloat(${authored(token).toFixed(2)})`,
   });
 
-  // Compose distinguishes dp from sp by $type, and sp is what respects the
-  // user's font-scale accessibility setting. One .dp transform for both would
-  // silently defeat that.
+  // sp is what respects the user's font-scale accessibility setting, and
+  // Compose's TextStyle takes TextUnit — not Dp — for fontSize, lineHeight and
+  // letterSpacing, so a Dp there does not even compile at the use site. One .dp
+  // transform for both would silently defeat the first and loudly break the
+  // second. The split is driven by the role classifyTextUnits stamped, plus
+  // Style Dictionary's own $type: fontSize convention for sources that use it.
   StyleDictionary.registerTransform({
     name: 'size/unit-aware/compose-dp',
     type: 'value',

--- a/references/native-adapter-config.md
+++ b/references/native-adapter-config.md
@@ -384,9 +384,12 @@ checks magnitude, not unit.
 //     correct, and those are what a consumer should reach for.
 //   - An em-valued letterSpacing is filtered out of native output entirely,
 //     rather than emitted as Compose's .em TextUnit.
-//   - A unitless ratio (leading.normal: "1.5") emits as 1.50.dp. It is
-//     deliberately NOT stamped: 1.50.sp would compile and render 1.5sp text,
-//     turning a loud failure into a silent one.
+//   - A unitless ratio emits as dp. leading.normal: "1.5" gives 1.50.dp, but
+//     that token is excluded twice over — its key is not a typography member
+//     AND its value has no absolute unit. The gate that carries the weight is
+//     the second one: a lineHeight-keyed "1.5" is deliberately NOT stamped,
+//     because 1.50.sp would compile and render 1.5sp text, turning a loud
+//     failure into a silent one.
 //
 // Stock, from SD 4.4.0:
 //   ios-swift: attribute/cti name/camel color/UIColorSwift

--- a/references/native-adapter-config.md
+++ b/references/native-adapter-config.md
@@ -373,14 +373,20 @@ checks magnitude, not unit.
 // whatever it forgets; three real defects arose that way, including Compose
 // font sizes rendered in dp instead of sp.
 //
-// That last one is only half fixed, and the half that remains is load-bearing:
-// the sp transform below gates on $type === 'fontSize', but DTCG has no
-// fontSize type — it types font sizes as dimension — so on a spec-compliant
-// source the sp branch never fires and Android font sizes still emit as dp.
-// Android-only; size/unit-aware/swift filters dimension || fontSize and is
-// correct. Same class as a unitless ratio (leading.normal: "1.5") emitting as
-// 1.50.dp. Both are measured, not theoretical — see
-// docs/superpowers/notes/2026-08-21-native-config-e2e-results.md.
+// That last one is fixed for tokens whose role a DTCG source actually states:
+// classifyTextUnits stamps fontSize, letterSpacing and lineHeight members, and
+// the sp transform gates on the stamp rather than on a $type DTCG never emits.
+// Three limits remain, all Android-only and all measured rather than
+// theoretical — see docs/superpowers/notes/2026-08-21-native-config-e2e-results.md:
+//
+//   - A scale primitive carries no role. text.base: "16px" is a font size only
+//     to a human, so it emits as dp. The semantic tokens referencing it are
+//     correct, and those are what a consumer should reach for.
+//   - An em-valued letterSpacing is filtered out of native output entirely,
+//     rather than emitted as Compose's .em TextUnit.
+//   - A unitless ratio (leading.normal: "1.5") emits as 1.50.dp. It is
+//     deliberately NOT stamped: 1.50.sp would compile and render 1.5sp text,
+//     turning a loud failure into a silent one.
 //
 // Stock, from SD 4.4.0:
 //   ios-swift: attribute/cti name/camel color/UIColorSwift
@@ -573,6 +579,8 @@ const authored = (token) => magnitude(token.original?.$value ?? token.$value);
 const isDimension = (token) => token.$type === 'dimension';
 const isFontSize = (token) => token.$type === 'fontSize';
 const hasMagnitude = (token) => authored(token) !== null;
+// The role preprocess stamped. $type cannot carry it — see classifyTextUnits.
+const isTextUnit = (token) => token.$extensions?.[EXT_NS]?.nativeUnit === 'text';
 
 // Quote string-valued tokens no stock transform covers.
 //
@@ -637,7 +645,7 @@ export function registerNativeTransforms(StyleDictionary) {
     name: 'size/unit-aware/compose-dp',
     type: 'value',
     transitive: true,
-    filter: (token) => isDimension(token) && hasMagnitude(token),
+    filter: (token) => isDimension(token) && !isTextUnit(token) && hasMagnitude(token),
     transform: (token) => `${authored(token).toFixed(2)}.dp`,
   });
 
@@ -645,7 +653,7 @@ export function registerNativeTransforms(StyleDictionary) {
     name: 'size/unit-aware/compose-sp',
     type: 'value',
     transitive: true,
-    filter: (token) => isFontSize(token) && hasMagnitude(token),
+    filter: (token) => (isTextUnit(token) || isFontSize(token)) && hasMagnitude(token),
     transform: (token) => `${authored(token).toFixed(2)}.sp`,
   });
 

--- a/references/native-adapter-config.md
+++ b/references/native-adapter-config.md
@@ -245,10 +245,75 @@ function hoistDualNodes(node, collisions, prefix = []) {
   return node;
 }
 
+// Which native unit a dimension belongs in: Compose's Dp, or its TextUnit.
+//
+// $type cannot answer this. DTCG's type set has no fontSize — font sizes are
+// dimension, and so are spacing, radius and stroke widths — so the stock
+// size/compose/remToSp filter on $type === 'fontSize' never fires on a
+// spec-compliant source and every font size falls through to dp.
+//
+// The role therefore comes from the one place a DTCG source states it: the
+// member names the Format Module's 30 July 2026 draft, §9.8, fixes at MUST
+// level for the typography composite. Three of the five are dimension-valued,
+// and Compose's TextStyle takes TextUnit for all three with no Dp overload.
+//
+// The limit, stated rather than hidden: §9.8 puts those names inside a
+// composite token's $value object, while Figma-derived sources put them as
+// sibling tokens in a group. Reading them there mirrors the spec's vocabulary;
+// it is not a guarantee the spec makes. A source naming its font size
+// typography.body.size sets $extensions itself and is honoured below.
+const TEXT_UNIT_NAMES = new Set(['fontSize', 'letterSpacing', 'lineHeight']);
+
+// Reverse-DNS, per DTCG's $extensions convention. Exported because the
+// transforms and their tests address the same key.
+export const EXT_NS = 'com.radicool.throughline';
+
+// px and rem only. magnitude() reads a bare number as an unscaled ratio, so a
+// lineHeight authored "1.5" would otherwise be stamped and emit 1.50.sp —
+// which compiles and renders 1.5sp text. That trades a loud failure (a Dp
+// where a TextUnit is required) for a silent one, which is the failure class
+// this module exists to prevent. A ratio keeps today's behaviour and stays the
+// separate defect it already is.
+const ABSOLUTE_UNIT = /^-?(?:\d+(?:\.\d+)?|\.\d+)(?:px|rem)$/;
+
+// Runs AFTER resolveInPlace and BEFORE hoistDualNodes. Both halves matter.
+//
+// After resolution, because the unit is not in the authored text: a semantic
+// font size is authored "{text.3xl}" and carries no unit at all. Reading the
+// authored string would classify only the px-authored primitives — 13 of 39
+// on a real source.
+//
+// Before the hoist, because the hoist consumes the leaf name:
+// text.xs.lineHeight becomes text.xsLineHeight, and the name this rule matches
+// on is gone. Matching a suffix against the camel-joined name instead would
+// couple the rule to the hoist's naming scheme, and case-insensitively it
+// false-positives on names like baselineHeight.
+function classifyTextUnits(node) {
+  for (const [key, val] of Object.entries(node)) {
+    if (key.startsWith('$') || !val || typeof val !== 'object') continue;
+    if (
+      TEXT_UNIT_NAMES.has(key) &&
+      '$value' in val &&
+      val.$type === 'dimension' &&
+      ABSOLUTE_UNIT.test(String(val.$value).trim())
+    ) {
+      val.$extensions ??= {};
+      val.$extensions[EXT_NS] ??= {};
+      const ns = val.$extensions[EXT_NS];
+      // A source that states the role itself wins. This is the override, and
+      // it costs no configuration parameter: declining to overwrite IS the
+      // feature. It is also what makes the pass idempotent.
+      if (!('nativeUnit' in ns)) ns.nativeUnit = 'text';
+    }
+    classifyTextUnits(val);
+  }
+  return node;
+}
+
 export function preprocess(dict) {
   const collisions = [];
   const out = hoistDualNodes(
-    resolveInPlace(structuredClone(dict), flattenDtcg(dict)),
+    classifyTextUnits(resolveInPlace(structuredClone(dict), flattenDtcg(dict))),
     collisions,
   );
   if (collisions.length) {

--- a/references/sync-adapters.md
+++ b/references/sync-adapters.md
@@ -73,10 +73,13 @@ not hidden.
 `android-kotlin` uses the same module and stays Tier 2: its remaining unknowns
 are on the consumption side — Compose `dp`/`sp` behaviour against a real Compose
 app, resource-qualifier conventions, package layout — which building tokens does
-not exercise. Concretely, DTCG has no `fontSize` type — it types font sizes as
-`dimension` — and the `sp` transform gates on `$type === 'fontSize'`, so on
-spec-compliant input Android font sizes currently emit as `dp`, not `sp`; the
-Swift transform filters `dimension || fontSize` and is unaffected.
+not exercise. The `dp`/`sp` split itself is no longer among them: font sizes and
+line heights whose role a DTCG source states — the `fontSize`, `letterSpacing`
+and `lineHeight` member names of §9.8's typography composite — now emit as
+`sp`. What remains is narrower and documented in
+`${CLAUDE_PLUGIN_ROOT}/references/native-adapter-config.md`: a bare scale
+primitive carries no role and stays `dp`, an `em` letterSpacing is filtered
+out rather than emitted as `.em`, and a unitless ratio still emits as `dp`.
 `tokens:validate-output` remains what decides whether any adapter can be
 trusted, and re-promotion is available to any adapter that passes it against a
 real source.

--- a/scripts/build-native-adapter-config.mjs
+++ b/scripts/build-native-adapter-config.mjs
@@ -112,24 +112,34 @@ Build the transform list from Style Dictionary's **stock group**, replacing only
 the rem-assuming size transforms. A hand-picked list silently drops whatever it
 forgets — three real defects arose exactly that way.
 
-**Two Android-only unit limitations remain, and are not fixed here.** Style
-Dictionary's Compose transforms select on \`$type\`, and DTCG's type set does not
-line up with what they expect:
+**The \`dp\`/\`sp\` split is fixed here; three narrower Android-only limits remain.**
+Style Dictionary's Compose transforms select on \`$type\`, and DTCG's type set
+does not line up with what they expect — there is no \`fontSize\` type, because
+DTCG types font sizes as \`dimension\`. So the role is taken instead from the
+member names DTCG §9.8 fixes for the typography composite, stamped onto
+\`$extensions\` during preprocessing, and the two Compose transforms partition on
+that stamp. Measured against a real source: 39 declarations that emitted \`dp\`
+now emit \`sp\`, with the Swift output byte-identical.
 
-- **Font sizes emit as \`dp\`, not \`sp\`.** DTCG has no \`fontSize\` type — it types
-  font sizes as \`dimension\` — while \`size/unit-aware/compose-sp\` filters on
-  \`$type === "fontSize"\`. On spec-compliant input it never fires and every font
-  size falls through to \`dp\`, which does not respect the user's font-scale
-  accessibility setting. Measured on a real 322-token source: zero \`.sp\` in the
-  Kotlin output.
+What remains:
+
+- **A bare scale primitive emits as \`dp\`.** \`text.base: "16px"\` is a font size
+  only to a human — no nominal or structural signal marks it — so it is not
+  stamped. The semantic tokens that reference it are, and those are what a
+  consumer should reach for.
+- **An \`em\`-valued \`letterSpacing\` is dropped from native output entirely**
+  rather than emitted as Compose's \`.em\` TextUnit. A filter gap, not a
+  \`dp\`/\`sp\` gap.
 - **A unitless ratio emits as \`dp\`.** \`leading.normal: "1.5"\`, typed
   \`dimension\`, emits \`1.50.dp\`. The magnitude is faithful; the unit is
-  semantically wrong.
+  semantically wrong. It is deliberately not stamped — \`1.50.sp\` would compile
+  and render 1.5sp text, turning a loud failure into a silent one.
 
-Both are Android-only. \`size/unit-aware/swift\` filters \`dimension || fontSize\`,
-so iOS handles dimension-typed font sizes correctly, and \`CGFloat(1.50)\` carries
-no unit to be wrong about. \`tokens:validate-output\` passes in both cases: it
-checks magnitude, not unit.`],
+All three are Android-only. \`size/unit-aware/swift\` filters
+\`dimension || fontSize\` and emits \`CGFloat\`, which carries no unit to be wrong
+about; iOS handles Dynamic Type at the use site via \`UIFontMetrics\`.
+\`tokens:validate-output\` passes in all three cases: it checks magnitude, not
+unit.`],
   ['sources', `## 5. Guard the per-mode source list
 
 Style Dictionary deduplicates by dot-path, so one build over both a light and a

--- a/scripts/lib/sd-native.mjs
+++ b/scripts/lib/sd-native.mjs
@@ -279,14 +279,20 @@ export function preprocess(dict) {
 // whatever it forgets; three real defects arose that way, including Compose
 // font sizes rendered in dp instead of sp.
 //
-// That last one is only half fixed, and the half that remains is load-bearing:
-// the sp transform below gates on $type === 'fontSize', but DTCG has no
-// fontSize type — it types font sizes as dimension — so on a spec-compliant
-// source the sp branch never fires and Android font sizes still emit as dp.
-// Android-only; size/unit-aware/swift filters dimension || fontSize and is
-// correct. Same class as a unitless ratio (leading.normal: "1.5") emitting as
-// 1.50.dp. Both are measured, not theoretical — see
-// docs/superpowers/notes/2026-08-21-native-config-e2e-results.md.
+// That last one is fixed for tokens whose role a DTCG source actually states:
+// classifyTextUnits stamps fontSize, letterSpacing and lineHeight members, and
+// the sp transform gates on the stamp rather than on a $type DTCG never emits.
+// Three limits remain, all Android-only and all measured rather than
+// theoretical — see docs/superpowers/notes/2026-08-21-native-config-e2e-results.md:
+//
+//   - A scale primitive carries no role. text.base: "16px" is a font size only
+//     to a human, so it emits as dp. The semantic tokens referencing it are
+//     correct, and those are what a consumer should reach for.
+//   - An em-valued letterSpacing is filtered out of native output entirely,
+//     rather than emitted as Compose's .em TextUnit.
+//   - A unitless ratio (leading.normal: "1.5") emits as 1.50.dp. It is
+//     deliberately NOT stamped: 1.50.sp would compile and render 1.5sp text,
+//     turning a loud failure into a silent one.
 //
 // Stock, from SD 4.4.0:
 //   ios-swift: attribute/cti name/camel color/UIColorSwift
@@ -466,6 +472,8 @@ const authored = (token) => magnitude(token.original?.$value ?? token.$value);
 const isDimension = (token) => token.$type === 'dimension';
 const isFontSize = (token) => token.$type === 'fontSize';
 const hasMagnitude = (token) => authored(token) !== null;
+// The role preprocess stamped. $type cannot carry it — see classifyTextUnits.
+const isTextUnit = (token) => token.$extensions?.[EXT_NS]?.nativeUnit === 'text';
 
 // Quote string-valued tokens no stock transform covers.
 //
@@ -530,7 +538,7 @@ export function registerNativeTransforms(StyleDictionary) {
     name: 'size/unit-aware/compose-dp',
     type: 'value',
     transitive: true,
-    filter: (token) => isDimension(token) && hasMagnitude(token),
+    filter: (token) => isDimension(token) && !isTextUnit(token) && hasMagnitude(token),
     transform: (token) => `${authored(token).toFixed(2)}.dp`,
   });
 
@@ -538,7 +546,7 @@ export function registerNativeTransforms(StyleDictionary) {
     name: 'size/unit-aware/compose-sp',
     type: 'value',
     transitive: true,
-    filter: (token) => isFontSize(token) && hasMagnitude(token),
+    filter: (token) => (isTextUnit(token) || isFontSize(token)) && hasMagnitude(token),
     transform: (token) => `${authored(token).toFixed(2)}.sp`,
   });
 

--- a/scripts/lib/sd-native.mjs
+++ b/scripts/lib/sd-native.mjs
@@ -185,8 +185,14 @@ function hoistDualNodes(node, collisions, prefix = []) {
 //
 // The role therefore comes from the one place a DTCG source states it: the
 // member names the Format Module's 30 July 2026 draft, §9.8, fixes at MUST
-// level for the typography composite. Three of the five are dimension-valued,
-// and Compose's TextStyle takes TextUnit for all three with no Dp overload.
+// level for the typography composite. Two of the five are dimension-valued:
+// fontSize and letterSpacing. §9.8 types lineHeight as a NUMBER multiplier, so
+// a source following the spec exactly emits no dimension-typed lineHeight and
+// this rule never fires on one. Figma-derived sources — what this module
+// targets — emit px line heights typed dimension, and those are the majority of
+// the tokens the rule fixes on a real source. lineHeight is named here anyway
+// because Compose's TextStyle takes TextUnit for all three, with no Dp
+// overload, so a px line height must reach the sp branch to be usable at all.
 //
 // The limit, stated rather than hidden: §9.8 puts those names inside a
 // composite token's $value object, while Figma-derived sources put them as
@@ -534,9 +540,12 @@ export function registerNativeTransforms(StyleDictionary) {
     transform: (token) => `CGFloat(${authored(token).toFixed(2)})`,
   });
 
-  // Compose distinguishes dp from sp by $type, and sp is what respects the
-  // user's font-scale accessibility setting. One .dp transform for both would
-  // silently defeat that.
+  // sp is what respects the user's font-scale accessibility setting, and
+  // Compose's TextStyle takes TextUnit — not Dp — for fontSize, lineHeight and
+  // letterSpacing, so a Dp there does not even compile at the use site. One .dp
+  // transform for both would silently defeat the first and loudly break the
+  // second. The split is driven by the role classifyTextUnits stamped, plus
+  // Style Dictionary's own $type: fontSize convention for sources that use it.
   StyleDictionary.registerTransform({
     name: 'size/unit-aware/compose-dp',
     type: 'value',

--- a/scripts/lib/sd-native.mjs
+++ b/scripts/lib/sd-native.mjs
@@ -176,10 +176,75 @@ function hoistDualNodes(node, collisions, prefix = []) {
   return node;
 }
 
+// Which native unit a dimension belongs in: Compose's Dp, or its TextUnit.
+//
+// $type cannot answer this. DTCG's type set has no fontSize — font sizes are
+// dimension, and so are spacing, radius and stroke widths — so the stock
+// size/compose/remToSp filter on $type === 'fontSize' never fires on a
+// spec-compliant source and every font size falls through to dp.
+//
+// The role therefore comes from the one place a DTCG source states it: the
+// member names the Format Module's 30 July 2026 draft, §9.8, fixes at MUST
+// level for the typography composite. Three of the five are dimension-valued,
+// and Compose's TextStyle takes TextUnit for all three with no Dp overload.
+//
+// The limit, stated rather than hidden: §9.8 puts those names inside a
+// composite token's $value object, while Figma-derived sources put them as
+// sibling tokens in a group. Reading them there mirrors the spec's vocabulary;
+// it is not a guarantee the spec makes. A source naming its font size
+// typography.body.size sets $extensions itself and is honoured below.
+const TEXT_UNIT_NAMES = new Set(['fontSize', 'letterSpacing', 'lineHeight']);
+
+// Reverse-DNS, per DTCG's $extensions convention. Exported because the
+// transforms and their tests address the same key.
+export const EXT_NS = 'com.radicool.throughline';
+
+// px and rem only. magnitude() reads a bare number as an unscaled ratio, so a
+// lineHeight authored "1.5" would otherwise be stamped and emit 1.50.sp —
+// which compiles and renders 1.5sp text. That trades a loud failure (a Dp
+// where a TextUnit is required) for a silent one, which is the failure class
+// this module exists to prevent. A ratio keeps today's behaviour and stays the
+// separate defect it already is.
+const ABSOLUTE_UNIT = /^-?(?:\d+(?:\.\d+)?|\.\d+)(?:px|rem)$/;
+
+// Runs AFTER resolveInPlace and BEFORE hoistDualNodes. Both halves matter.
+//
+// After resolution, because the unit is not in the authored text: a semantic
+// font size is authored "{text.3xl}" and carries no unit at all. Reading the
+// authored string would classify only the px-authored primitives — 13 of 39
+// on a real source.
+//
+// Before the hoist, because the hoist consumes the leaf name:
+// text.xs.lineHeight becomes text.xsLineHeight, and the name this rule matches
+// on is gone. Matching a suffix against the camel-joined name instead would
+// couple the rule to the hoist's naming scheme, and case-insensitively it
+// false-positives on names like baselineHeight.
+function classifyTextUnits(node) {
+  for (const [key, val] of Object.entries(node)) {
+    if (key.startsWith('$') || !val || typeof val !== 'object') continue;
+    if (
+      TEXT_UNIT_NAMES.has(key) &&
+      '$value' in val &&
+      val.$type === 'dimension' &&
+      ABSOLUTE_UNIT.test(String(val.$value).trim())
+    ) {
+      val.$extensions ??= {};
+      val.$extensions[EXT_NS] ??= {};
+      const ns = val.$extensions[EXT_NS];
+      // A source that states the role itself wins. This is the override, and
+      // it costs no configuration parameter: declining to overwrite IS the
+      // feature. It is also what makes the pass idempotent.
+      if (!('nativeUnit' in ns)) ns.nativeUnit = 'text';
+    }
+    classifyTextUnits(val);
+  }
+  return node;
+}
+
 export function preprocess(dict) {
   const collisions = [];
   const out = hoistDualNodes(
-    resolveInPlace(structuredClone(dict), flattenDtcg(dict)),
+    classifyTextUnits(resolveInPlace(structuredClone(dict), flattenDtcg(dict))),
     collisions,
   );
   if (collisions.length) {

--- a/scripts/lib/sd-native.mjs
+++ b/scripts/lib/sd-native.mjs
@@ -290,9 +290,12 @@ export function preprocess(dict) {
 //     correct, and those are what a consumer should reach for.
 //   - An em-valued letterSpacing is filtered out of native output entirely,
 //     rather than emitted as Compose's .em TextUnit.
-//   - A unitless ratio (leading.normal: "1.5") emits as 1.50.dp. It is
-//     deliberately NOT stamped: 1.50.sp would compile and render 1.5sp text,
-//     turning a loud failure into a silent one.
+//   - A unitless ratio emits as dp. leading.normal: "1.5" gives 1.50.dp, but
+//     that token is excluded twice over — its key is not a typography member
+//     AND its value has no absolute unit. The gate that carries the weight is
+//     the second one: a lineHeight-keyed "1.5" is deliberately NOT stamped,
+//     because 1.50.sp would compile and render 1.5sp text, turning a loud
+//     failure into a silent one.
 //
 // Stock, from SD 4.4.0:
 //   ios-swift: attribute/cti name/camel color/UIColorSwift

--- a/scripts/lib/sd-native.test.mjs
+++ b/scripts/lib/sd-native.test.mjs
@@ -12,6 +12,7 @@ import {
   nativeSources,
   registerNativeTransforms,
   hasNativeForm,
+  EXT_NS,
 } from './sd-native.mjs';
 
 test('magnitude treats px as 1:1', () => {
@@ -774,4 +775,128 @@ test('a reference embedded inside an expression still inherits $type', () => {
     },
   });
   assert.equal(out.text.smTracking.$type, 'dimension');
+});
+
+// #51. DTCG has no fontSize type, so the role cannot come from $type. It comes
+// from the member names the Format Module's 30 July 2026 draft §9.8 fixes at
+// MUST level for the typography composite.
+const roleOf = (token) => token?.$extensions?.[EXT_NS]?.nativeUnit;
+
+test('preprocess stamps a dimension named fontSize as a text unit', () => {
+  const out = preprocess({
+    typography: { h1: { fontSize: { $value: '30px', $type: 'dimension' } } },
+  });
+  assert.equal(roleOf(out.typography.h1.fontSize), 'text');
+});
+
+test('preprocess stamps letterSpacing and lineHeight, not fontFamily or fontWeight', () => {
+  const out = preprocess({
+    t: {
+      letterSpacing: { $value: '0.5px', $type: 'dimension' },
+      lineHeight: { $value: '24px', $type: 'dimension' },
+      fontFamily: { $value: 'Nunito Sans', $type: 'fontFamily' },
+      fontWeight: { $value: '700', $type: 'fontWeight' },
+    },
+  });
+  assert.equal(roleOf(out.t.letterSpacing), 'text');
+  assert.equal(roleOf(out.t.lineHeight), 'text');
+  assert.equal(roleOf(out.t.fontFamily), undefined);
+  assert.equal(roleOf(out.t.fontWeight), undefined);
+});
+
+// The load-bearing case, and the one the spec review caught. Every semantic
+// font size in a real source is authored as a REFERENCE — "{text.3xl}" — and
+// carries no unit at all. Classifying on the authored string would stamp only
+// the px-authored primitives and miss two thirds of the fix.
+test('preprocess stamps a fontSize authored as a reference, using the resolved value', () => {
+  const out = preprocess({
+    text: { '3xl': { $value: '30px', $type: 'dimension' } },
+    typography: { h1: { fontSize: { $value: '{text.3xl}', $type: 'dimension' } } },
+  });
+  assert.equal(out.typography.h1.fontSize.$value, '30px');
+  assert.equal(roleOf(out.typography.h1.fontSize), 'text');
+});
+
+// The hoist renames text.xs.lineHeight to text.xsLineHeight, consuming the
+// leaf name the rule matches on. Classification must run first.
+test('preprocess stamps a dual-node child before the hoist consumes its name', () => {
+  const out = preprocess({
+    text: { xs: { $value: '12px', $type: 'dimension', lineHeight: { $value: '16px', $type: 'dimension' } } },
+  });
+  assert.equal(out.text.xsLineHeight.$value, '16px');
+  assert.equal(roleOf(out.text.xsLineHeight), 'text');
+  assert.equal(roleOf(out.text.xs), undefined);
+});
+
+// magnitude() reads a bare number as a ratio. Stamping one would emit
+// 1.50.sp — which compiles and renders 1.5sp text, trading a loud failure for
+// a silent one. leading.normal stays the separate defect it already is.
+test('preprocess does not stamp a unitless ratio named lineHeight', () => {
+  const out = preprocess({
+    t: { lineHeight: { $value: '1.5', $type: 'dimension' } },
+  });
+  assert.equal(roleOf(out.t.lineHeight), undefined);
+});
+
+test('preprocess does not stamp an em or percentage value', () => {
+  const out = preprocess({
+    t: {
+      letterSpacing: { $value: '-0.03em', $type: 'dimension' },
+      lineHeight: { $value: '150%', $type: 'dimension' },
+    },
+  });
+  assert.equal(roleOf(out.t.letterSpacing), undefined);
+  assert.equal(roleOf(out.t.lineHeight), undefined);
+});
+
+test('preprocess stamps rem as well as px', () => {
+  const out = preprocess({ t: { fontSize: { $value: '1.5rem', $type: 'dimension' } } });
+  assert.equal(roleOf(out.t.fontSize), 'text');
+});
+
+// The $type check reads the token's OWN key, so a fontSize typed something
+// else is not swept in.
+test('preprocess does not stamp a fontSize that is not dimension-typed', () => {
+  const out = preprocess({ t: { fontSize: { $value: '30px', $type: 'string' } } });
+  assert.equal(roleOf(out.t.fontSize), undefined);
+});
+
+// The override, and the reason this design needs no new config parameter.
+test('preprocess honours a nativeUnit the source already set', () => {
+  const out = preprocess({
+    t: {
+      lineHeight: {
+        $value: '24px',
+        $type: 'dimension',
+        $extensions: { 'com.radicool.throughline': { nativeUnit: 'device' } },
+      },
+      size: {
+        $value: '30px',
+        $type: 'dimension',
+        $extensions: { 'com.radicool.throughline': { nativeUnit: 'text' } },
+      },
+    },
+  });
+  assert.equal(roleOf(out.t.lineHeight), 'device');
+  assert.equal(roleOf(out.t.size), 'text');
+});
+
+test('preprocess leaves an unrelated $extensions namespace untouched', () => {
+  const out = preprocess({
+    t: {
+      fontSize: {
+        $value: '30px',
+        $type: 'dimension',
+        $extensions: { 'org.example.other': { hint: 'keep me' } },
+      },
+    },
+  });
+  assert.equal(out.t.fontSize.$extensions['org.example.other'].hint, 'keep me');
+  assert.equal(roleOf(out.t.fontSize), 'text');
+});
+
+test('preprocess does not stamp the caller input', () => {
+  const input = { t: { fontSize: { $value: '30px', $type: 'dimension' } } };
+  preprocess(input);
+  assert.equal(input.t.fontSize.$extensions, undefined);
 });

--- a/scripts/lib/sd-native.test.mjs
+++ b/scripts/lib/sd-native.test.mjs
@@ -279,7 +279,7 @@ test('the registered swift transform converts a px dimension 1:1', () => {
   assert.equal(swift.transform(token), 'CGFloat(14.00)');
 });
 
-test('the registered compose transforms split sp from dp by $type', () => {
+test('the registered compose transforms split sp from dp by $type or stamp', () => {
   const transforms = [];
   registerNativeTransforms({ registerPreprocessor: () => {}, registerTransform: (t) => transforms.push(t) });
   const dp = transforms.find((t) => t.name === 'size/unit-aware/compose-dp');
@@ -899,4 +899,75 @@ test('preprocess does not stamp the caller input', () => {
   const input = { t: { fontSize: { $value: '30px', $type: 'dimension' } } };
   preprocess(input);
   assert.equal(input.t.fontSize.$extensions, undefined);
+});
+
+// #51. The sp branch used to gate on $type === 'fontSize', which DTCG never
+// produces. It now gates on the role stamped in preprocess.
+const stamped = (value) => ({
+  $type: 'dimension',
+  $value: value,
+  original: { $value: value },
+  $extensions: { [EXT_NS]: { nativeUnit: 'text' } },
+});
+
+test('the compose transforms split sp from dp by the text-unit stamp', () => {
+  const t = collectTransforms();
+  const dp = t.get('size/unit-aware/compose-dp');
+  const sp = t.get('size/unit-aware/compose-sp');
+
+  const textUnit = stamped('30px');
+  const device = { $type: 'dimension', $value: '16px', original: { $value: '16px' } };
+
+  assert.equal(sp.filter(textUnit), true);
+  assert.equal(dp.filter(textUnit), false);
+  assert.equal(sp.transform(textUnit), '30.00.sp');
+
+  assert.equal(dp.filter(device), true);
+  assert.equal(sp.filter(device), false);
+  assert.equal(dp.transform(device), '16.00.dp');
+});
+
+// The partition must be disjoint: no token may be transformed by both, and
+// none may fall through neither.
+test('no dimension token matches both compose transforms', () => {
+  const t = collectTransforms();
+  const dp = t.get('size/unit-aware/compose-dp');
+  const sp = t.get('size/unit-aware/compose-sp');
+  for (const token of [
+    stamped('30px'),
+    { $type: 'dimension', $value: '16px', original: { $value: '16px' } },
+    { $type: 'fontSize', $value: '14px', original: { $value: '14px' } },
+  ]) {
+    assert.equal(dp.filter(token) && sp.filter(token), false);
+  }
+});
+
+// The override invites a source to stamp any token it likes, so the sp filter
+// needs the same hasMagnitude guard both size transforms already carry.
+// Without it this reaches authored(token).toFixed(2) on null.
+test('the sp transform skips a stamped token with no build-time magnitude', () => {
+  const sp = collectTransforms().get('size/unit-aware/compose-sp');
+  assert.equal(sp.filter(stamped('-0.03em')), false);
+  assert.equal(sp.filter(stamped('Nunito Sans')), false);
+});
+
+// Style Dictionary's own convention keeps working: this change is additive.
+test('the sp transform still fires on a Style Dictionary $type fontSize', () => {
+  const sp = collectTransforms().get('size/unit-aware/compose-sp');
+  const token = { $type: 'fontSize', $value: '14px', original: { $value: '14px' } };
+  assert.equal(sp.filter(token), true);
+  assert.equal(sp.transform(token), '14.00.sp');
+});
+
+// End to end through preprocess: the shape a real source actually has.
+test('a resolved semantic fontSize reaches the sp transform', () => {
+  const out = preprocess({
+    text: { '3xl': { $value: '30px', $type: 'dimension' } },
+    typography: { h1: { fontSize: { $value: '{text.3xl}', $type: 'dimension' } } },
+  });
+  const token = out.typography.h1.fontSize;
+  token.original = { $value: token.$value };
+  const sp = collectTransforms().get('size/unit-aware/compose-sp');
+  assert.equal(sp.filter(token), true);
+  assert.equal(sp.transform(token), '30.00.sp');
 });

--- a/scripts/lib/sd-native.test.mjs
+++ b/scripts/lib/sd-native.test.mjs
@@ -927,8 +927,9 @@ test('the compose transforms split sp from dp by the text-unit stamp', () => {
   assert.equal(dp.transform(device), '16.00.dp');
 });
 
-// The partition must be disjoint: no token may be transformed by both, and
-// none may fall through neither.
+// The partition must be disjoint AND total: exactly one of the two filters
+// matches. Asserting `dp && sp === false` alone would pass against an
+// implementation where both always return false, so assert the exclusive-or.
 test('no dimension token matches both compose transforms', () => {
   const t = collectTransforms();
   const dp = t.get('size/unit-aware/compose-dp');
@@ -938,7 +939,7 @@ test('no dimension token matches both compose transforms', () => {
     { $type: 'dimension', $value: '16px', original: { $value: '16px' } },
     { $type: 'fontSize', $value: '14px', original: { $value: '14px' } },
   ]) {
-    assert.equal(dp.filter(token) && sp.filter(token), false);
+    assert.equal(dp.filter(token) !== sp.filter(token), true, `${JSON.stringify(token)} must match exactly one transform`);
   }
 });
 

--- a/scripts/lib/sd-native.test.mjs
+++ b/scripts/lib/sd-native.test.mjs
@@ -279,7 +279,7 @@ test('the registered swift transform converts a px dimension 1:1', () => {
   assert.equal(swift.transform(token), 'CGFloat(14.00)');
 });
 
-test('the registered compose transforms split sp from dp by $type or stamp', () => {
+test('the registered compose transforms still split sp from dp by the legacy $type gate', () => {
   const transforms = [];
   registerNativeTransforms({ registerPreprocessor: () => {}, registerTransform: (t) => transforms.push(t) });
   const dp = transforms.find((t) => t.name === 'size/unit-aware/compose-dp');


### PR DESCRIPTION
Closes #51. **Stacked on #59** — base is `fix/55-hoist-dual-nodes`, not `main`. Merge #59 first.

## The problem

`size/unit-aware/compose-sp` gated on `$type === 'fontSize'`. DTCG defines no such type — it types font sizes as `dimension`, which is also what spacing, radius and stroke widths are. So the branch was unreachable and every dimension fell through to `.dp`.

Measured on zygarden's real source: **195 Kotlin declarations, zero `.sp`.**

## Two corrections to the issue's own text

**The severity mechanism in #51 is wrong.** The issue says this is "an accessibility regression that compiles, renders, and looks correct." It doesn't compile. From the androidx source, every `TextStyle` overload declares `fontSize: TextUnit`, `lineHeight: TextUnit`, `letterSpacing: TextUnit` — no `Dp` overload, no implicit conversion.

The bug is still real and still an a11y bug, but it arrives one step later: the developer hits the compile error and repairs it, and the idiomatic-looking repair is `Dp.toSp()`, which divides by `fontScale` and pins the text at a fixed size regardless of the user's setting. *That* compiles, renders, and looks correct.

This matters for scope, not just accuracy — a partial fix is worth much less than it looks, because a `TextStyle` needs all its text-unit members before it compiles at all.

**It is three roles, not one.** `lineHeight` is the largest group at 26 tokens; `fontSize`, which the issue is named after, is 13.

## The rule

`$type` provably cannot carry this, so the role comes from the one place a DTCG source states it: the member names §9.8 fixes at MUST level for the typography composite. A token whose **own** `$type` is `dimension`, named `fontSize` / `letterSpacing` / `lineHeight`, whose **resolved** value carries `px` or `rem`, is stamped `$extensions["com.radicool.throughline"].nativeUnit = "text"`. The two Compose transforms then partition on that stamp.

Three details are load-bearing, each settled by measurement rather than argument:

- **Classification runs between `resolveInPlace` and `hoistDualNodes`.** After resolution because every semantic font size is authored as a reference (`"{text.3xl}"`) carrying no unit — reading the authored string would fix 13 tokens instead of 39. Before the hoist because the hoist renames `text.xs.lineHeight` to `text.xsLineHeight`, consuming the leaf name the rule matches on.
- **`$extensions` is the carrier**, verified by probing Style Dictionary directly: it survives to transform filters. A `WeakSet` — the mechanism #55 used — does not, because the marking and the reading are no longer in the same tick.
- **The override is free.** Declining to overwrite a `nativeUnit` a source already set *is* the escape hatch, so a source with unconventional names needs no new config parameter. `"device"` opts a token out.

`$type === 'fontSize'` is kept as an `||`, so Style Dictionary's own convention still works and the change is purely additive.

## Verification

Built at base and at HEAD and diffed, rather than counting declarations — counting cannot see compensating changes.

| Prediction (written before the code) | Result |
|---|---|
| Exactly 39 declarations flip | **39** |
| Every one a pure `.dp` → `.sp` | **zero magnitude drift** |
| Other 156 byte-identical | no non-declaration line changed |
| `Tokens.swift` byte-identical | `cmp` clean |
| Count stays 195 | 195 |

Composition: 13 `typography.textStyle.*.fontSize` + 13 `typography.textStyle.*.lineHeight` + 13 hoisted `text.*LineHeight`. `validate-token-output` exits 0 on both platforms, 195/195 matched. 347 tests, six gates green.

## Deliberately not fixed

- **13 `text.*` scale primitives stay `.dp`** — `text.base = 16px` has no role signal at all. The semantic tokens referencing it are all correct. → #63
- **13 `em` `letterSpacing` tokens stay dropped** — a filter gap, not a dp/sp gap. → #64
- **5 `leading.*` unitless ratios stay `.dp`** — and this constrains the design: stamping them would emit `1.50.sp`, which compiles and renders 1.5sp text, trading a loud failure for a silent one. Hence the absolute-unit gate.

## Review found what tests could not

Six defects across the spec review and the final review, **every one in prose rather than behaviour** — and two were the overclaim class the last two PRs on this module also shipped:

- The rule read the *authored* value, which would have fixed 13 of 39 and failed its own prediction on first contact.
- The generated reference still described this bug as live, in the present tense, 22 lines above the code fixing it. Its prose lives in the *generator*, which no task's file list named — so `--check` stayed green while the installed reference contradicted itself.
- "Three of the five are dimension-valued" was false: DTCG types `lineHeight` as a **number** multiplier, so for 26 of the 39 tokens the rule fires only on sources that deviate from §9.8. The sentence borrowed DTCG's authority for the one member where DTCG says otherwise.

Also filed: #62 (a primitive-valued `$extensions` namespace throws a `TypeError` naming nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6zsxr3abwpVMhYh7cNdB1
