### PR TITLE
fix: an enclosing group's $type is no longer shadowed by a dual node's (#60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,10 +66,11 @@ to [Semantic Versioning](https://semver.org).
   ancestry the hoist costs it. Where an enclosing *group* already supplies a
   type, nothing was lost — DTCG §5.2.2 inherits from the closest parent
   *group*, and §6.1 makes a node carrying a `$value` a token — so the carry
-  shadowed a type that was already correct. It is now suppressed there, which
-  makes the hoist type-transparent: a child ends with the type DTCG
-  inheritance gives it in the authored tree, including where that type suits
-  the child badly. Measured through Compose, the shape emitted
+  shadowed a type that was already correct. It is now suppressed there, so the
+  hoist never *changes* a type DTCG inheritance already determines — including
+  where that type suits the child badly. Where inheritance determines none,
+  the carry still supplies the dual node's, which is a repair rather than a
+  reading of the source. Measured through Compose, the shape emitted
   `val textSmLineHeight = 20px` (does not compile, and
   `tokens:validate-output` caught it) for a `px` child, and
   `val textSmLineHeight = 1.5` — a `Double` where a `Dp` belongs, compiling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,8 @@ to [Semantic Versioning](https://semver.org).
   ancestor as authored, and that ancestry is lost once the hoist makes the
   child a sibling instead. A child whose authored value was a whole-value
   reference is excluded and keeps its referent's resolved type per DTCG
-  5.2.2. Three consequences are knowingly accepted, and none is subtle enough
-  to leave implicit:
+  5.2.2. Two consequences are knowingly accepted and a third was not, and none
+  is subtle enough to leave implicit:
   - An untyped `fontSize` child under a `dimension`-typed parent now emits
     through the `dimension` transform — `.dp` on Android rather than `.sp`,
     which **defeats the user's font-scale accessibility setting**. It
@@ -55,15 +55,27 @@ to [Semantic Versioning](https://semver.org).
   - An untyped unitless child now emits as a `dimension` — a ratio rendered in
     density-independent pixels. Also previously caught loudly.
   - Where an enclosing *group* carries a `$type` that correctly describes the
-    child, the dual node's type now shadows it, so a token that resolved
-    correctly before can resolve wrongly. Contrived, and not present in any
-    source we have measured, but it is the one case that turns right into
-    wrong rather than loud into silent.
+    child, the dual node's type shadowed it, so a token that resolved
+    correctly before resolved wrongly. **Fixed below**; it is listed here
+    because the two above are accepted and this one was not.
 
-  The first two are covered by tests; the third is documented in
-  `docs/superpowers/specs/2026-08-23-hoist-dual-nodes-design.md` and is not.
-  This does not make native output compile-verified or validate DTCG
-  conformance on its own.
+  The two accepted consequences are covered by tests. This does not make
+  native output compile-verified or validate DTCG conformance on its own.
+- **An enclosing group's `$type` is no longer shadowed by a dual node's.**
+  The hoist carries a dual node's `$type` onto an untyped child to replace the
+  ancestry the hoist costs it. Where an enclosing *group* already supplies a
+  type, nothing was lost — DTCG §5.2.2 inherits from the closest parent
+  *group*, and §6.1 makes a node carrying a `$value` a token — so the carry
+  shadowed a type that was already correct. It is now suppressed there, which
+  makes the hoist type-transparent: a child ends with the type DTCG
+  inheritance gives it in the authored tree, including where that type suits
+  the child badly. Measured through Compose, the shape emitted
+  `val textSmLineHeight = 20px` (does not compile, and
+  `tokens:validate-output` caught it) for a `px` child, and
+  `val textSmLineHeight = 1.5` — a `Double` where a `Dp` belongs, compiling
+  and passing the gate clean — for a unitless one. Both now emit `.dp`. Output
+  against a real 322-token source is byte-identical: the shape requires a dual
+  node typed differently from both its enclosing group and its own child.
 - **`no-foreign-syntax` reconciled with the native output filter.** An
   unrescued `calc(...)`, `var(...)`, or `color-mix(...)` variant was
   previously dropped from native output by `sd-native.mjs`'s filter before

--- a/docs/superpowers/notes/2026-08-24-native-backlog-handoff.md
+++ b/docs/superpowers/notes/2026-08-24-native-backlog-handoff.md
@@ -1,0 +1,108 @@
+# Native-token backlog — handoff
+
+**Date:** 2026-08-24
+**Supersedes:** `2026-08-24-ranked-backlog-handoff.md`
+
+## Where the backlog stands
+
+Agreed order, one item at a time, full brainstorm → spec → `/review-spec` →
+plan → subagent execution → PR, pausing after each PR:
+
+**#53 ✅ → #55 ✅ → #51 ✅ → #60 ✅ (PR #68 open) → #52 → #36 → #54**
+
+| | |
+|---|---|
+| **#53** | Merged `698a236`. Native output that did not compile: 196 declarations with 15 broken symbols → **195 with 0**. |
+| **#55** | Merged `b593b3b` (PR #59). Collision throw + `$type` inheritance. |
+| **#51** | Merged `b73adcf` (PR #66). Compose font sizes and line heights emit `.sp`: **39 declarations flipped, zero magnitude drift.** |
+| **#60** | [PR #68](https://github.com/jrpease/throughline/pull/68), **open**. Group `$type` no longer shadowed. 353 tests, six gates, e2e byte-identical. |
+| Filed across these | #57, #58, #60✅, #61, #62, #63, #64, #67 |
+
+**#60 was ranked above the remaining originals** because it was the one item
+that turned correct output into wrong. That ranking survived contact with the
+evidence only partly — see below.
+
+## Start here — three things that change how the next item goes
+
+**1. Measure severity on emitted output, not on a `preprocess` tree.** #60's
+issue text, and spec revision 4 that spawned it, both claimed "correct becomes
+wrong rather than loud becomes silent." Built end-to-end, #60's own example
+emits `val textSmLineHeight = 20px` — does not compile, and
+`tokens:validate-output` catches it under `no-bare-units` and
+`unverifiable-dimension`. The genuinely silent case is a *unitless* child:
+`val textSmLineHeight = 1.5`, a `Double` where a `Dp` belongs, passing the gate
+clean. The deciding rule — `BARE_UNIT` fires only on unit-suffixed literals —
+was already written two paragraphs above the wrong claim.
+
+This matters directly for **#52**, which is *about* unitless ratios. Its
+severity should be measured the same way before its spec argues anything.
+
+**2. The stack is gone; branch off `main` again.** `scripts/lib/sd-native.mjs`
+generates `references/native-adapter-config.md` from its whole body, so
+concurrent branches conflict guaranteed — that is why #53/#55/#51 were stacked.
+All three are merged and #68 is the only open native branch. If #52 starts
+before #68 merges, **stack on `fix/60-group-type-shadowing`** and retarget the
+child PR to `main` *before* the parent merges. Merging a parent with
+`--delete-branch` auto-closes the stacked PR and it cannot be reopened once its
+head has been rebased; that cost PR #65 on 2026-08-24, and its content had to
+be reopened as #66.
+
+**3. The e2e harness survives in this session's scratchpad and is the strongest
+assertion available.** `<scratchpad>/e2e` holds style-dictionary 4.4.0 with
+`lib/` symlinked to the repo's live `scripts/lib`, so building at `main` and at
+`HEAD` and running `diff -r` is nearly free and rules out compensating changes
+that declaration counts would miss. It is scratchpad-only and will not survive
+indefinitely; rebuilding is the first step of any e2e run. No token source is
+vendored — zygarden is external at `~/Dev/zygarden-frontend`, branch
+`feature/apply-brandguide-styles`, read with `git show <branch>:<path>`.
+**Do not check it out or modify it.**
+
+Current baseline on `main` and on #68: **195 declarations, 39 `.sp`, 50 `.dp`**,
+Kotlin and Swift byte-identical between the two.
+
+## What #60 established that outlives it
+
+**The hoist's type rule, stated no wider than it holds.** `hoistDualNodes`
+never *changes* a type DTCG inheritance already determines; where inheritance
+determines none, the carry supplies the dual node's as a repair. The tempting
+stronger form — "a child ends with the type DTCG inheritance gives it in the
+authored tree" — is false in exactly the case the carry exists for, and false
+again when the hoisted node is a **group**, which acquires the type and passes
+it to children the source never typed. That second case is
+[#67](https://github.com/jrpease/throughline/issues/67), filed rather than
+absorbed.
+
+**The guard is one value per frame**, and the reason it is not more:
+
+```js
+const inherited = '$value' in node ? groupType : (node.$type ?? groupType);
+```
+
+Looking through `$value`-bearing nodes is what makes a dual node a non-source,
+and the same value serves both the recursive descent and the carry guard,
+because a hoisted child lands as a member of the frame it is computed for.
+Anything touching that recursion must preserve both properties.
+
+## Open questions
+
+- **Does #52 still rank where it did?** It is the unitless-ratio case, which
+  #60 just established is the *silent* half of this defect family — which
+  argues it up, not down.
+- **Does the consumption-layer epic (#39–#44) start after #54, or sooner?** All
+  four native correctness items from the original ranking are now done or in
+  review. The original reasoning was that #39 should begin on a clean base.
+- **#67 vs #52 vs #36 for the next slot.** #67 is fresh, unmeasured, and
+  unreachable in zygarden; measuring it is cheap and would settle it.
+
+## Working note on process
+
+Across #53, #55, #51 and #60, every defect a review caught was **a defect in the
+written design, not the implementation** — and in #60 the reviewer's finding was
+against prose I had written to *correct* earlier wrong prose. Two patterns worth
+carrying:
+
+- A tidy invariant is the most dangerous sentence in a spec, because it reads as
+  the thing that makes a fix principled. State it, then hunt the case that
+  breaks it.
+- "Verification means executing something" has a layer. Executing the
+  preprocessor is not executing the pipeline.

--- a/docs/superpowers/specs/2026-08-23-hoist-dual-nodes-design.md
+++ b/docs/superpowers/specs/2026-08-23-hoist-dual-nodes-design.md
@@ -200,14 +200,17 @@ child's, and the emitted unit is still wrong.
 *correct becomes wrong*. When an enclosing **group** carries a `$type` that does
 describe the child, the carry shadows it — DTCG §5.2.2 inherits from the closest
 parent *group*, and the dual node is a token, not a group, so before this change
-the group's type was the one that applied. Measured against `main`:
+the group's type was the one that applied. Measured at the time against `main`
+at `698a236` — the pin matters, because #59 has since merged and the row labelled
+`HEAD` is what `main` produces today:
 
 ```
-in   : { text: { $type: "dimension",
-                 sm: { $value: "#fff", $type: "color",
-                       lineHeight: { $value: "20px" } } } }
-main : text.smLineHeight = { $value: "20px" }                  -> inherits dimension from the group: RIGHT
-HEAD : text.smLineHeight = { $value: "20px", $type: "color" }  -> WRONG
+in     : { text: { $type: "dimension",
+                   sm: { $value: "#fff", $type: "color",
+                         lineHeight: { $value: "20px" } } } }
+698a236: text.smLineHeight = { $value: "20px" }                  -> inherits dimension from the group: RIGHT
+  #59  : text.smLineHeight = { $value: "20px", $type: "color" }  -> WRONG
+  #60  : text.smLineHeight = { $value: "20px" }                  -> RIGHT again
 ```
 
 There was no loud failure here and no malformed input by the standard the
@@ -226,12 +229,33 @@ guard, because a hoisted child lands as a member of the frame it is computed
 for.
 
 The invariant is worth stating, because it is what makes the rule principled
-rather than a patch: **the hoist is type-transparent.** A child ends with the
-type DTCG inheritance gives it in the authored tree. That holds even where the
-group's type suits the child badly — `g: {$type: "color", a: {$value: "#fff",
-$type: "dimension", b: {$value: "2px"}}}` gives `b` colour before the hoist and
-after it, because `a` is a token and never was `b`'s inheritance source. The
-hoist is not entitled to improve on what the source says.
+rather than a patch — and worth stating no wider than it holds: **the hoist
+never *changes* a type DTCG inheritance already determines.** Where inheritance
+determines none, the carry supplies the dual node's, which is a repair rather
+than a reading of the source.
+
+So an enclosing group wins even where its type suits the child badly —
+`g: {$type: "color", a: {$value: "#fff", $type: "dimension", b: {$value:
+"2px"}}}` gives `b` colour before the hoist and after it, because `a` is a token
+and never was `b`'s inheritance source, and the hoist is not entitled to improve
+on what the source says.
+
+An earlier draft of this paragraph claimed the stronger "a child ends with the
+type DTCG inheritance gives it in the authored tree," which is false in exactly
+the case the carry exists for, and false again where the hoisted node is a
+*group*:
+
+```
+in : { text: { sm: { $value: "#fff", $type: "color",
+                     heights: { line: { $value: "20px" } } } } }
+out: { text: { sm: {...}, smHeights: { $type: "color", line: { $value: "20px" } } } }
+                                       ^ line now inherits color; authored, it inherited nothing
+```
+
+That is pre-existing behaviour, unchanged here and out of scope for #60, which
+is about shadowing a type that already applied. It is the same over-reach one
+step further out, and it is filed as
+[#67](https://github.com/jrpease/throughline/issues/67) rather than absorbed.
 
 ### Revision 4 measured this case at the wrong layer
 
@@ -249,8 +273,14 @@ the *identical* asymmetry this section documents two paragraphs above, where
 `BARE_UNIT` is shown to fire "only on a *unit-suffixed* literal" and the
 archetypal wrongly-typed child is noted to be a unitless ratio. Revision 4
 established the asymmetry and then chose an example that falls on the other side
-of it. Both rows are now tests; the second is the one with teeth, and it is the
-one revision 4's transcript did not show.
+of it.
+
+Both rows now have a test — at the `preprocess` layer, asserting no `$type` is
+carried. The emitted `val …` strings and the `fixed` column were measured by
+hand through a Style Dictionary 4.4.0 build and are not pinned by the suite,
+which is worth saying plainly in a section whose whole complaint is that
+revision 4 read severity off the wrong layer. The second row is the one with
+teeth, and it is the one revision 4's transcript did not show.
 
 ### Blast radius — two open issues, both widened, both recorded
 
@@ -406,8 +436,9 @@ residual rather than about the decision to ship #55:
    this document had already established, applied to everything except its own
    example.
 
-Both rows are now tests, so the section that had "the one residual not pinned by
-a test" has no residual left to pin. Output against the real source is
+Both rows now have a `preprocess`-layer test, so the section that had "the one
+residual not pinned by a test" has no residual left to pin; the emitted-output
+half was measured by hand and says so. Output against the real source is
 byte-identical: the shape requires a dual node typed differently from both its
 enclosing group and its own child, which zygarden does not contain.
 

--- a/docs/superpowers/specs/2026-08-23-hoist-dual-nodes-design.md
+++ b/docs/superpowers/specs/2026-08-23-hoist-dual-nodes-design.md
@@ -2,9 +2,9 @@
 
 **Issue:** [#55](https://github.com/jrpease/throughline/issues/55)
 **Date:** 2026-08-23
-**Revision:** 4 — the accepted-cost section now records the *correct becomes
-wrong* sub-case alongside *loud becomes silent*. See
-[Revision history](#revision-history).
+**Revision:** 5 — the *correct becomes wrong* residual is **fixed** in
+[#60](https://github.com/jrpease/throughline/issues/60), and revision 4's
+severity claim about it was wrong. See [Revision history](#revision-history).
 **Depends on:** [#56](https://github.com/jrpease/throughline/pull/56) (#53). Same
 file, and `references/native-adapter-config.md` is generated from the whole
 module, so this branch stacks rather than forking from `main`.
@@ -213,23 +213,44 @@ HEAD : text.smLineHeight = { $value: "20px", $type: "color" }  -> WRONG
 There was no loud failure here and no malformed input by the standard the
 sentence above uses — there was a right answer, and the carry replaces it.
 
-Not fixed, deliberately. The rule that would fix it — carry the dual node's
-`$type` only when no enclosing group supplies one — means threading the ancestor
-group chain through the recursion for a shape that requires a dual node typed
-differently from both its parent group and its own child. Unreachable in
-zygarden, and the added machinery is a worse trade than the defect. Recorded
-here so the residual is described accurately rather than flatteringly, which is
-the whole point of this section.
+**Fixed in [#60](https://github.com/jrpease/throughline/issues/60), and the
+machinery cost one parameter.** Revision 4 declined the fix on the grounds that
+carrying the dual node's `$type` only when no enclosing group supplies one
+"means threading the ancestor group chain through the recursion." It does, and
+the chain is one value: the `$type` a plain member of the current frame
+inherits, recomputed per frame as `'$value' in node ? groupType : node.$type ??
+groupType`. Looking through a `$value`-bearing node is what makes a dual node a
+non-source, and it is also what makes the nested case work, since the child
+hoists past that node on the next frame up anyway. The same value serves the
+guard, because a hoisted child lands as a member of the frame it is computed
+for.
 
-**This is the one residual not pinned by a test**, and the asymmetry is worth
-naming, because the blast-radius section immediately below insists that a
-widening be "demonstrated by test rather than asserted away." That standard is
-met for #52 and #51 and not for this. The reason is that a test would pin
-behaviour we have judged wrong rather than behaviour we have judged acceptable
-— the other two record a bad-but-accepted *output*, whereas this records a
-*regression* from a correct answer. Pinning it would read as endorsement.
-Reproduced above from a real run against `main` and `HEAD`; that transcript is
-the evidence, and it is weaker than a test, deliberately.
+The invariant is worth stating, because it is what makes the rule principled
+rather than a patch: **the hoist is type-transparent.** A child ends with the
+type DTCG inheritance gives it in the authored tree. That holds even where the
+group's type suits the child badly — `g: {$type: "color", a: {$value: "#fff",
+$type: "dimension", b: {$value: "2px"}}}` gives `b` colour before the hoist and
+after it, because `a` is a token and never was `b`'s inheritance source. The
+hoist is not entitled to improve on what the source says.
+
+### Revision 4 measured this case at the wrong layer
+
+The transcript above is a `preprocess` tree, and revision 4 read severity off
+it: "there was no loud failure here." Built end-to-end through Style Dictionary,
+that is false for the very example it uses.
+
+| input child | with the carry | `tokens:validate-output` | fixed |
+|---|---|---|---|
+| `20px`, group `dimension`, dual node `color` | `val textSmLineHeight = 20px` — does not compile | **caught**: `no-bare-units`, `unverifiable-dimension` | `20.00.dp` |
+| `1.5`, group `dimension`, dual node `number` | `val textSmLineHeight = 1.5` — a `Double`, compiles | **clean** | `1.50.dp` |
+
+So the shape is loud for a unit-suffixed literal and silent for a unitless one —
+the *identical* asymmetry this section documents two paragraphs above, where
+`BARE_UNIT` is shown to fire "only on a *unit-suffixed* literal" and the
+archetypal wrongly-typed child is noted to be a unitless ratio. Revision 4
+established the asymmetry and then chose an example that falls on the other side
+of it. Both rows are now tests; the second is the one with teeth, and it is the
+one revision 4's transcript did not show.
 
 ### Blast radius — two open issues, both widened, both recorded
 
@@ -371,6 +392,24 @@ wrong recursion frame passes every single-level test.
 records the one place it widens #52 rather than leaving the claim unexamined.
 
 ## Revision history
+
+**Revision 5 (2026-08-24)** — the *correct becomes wrong* residual revision 4
+recorded is fixed, in #60. Two things revision 4 got wrong, both about its own
+residual rather than about the decision to ship #55:
+
+1. **The cost of fixing it was overstated.** "Threading the ancestor group chain
+   through the recursion" is one parameter and one expression, not machinery.
+2. **Its severity was measured on a `preprocess` tree rather than on emitted
+   output.** The `20px` example it chose does not compile and the output gate
+   catches it. The silent case is a unitless child, which emits a `Double` where
+   a `Dp` belongs and passes the gate clean — the same `BARE_UNIT` asymmetry
+   this document had already established, applied to everything except its own
+   example.
+
+Both rows are now tests, so the section that had "the one residual not pinned by
+a test" has no residual left to pin. Output against the real source is
+byte-identical: the shape requires a dual node typed differently from both its
+enclosing group and its own child, which zygarden does not contain.
 
 **Revision 4 (2026-08-24)** — the final whole-branch review. One correction,
 again to a claim rather than the decision: the accepted-cost section framed the

--- a/references/native-adapter-config.md
+++ b/references/native-adapter-config.md
@@ -248,10 +248,13 @@ function hoistDualNodes(node, collisions, prefix = [], groupType = undefined) {
         // group, and the dual node is a token — so it still is after the hoist,
         // and carrying would shadow it.
         //
-        // The invariant is transparency, not correctness: the child ends with
-        // the type DTCG inheritance gives it in the authored tree. An enclosing
-        // group wins even where its type suits the child badly, because that is
-        // what the source says and the hoist is not entitled to improve on it.
+        // The invariant, stated no wider than it holds: the hoist never
+        // CHANGES a type DTCG inheritance already determines. Where it
+        // determines none, the carry supplies the dual node's — a repair, not
+        // a reading of the source. So an enclosing group wins even where its
+        // type suits the child badly, because the hoist is not entitled to
+        // improve on what the source says; but the carry firing at all is the
+        // hoist saying something the source did not.
         if (
           !('$type' in childVal) &&
           '$type' in val &&

--- a/references/native-adapter-config.md
+++ b/references/native-adapter-config.md
@@ -198,7 +198,14 @@ function resolveInPlace(node, flat, prefix = []) {
 // an inherited Object.prototype member (toString, valueOf, ...) reported a
 // collision against a sibling that does not exist. Object.hasOwn checks the
 // tree's own keys only.
-function hoistDualNodes(node, collisions, prefix = []) {
+function hoistDualNodes(node, collisions, prefix = [], groupType = undefined) {
+  // The $type a plain member of THIS frame inherits, and the one a child
+  // hoisted INTO it will inherit — the same value, because the hoist makes the
+  // child a member of node. A node carrying a $value is a token, not a group
+  // (DTCG 6.1), so it is not an inheritance source: look through it and keep
+  // the chain from above. That also covers the nested case, where node is a
+  // dual node and the child hoists past it on the next frame up anyway.
+  const inherited = '$value' in node ? groupType : (node.$type ?? groupType);
   // Which hoisted names THIS pass has already claimed, and the authored path
   // of the child that claimed each one — a collision here is a second hoist
   // landing on a name no sibling ever authored. Local to this frame: node is
@@ -207,7 +214,7 @@ function hoistDualNodes(node, collisions, prefix = []) {
   const claimedBy = new Map();
   for (const [key, val] of Object.entries(node)) {
     if (key.startsWith('$') || !val || typeof val !== 'object') continue;
-    hoistDualNodes(val, collisions, [...prefix, key]);
+    hoistDualNodes(val, collisions, [...prefix, key], inherited);
     if ('$value' in val) {
       for (const [childKey, childVal] of Object.entries(val)) {
         if (childKey.startsWith('$') || !childVal || typeof childVal !== 'object') continue;
@@ -229,11 +236,28 @@ function hoistDualNodes(node, collisions, prefix = []) {
           });
           continue;
         }
-        // The dual node is the child's closest $type-bearing ancestor as
-        // authored; after the hoist it is a sibling, so the type is lost unless
-        // it travels. Excluded for a reference-valued child — DTCG 5.2.2 gives
-        // it the referent's type, which outranks inheritance.
-        if (!('$type' in childVal) && '$type' in val && !WAS_REF.has(childVal)) {
+        // The carry pays for what the hoist costs: the dual node is the
+        // child's closest $type-bearing ancestor as authored, and after the
+        // hoist it is a sibling, so that type is lost unless it travels.
+        //
+        // Two cases where nothing was lost, so nothing is carried. A
+        // reference-valued child already has its referent's resolved type, and
+        // DTCG 5.2.2 rule 1 ranks that above inheritance. And where an
+        // enclosing GROUP supplies a type, that group was the child's
+        // inheritance source all along — 5.2.2 inherits from the closest parent
+        // group, and the dual node is a token — so it still is after the hoist,
+        // and carrying would shadow it.
+        //
+        // The invariant is transparency, not correctness: the child ends with
+        // the type DTCG inheritance gives it in the authored tree. An enclosing
+        // group wins even where its type suits the child badly, because that is
+        // what the source says and the hoist is not entitled to improve on it.
+        if (
+          !('$type' in childVal) &&
+          '$type' in val &&
+          !WAS_REF.has(childVal) &&
+          inherited === undefined
+        ) {
           childVal.$type = val.$type;
         }
         node[hoisted] = childVal;

--- a/scripts/lib/sd-native.mjs
+++ b/scripts/lib/sd-native.mjs
@@ -129,7 +129,14 @@ function resolveInPlace(node, flat, prefix = []) {
 // an inherited Object.prototype member (toString, valueOf, ...) reported a
 // collision against a sibling that does not exist. Object.hasOwn checks the
 // tree's own keys only.
-function hoistDualNodes(node, collisions, prefix = []) {
+function hoistDualNodes(node, collisions, prefix = [], groupType = undefined) {
+  // The $type a plain member of THIS frame inherits, and the one a child
+  // hoisted INTO it will inherit — the same value, because the hoist makes the
+  // child a member of node. A node carrying a $value is a token, not a group
+  // (DTCG 6.1), so it is not an inheritance source: look through it and keep
+  // the chain from above. That also covers the nested case, where node is a
+  // dual node and the child hoists past it on the next frame up anyway.
+  const inherited = '$value' in node ? groupType : (node.$type ?? groupType);
   // Which hoisted names THIS pass has already claimed, and the authored path
   // of the child that claimed each one — a collision here is a second hoist
   // landing on a name no sibling ever authored. Local to this frame: node is
@@ -138,7 +145,7 @@ function hoistDualNodes(node, collisions, prefix = []) {
   const claimedBy = new Map();
   for (const [key, val] of Object.entries(node)) {
     if (key.startsWith('$') || !val || typeof val !== 'object') continue;
-    hoistDualNodes(val, collisions, [...prefix, key]);
+    hoistDualNodes(val, collisions, [...prefix, key], inherited);
     if ('$value' in val) {
       for (const [childKey, childVal] of Object.entries(val)) {
         if (childKey.startsWith('$') || !childVal || typeof childVal !== 'object') continue;
@@ -160,11 +167,28 @@ function hoistDualNodes(node, collisions, prefix = []) {
           });
           continue;
         }
-        // The dual node is the child's closest $type-bearing ancestor as
-        // authored; after the hoist it is a sibling, so the type is lost unless
-        // it travels. Excluded for a reference-valued child — DTCG 5.2.2 gives
-        // it the referent's type, which outranks inheritance.
-        if (!('$type' in childVal) && '$type' in val && !WAS_REF.has(childVal)) {
+        // The carry pays for what the hoist costs: the dual node is the
+        // child's closest $type-bearing ancestor as authored, and after the
+        // hoist it is a sibling, so that type is lost unless it travels.
+        //
+        // Two cases where nothing was lost, so nothing is carried. A
+        // reference-valued child already has its referent's resolved type, and
+        // DTCG 5.2.2 rule 1 ranks that above inheritance. And where an
+        // enclosing GROUP supplies a type, that group was the child's
+        // inheritance source all along — 5.2.2 inherits from the closest parent
+        // group, and the dual node is a token — so it still is after the hoist,
+        // and carrying would shadow it.
+        //
+        // The invariant is transparency, not correctness: the child ends with
+        // the type DTCG inheritance gives it in the authored tree. An enclosing
+        // group wins even where its type suits the child badly, because that is
+        // what the source says and the hoist is not entitled to improve on it.
+        if (
+          !('$type' in childVal) &&
+          '$type' in val &&
+          !WAS_REF.has(childVal) &&
+          inherited === undefined
+        ) {
           childVal.$type = val.$type;
         }
         node[hoisted] = childVal;

--- a/scripts/lib/sd-native.mjs
+++ b/scripts/lib/sd-native.mjs
@@ -179,10 +179,13 @@ function hoistDualNodes(node, collisions, prefix = [], groupType = undefined) {
         // group, and the dual node is a token — so it still is after the hoist,
         // and carrying would shadow it.
         //
-        // The invariant is transparency, not correctness: the child ends with
-        // the type DTCG inheritance gives it in the authored tree. An enclosing
-        // group wins even where its type suits the child badly, because that is
-        // what the source says and the hoist is not entitled to improve on it.
+        // The invariant, stated no wider than it holds: the hoist never
+        // CHANGES a type DTCG inheritance already determines. Where it
+        // determines none, the carry supplies the dual node's — a repair, not
+        // a reading of the source. So an enclosing group wins even where its
+        // type suits the child badly, because the hoist is not entitled to
+        // improve on what the source says; but the carry firing at all is the
+        // hoist saying something the source did not.
         if (
           !('$type' in childVal) &&
           '$type' in val &&

--- a/scripts/lib/sd-native.test.mjs
+++ b/scripts/lib/sd-native.test.mjs
@@ -688,6 +688,92 @@ test('nothing is invented when the dual node has no $type', () => {
   assert.equal('$type' in out.text.smLineHeight, false);
 });
 
+// The carry exists because the hoist costs the child its closest $type-bearing
+// ancestor. Where an enclosing GROUP already supplies one, nothing was lost:
+// DTCG 5.2.2 inherits from the closest parent group, and 6.1 makes a node with
+// a $value a token, so the dual node never was the child's inheritance source.
+// Carrying there does not restore a type, it shadows a correct one.
+test('an enclosing group $type is not shadowed by the dual node $type', () => {
+  const out = preprocess({
+    text: {
+      $type: 'dimension',
+      sm: { $value: '#fff', $type: 'color', lineHeight: { $value: '20px' } },
+    },
+  });
+  assert.equal('$type' in out.text.smLineHeight, false);
+});
+
+// The invariant is transparency, not correctness: the child ends with the type
+// DTCG inheritance gives it in the AUTHORED tree, even where that type suits it
+// badly. b inherits color before the hoist — a is a token, so g is b's closest
+// group either way — and carrying dimension here would be the hoist inventing a
+// better answer than the source states.
+// The variant with teeth, and the reason this is worth fixing rather than
+// documenting. Measured end-to-end through Style Dictionary against the real
+// Compose config: with the carry, this emits `val textSmLineHeight = 1.5` — a
+// Double where a Dp belongs, which compiles and passes tokens:validate-output
+// clean, because no-bare-units fires only on a unit-suffixed literal. Without
+// it, 1.50.dp. The issue's own 20px example is the LOUD one: it emits a bare
+// `20px` the gate catches under no-bare-units and unverifiable-dimension.
+test('an enclosing group is not shadowed where the shadowed output would compile', () => {
+  const out = preprocess({
+    text: {
+      $type: 'dimension',
+      sm: { $value: '1.25', $type: 'number', lineHeight: { $value: '1.5' } },
+    },
+  });
+  assert.equal('$type' in out.text.smLineHeight, false);
+});
+
+test('an enclosing group wins even where its $type suits the child badly', () => {
+  const out = preprocess({
+    g: {
+      $type: 'color',
+      a: { $value: '#fff', $type: 'dimension', b: { $value: '2px' } },
+    },
+  });
+  assert.equal('$type' in out.g.aB, false);
+});
+
+// Depth-first, so b hoists to a and then a's children hoist to g. The frame
+// that decides b's carry has a as its node, and a is a dual node — the guard
+// has to look through it to g, or the two-level case keeps the shadowing the
+// single-level case just lost.
+test('the group guard reaches a child hoisted through two levels', () => {
+  const out = preprocess({
+    text: {
+      $type: 'dimension',
+      sm: {
+        $value: '#fff',
+        $type: 'color',
+        lineHeight: { $value: '20px', tight: { $value: '18px' } },
+      },
+    },
+  });
+  assert.equal('$type' in out.text.smLineHeight, false);
+  assert.equal('$type' in out.text.smLineHeightTight, false);
+});
+
+// A group with no $type of its own is not a supplier; the chain continues past
+// it. Without this the guard could read "has an enclosing group" rather than
+// "an enclosing group supplies a type" and suppress every carry one level down.
+test('an untyped enclosing group does not suppress the carry', () => {
+  const out = preprocess({
+    text: { sm: { $value: '14px', $type: 'dimension', lineHeight: { $value: '20px' } } },
+  });
+  assert.equal(out.text.smLineHeight.$type, 'dimension');
+});
+
+// $type at the file root is a group's, per DTCG 5.2.2 — the root object is a
+// group like any other.
+test('a root $type suppresses the carry', () => {
+  const out = preprocess({
+    $type: 'dimension',
+    sm: { $value: '#fff', $type: 'color', lineHeight: { $value: '20px' } },
+  });
+  assert.equal('$type' in out.smLineHeight, false);
+});
+
 // Depth-first recursion means the inner hoist completes first, so lineHeightTight
 // is a direct child of sm by the time sm hoists. This is the test that catches a
 // $type carry running in the wrong recursion frame — every single-level test


### PR DESCRIPTION
Closes #60.

`hoistDualNodes` carries a dual node's `$type` onto an untyped child to replace the ancestry the hoist costs it. Where an enclosing **group** already supplies a type, nothing was lost — DTCG §5.2.2 inherits from the closest parent *group*, and §6.1 makes a node carrying a `$value` a token — so the carry shadowed a type that was already correct.

## The change

One value per frame, threaded through the recursion:

```js
const inherited = '$value' in node ? groupType : (node.$type ?? groupType);
```

Looking through `$value`-bearing nodes is what makes a dual node a non-source. The same value serves both the descent and the carry guard, because a hoisted child lands as a member of the frame it is computed for — and that also covers the nested case, where the child hoists past the intervening dual node on the next frame up anyway.

Revision 4 of the spec declined this fix on the grounds that it "means threading the ancestor group chain through the recursion." It does. The chain is one expression.

## The issue's severity claim is wrong, and the correction is the interesting part

#60 says this case "turns right into wrong rather than loud into silent." Built end-to-end through Style Dictionary rather than read off a `preprocess` tree, that is false for the very example it uses:

| input child | on `main` | `tokens:validate-output` | this branch |
|---|---|---|---|
| `20px`, group `dimension`, dual node `color` | `val textSmLineHeight = 20px` — does not compile | **caught**: `no-bare-units`, `unverifiable-dimension` | `20.00.dp` |
| `1.5`, group `dimension`, dual node `number` | `val textSmLineHeight = 1.5` — a `Double` where a `Dp` belongs, compiles | **clean** | `1.50.dp` |

The silent case is the *unitless* one. That is the same `BARE_UNIT` asymmetry the spec documents two paragraphs above the claim — it establishes that the gate fires only on unit-suffixed literals, then picks an example on the other side of the line. Both rows now have a test.

## Verification

- **353 tests**, six gates green. Six new tests; four failed before the fix, and one is a positive control that passes on both sides (an *untyped* enclosing group must not suppress the carry).
- **e2e against zygarden's real 322-token source: byte-identical to `main`**, 195 declarations / 39 `.sp` / 50 `.dp`. Stated as a falsifiable prediction before the code was written — the shape needs a dual node typed differently from both its enclosing group and its own child, which zygarden does not contain.
- The gate rows above were re-run directly against `validate()`; the emitted `val …` strings were measured through a Style Dictionary 4.4.0 build harness and are **not** pinned by the suite. Worth naming, in a change whose whole complaint is about reading severity off the wrong layer.

## Review findings, applied

A critic review returned ready-to-merge with three claims stated wider than they hold, all now fixed in `ad97c06`:

- **The transparency invariant was overstated.** "A child ends with the type DTCG inheritance gives it in the authored tree" is false precisely when the carry fires, and false again where the hoisted node is a *group* — the carry types the group and every token beneath inherits a type the source never supplied. What holds is narrower: the hoist never *changes* a type inheritance already determines; where it determines none, the carry supplies the dual node's as a repair. The group case is pre-existing and out of scope; filed as #67.
- **The spec's `main`/`HEAD` transcript had been inverted by #59 merging.** Now pinned to `698a236` with the #59 and #60 rows named.
- **"Both rows are now tests" overstated** what the suite pins. Corrected.

## Also updated

`references/native-adapter-config.md` regenerated. `CHANGELOG.md`'s #55 entry drops its third accepted cost, since it is no longer accepted. Spec amended to revision 5.
