### PR TITLE
fix: a unitless value is a ratio, not a measurement (#52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,31 @@ to [Semantic Versioning](https://semver.org).
   `var(` (e.g. `"width: calc(100% - 2rem)"`) — a value the grammar accepts as
   a literal is not foreign syntax, whatever text it contains, and this
   previously false-failed a build that compiles.
+- **A unitless value no longer emits with an invented unit.** `leading.normal:
+  "1.5"` typed `dimension` emitted `1.50.dp` on Compose and `CGFloat(1.50)` on
+  Swift — the magnitude faithful, the unit meaningless. DTCG §8.2.1 requires a
+  dimension to carry a unit and §8.7's `number` is the type for a ratio, so this
+  is malformed input rather than a shape to interpret. No size transform now
+  claims a unitless value; it emits bare, which is byte-for-byte what a
+  correctly typed `number` already produced on both platforms, so correcting a
+  source's `$type` changes no output. `tokens:validate-output` reports it as a
+  `unitless-dimension` advisory, which does not gate.
+
+### Changed
+- **A dimension whose unit was omitted by mistake now fails loudly instead of
+  working by accident.** `spacing.gutter: "16"` meant as `16px` previously
+  emitted `16.00.dp`, correct only because px and dp map 1:1 by convention. It
+  now emits bare `16`, which does not compile at a Compose `Dp` use site and
+  infers `Int` in Swift, where it will not convert at a `CGFloat` use site. A
+  unitless `0` is affected identically — DTCG §8.2.1 requires the unit "even if
+  `$value.value` is `0`". Add the unit, or type the token `number` if it really
+  is a ratio.
+- **The `nativeUnit` override no longer applies to a unitless value.** It
+  chooses between `dp` and `sp` for a value that has a unit; it does not
+  manufacture one. A source that stamped `nativeUnit: "text"` onto a unitless
+  token previously got `1.50.sp` — which compiles and renders 1.5sp text — and
+  now gets the bare value. This narrows the "a source that states the role
+  itself wins" contract introduced in 0.15.0.
 
 ## [0.15.0] — 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,13 @@ to [Semantic Versioning](https://semver.org).
   token previously got `1.50.sp` — which compiles and renders 1.5sp text — and
   now gets the bare value. This narrows the "a source that states the role
   itself wins" contract introduced in 0.15.0.
+- **A unitless dimension authored in leading-dot form (`".5"`) now emits a
+  bare `.5`, which does not compile on either platform** — it is not a valid
+  float literal in Kotlin or Swift. Previously it emitted `0.50.dp` and
+  compiled. `tokens:validate-output` does not catch it: the shared native
+  literal grammar's `NUMBER` already accepts a leading dot, a pre-existing gap
+  that a unitless `$type: number` value hit before this change and that
+  `invalid-literal` has never closed. Known gap, not fixed here.
 
 ## [0.15.0] — 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,9 @@ to [Semantic Versioning](https://semver.org).
     which **defeats the user's font-scale accessibility setting**. It
     previously emitted a bare literal that `tokens:validate-output` caught
     loudly; that gate no longer fires on it.
-  - An untyped unitless child now emits as a `dimension` — a ratio rendered in
-    density-independent pixels. Also previously caught loudly.
+  - An untyped unitless child now emits as a `dimension` — a ratio. It emitted
+    in density-independent pixels until the unitless-dimension fix below made
+    it emit bare instead. Also previously caught loudly.
   - Where an enclosing *group* carries a `$type` that correctly describes the
     child, the dual node's type shadowed it, so a token that resolved
     correctly before resolved wrongly. **Fixed below**; it is listed here
@@ -72,9 +73,11 @@ to [Semantic Versioning](https://semver.org).
   `val textSmLineHeight = 20px` (does not compile, and
   `tokens:validate-output` caught it) for a `px` child, and
   `val textSmLineHeight = 1.5` — a `Double` where a `Dp` belongs, compiling
-  and passing the gate clean — for a unitless one. Both now emit `.dp`. Output
-  against a real 322-token source is byte-identical: the shape requires a dual
-  node typed differently from both its enclosing group and its own child.
+  and passing the gate clean — for a unitless one. The `px` child now emits
+  `.dp`; the unitless one now emits bare instead, per the unitless-dimension
+  fix below. Output against a real 322-token source is byte-identical: the
+  shape requires a dual node typed differently from both its enclosing group
+  and its own child.
 - **`no-foreign-syntax` reconciled with the native output filter.** An
   unrescued `calc(...)`, `var(...)`, or `color-mix(...)` variant was
   previously dropped from native output by `sd-native.mjs`'s filter before

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,9 @@ to [Semantic Versioning](https://semver.org).
   set it to `"device"` to opt a token out. The `$type` check reads the token's
   own key, so a dual-node child that carries no `$type` of its own — and would
   inherit `dimension` from its parent during hoisting — is not stamped and
-  still emits `dp`. Three limits remain and are documented: a bare scale
+  still emits `dp`. Two limits remain and are documented: a bare scale
   primitive (`text.base`) carries no role and stays
-  `dp`, an `em` letterSpacing is still filtered out of native output, and a
-  unitless ratio still emits as `dp` — deliberately, since `1.50.sp` would
-  compile and render 1.5sp text.
+  `dp`, and an `em` letterSpacing is still filtered out of native output.
 - **`preprocess` throws on a dual-node hoist collision instead of silently
   discarding a token.** `hoistDualNodes` renames a dual node's child to a
   camel-joined sibling (`text.sm.lineHeight` becomes `text.smLineHeight`).

--- a/docs/superpowers/notes/2026-08-26-unitless-dimension-e2e.md
+++ b/docs/superpowers/notes/2026-08-26-unitless-dimension-e2e.md
@@ -1,0 +1,240 @@
+# unitless-dimension (#52) — e2e proof against zygarden
+
+**Date:** 2026-08-26
+**Gate for:** Task 5 of the `#52` plan — end-to-end verification of Tasks 1-4
+(unitless `dimension` values no longer get a size unit; the emitter infers
+`Int`/`Double`/`CGFloat` from the literal; the validator reports an advisory,
+not a gate failure).
+**Verdict:** PASS against spec §7's stated prediction, on every particular.
+`diff -r` between a build at this branch's HEAD and a build at `main`
+(pre-`#52`) shows exactly 5 changed lines in `Tokens.kt` and exactly 5 in
+`Tokens.swift`, all `leading*`, all `N.dp`/`CGFloat(N)` collapsing to bare
+`N`, `leadingLoose` emitting `2` not `2.00`, no other line differing. The
+validator exits 0 on both platforms at HEAD, each reporting 5
+`unitless-dimension` advisories naming the same five `leading*` tokens.
+
+## Why this run exists
+
+Spec §7 made a falsifiable, numeric prediction about what Tasks 1-4 do to a
+real 322-token design system: 195 declarations unchanged, `.sp` count
+unchanged at 39, `.dp` count dropping from 50 to 45 (5 tokens losing their
+unit), and exactly those 5 lines changing in each native output file. This
+run builds the same real source at both commits and checks the prediction
+against actual bytes, not against the reasoning that produced it.
+
+## Harness
+
+Reused, not rebuilt from scratch — live at the time this task started:
+
+```
+/private/tmp/claude-501/-Users-jordansstudio-Dev-throughline/395cf4ed-9e55-4c18-a73d-e9980db4545c/scratchpad/e2e
+```
+
+- **Style Dictionary:** `4.4.0`, installed in the scratch directory.
+- **Source:** the 15 zygarden JSON files in `../tokens` (the harness's parent
+  scratchpad directory), extracted from zygarden-frontend in prior work. Not
+  re-extracted; the zygarden repo was not touched.
+- **`build.mjs`:** takes a token dir and an output dir as CLI args, builds
+  `android-kotlin` and `ios-swift` flat into that output dir (no light/dark
+  axis in this version of the harness — it was rewritten since the
+  `#55`/`#60` runs), `packageName: 'com.zygarden.tokens'` for Kotlin.
+  Unmodified.
+- **`run.sh`:** runs `build.mjs`, then `cd`s into
+  `/Users/jordansstudio/Dev/throughline` (this checkout, on
+  `fix/52-unitless-dimension`) and runs the repo's real
+  `scripts/validate-token-output.mjs` against the built files, then prints a
+  `declarations | .sp | .dp` count line via `grep -c` on the output file.
+
+### A correction to the brief's stated wiring
+
+The brief (and the task that set up this harness) describes swapping
+`<harness>/scripts/lib` to retarget the code `build.mjs` compiles against.
+That symlink exists and does point at
+`/Users/jordansstudio/Dev/throughline/scripts/lib`, but `build.mjs` does not
+import from it — it imports from `./lib/sd-native.mjs`, a *separate*
+top-level `<harness>/lib/` directory of three per-file symlinks
+(`dtcg.mjs`, `native-literal.mjs`, `sd-native.mjs`). `run.sh` also always
+`cd`s into the real repo checkout to run the validator, regardless of either
+symlink — so the validator step is pinned to whatever branch this checkout
+has out (`fix/52-unitless-dimension` throughout this run).
+
+Repointing only `scripts/lib` to the `main` worktree (as the brief's Step 3
+literally says) is a no-op: the build phase still reads the unchanged
+top-level `lib/`, so a "main" build under that instruction is byte-identical
+to the HEAD build, not because the fix has no effect, but because the swap
+never touched the module `build.mjs` actually loads. This was caught by
+running the intended swap and observing the "main" build still contained the
+`#52` fix (bare `leadingLoose = 2`, not `2.00.dp`) — the wrong result for a
+build claiming to be pre-fix. The three symlinks under `<harness>/lib/` were
+repointed instead, which produced the expected pre-fix output
+(`leadingLoose = 2.00.dp` / `CGFloat(2.00)`), and were restored afterward
+alongside `scripts/lib`.
+
+## Procedure
+
+1. Build at HEAD (`5cff43b`) — output to `out-52-head/`.
+2. `git worktree add /tmp/tl-main main` (`main` = `4025ac5`).
+3. Repoint `<harness>/lib/{dtcg,native-literal,sd-native}.mjs` to
+   `/tmp/tl-main/scripts/lib/*` (see correction above), rebuild — output to
+   `out-52-main/`.
+4. `diff -r out-52-main out-52-head`.
+5. Repoint `<harness>/lib/*` and `<harness>/scripts/lib` back to
+   `/Users/jordansstudio/Dev/throughline/scripts/lib`, `git worktree remove
+   /tmp/tl-main`.
+6. Re-run `out-52-head` once more and read the validator output in full, to
+   confirm the advisory list.
+
+### Step 1 — build at HEAD
+
+```
+$ bash run.sh out-52-head
+--- kotlin
+tokens:validate-output — 195/195 emitted symbols matched a source token (100%)
+
+5 advisory note(s) — reported, not gating:
+  - [unitless-dimension] leadingLoose: source "2" for leading.loose is a dimension with no unit, which DTCG §8.2.1 does not permit. It emitted 2, read as a ratio. If it is a ratio, type it "number" (§8.7); if it is a measurement, add the unit you meant.
+  - [unitless-dimension] leadingNormal: source "1.5" for leading.normal is a dimension with no unit, which DTCG §8.2.1 does not permit. It emitted 1.5, read as a ratio. If it is a ratio, type it "number" (§8.7); if it is a measurement, add the unit you meant.
+  - [unitless-dimension] leadingRelaxed: source "1.7" for leading.relaxed is a dimension with no unit, which DTCG §8.2.1 does not permit. It emitted 1.7, read as a ratio. If it is a ratio, type it "number" (§8.7); if it is a measurement, add the unit you meant.
+  - [unitless-dimension] leadingSnug: source "1.25" for leading.snug is a dimension with no unit, which DTCG §8.2.1 does not permit. It emitted 1.25, read as a ratio. If it is a ratio, type it "number" (§8.7); if it is a measurement, add the unit you meant.
+  - [unitless-dimension] leadingTight: source "1.1" for leading.tight is a dimension with no unit, which DTCG §8.2.1 does not permit. It emitted 1.1, read as a ratio. If it is a ratio, type it "number" (§8.7); if it is a measurement, add the unit you meant.
+
+19 source token(s) had no matching emitted symbol.
+exit=0
+--- swift
+tokens:validate-output — 195/195 emitted symbols matched a source token (100%)
+
+5 advisory note(s) — reported, not gating:
+  - [unitless-dimension] leadingLoose: source "2" for leading.loose is a dimension with no unit, which DTCG §8.2.1 does not permit. It emitted 2, read as a ratio. If it is a ratio, type it "number" (§8.7); if it is a measurement, add the unit you meant.
+  - [unitless-dimension] leadingNormal: source "1.5" for leading.normal is a dimension with no unit, which DTCG §8.2.1 does not permit. It emitted 1.5, read as a ratio. If it is a ratio, type it "number" (§8.7); if it is a measurement, add the unit you meant.
+  - [unitless-dimension] leadingRelaxed: source "1.7" for leading.relaxed is a dimension with no unit, which DTCG §8.2.1 does not permit. It emitted 1.7, read as a ratio. If it is a ratio, type it "number" (§8.7); if it is a measurement, add the unit you meant.
+  - [unitless-dimension] leadingSnug: source "1.25" for leading.snug is a dimension with no unit, which DTCG §8.2.1 does not permit. It emitted 1.25, read as a ratio. If it is a ratio, type it "number" (§8.7); if it is a measurement, add the unit you meant.
+  - [unitless-dimension] leadingTight: source "1.1" for leading.tight is a dimension with no unit, which DTCG §8.2.1 does not permit. It emitted 1.1, read as a ratio. If it is a ratio, type it "number" (§8.7); if it is a measurement, add the unit you meant.
+
+19 source token(s) had no matching emitted symbol.
+exit=0
+--- counts
+declarations 195 | .sp 39 | .dp 45
+```
+
+### Step 2-3 — build at `main`, in a throwaway worktree
+
+```
+$ git worktree add /tmp/tl-main main
+Preparing worktree (checking out 'main')
+HEAD is now at 4025ac5 fix: an enclosing group's $type is no longer shadowed by a dual node's (#60) (#68)
+
+$ ln -sfn /tmp/tl-main/scripts/lib/dtcg.mjs lib/dtcg.mjs
+$ ln -sfn /tmp/tl-main/scripts/lib/native-literal.mjs lib/native-literal.mjs
+$ ln -sfn /tmp/tl-main/scripts/lib/sd-native.mjs lib/sd-native.mjs
+
+$ bash run.sh out-52-main
+--- kotlin
+tokens:validate-output — 195/195 emitted symbols matched a source token (100%)
+
+5 advisory note(s) — reported, not gating:
+  - [unitless-dimension] leadingLoose: source "2" for leading.loose is a dimension with no unit, which DTCG §8.2.1 does not permit. It emitted 2.00.dp, read as a ratio. If it is a ratio, type it "number" (§8.7); if it is a measurement, add the unit you meant.
+  - [unitless-dimension] leadingNormal: source "1.5" for leading.normal is a dimension with no unit, which DTCG §8.2.1 does not permit. It emitted 1.50.dp, read as a ratio. If it is a ratio, type it "number" (§8.7); if it is a measurement, add the unit you meant.
+  - [unitless-dimension] leadingRelaxed: source "1.7" for leading.relaxed is a dimension with no unit, which DTCG §8.2.1 does not permit. It emitted 1.70.dp, read as a ratio. If it is a ratio, type it "number" (§8.7); if it is a measurement, add the unit you meant.
+  - [unitless-dimension] leadingSnug: source "1.25" for leading.snug is a dimension with no unit, which DTCG §8.2.1 does not permit. It emitted 1.25.dp, read as a ratio. If it is a ratio, type it "number" (§8.7); if it is a measurement, add the unit you meant.
+  - [unitless-dimension] leadingTight: source "1.1" for leading.tight is a dimension with no unit, which DTCG §8.2.1 does not permit. It emitted 1.10.dp, read as a ratio. If it is a ratio, type it "number" (§8.7); if it is a measurement, add the unit you meant.
+
+19 source token(s) had no matching emitted symbol.
+exit=0
+--- swift
+tokens:validate-output — 195/195 emitted symbols matched a source token (100%)
+
+5 advisory note(s) — reported, not gating:
+  - [unitless-dimension] leadingLoose: source "2" for leading.loose is a dimension with no unit, which DTCG §8.2.1 does not permit. It emitted CGFloat(2.00), read as a ratio. If it is a ratio, type it "number" (§8.7); if it is a measurement, add the unit you meant.
+  - [unitless-dimension] leadingNormal: source "1.5" for leading.normal is a dimension with no unit, which DTCG §8.2.1 does not permit. It emitted CGFloat(1.50), read as a ratio. If it is a ratio, type it "number" (§8.7); if it is a measurement, add the unit you meant.
+  - [unitless-dimension] leadingRelaxed: source "1.7" for leading.relaxed is a dimension with no unit, which DTCG §8.2.1 does not permit. It emitted CGFloat(1.70), read as a ratio. If it is a ratio, type it "number" (§8.7); if it is a measurement, add the unit you meant.
+  - [unitless-dimension] leadingSnug: source "1.25" for leading.snug is a dimension with no unit, which DTCG §8.2.1 does not permit. It emitted CGFloat(1.25), read as a ratio. If it is a ratio, type it "number" (§8.7); if it is a measurement, add the unit you meant.
+  - [unitless-dimension] leadingTight: source "1.1" for leading.tight is a dimension with no unit, which DTCG §8.2.1 does not permit. It emitted CGFloat(1.10), read as a ratio. If it is a ratio, type it "number" (§8.7); if it is a measurement, add the unit you meant.
+
+19 source token(s) had no matching emitted symbol.
+exit=0
+--- counts
+declarations 195 | .sp 39 | .dp 50
+```
+
+Note: the validator output above still comes from HEAD's `validate-token-output.mjs`
+(the checkout it runs from was never repointed — see the correction above),
+so it still reports the advisory even against `main`'s unit-suffixed output.
+That is a property of the validator being source-type-driven, not
+literal-format-driven, and does not affect the count line, which is a
+`grep -c` over the built file's own bytes.
+
+### Step 4 — diff
+
+```
+$ diff -r out-52-main out-52-head
+diff -r out-52-main/Tokens.kt out-52-head/Tokens.kt
+87,91c87,91
+<   val leadingLoose = 2.00.dp
+<   val leadingNormal = 1.50.dp
+<   val leadingRelaxed = 1.70.dp
+<   val leadingSnug = 1.25.dp
+<   val leadingTight = 1.10.dp
+---
+>   val leadingLoose = 2
+>   val leadingNormal = 1.5
+>   val leadingRelaxed = 1.7
+>   val leadingSnug = 1.25
+>   val leadingTight = 1.1
+diff -r out-52-main/Tokens.swift out-52-head/Tokens.swift
+86,90c86,90
+<     public static let leadingLoose = CGFloat(2.00)
+<     public static let leadingNormal = CGFloat(1.50)
+<     public static let leadingRelaxed = CGFloat(1.70)
+<     public static let leadingSnug = CGFloat(1.25)
+<     public static let leadingTight = CGFloat(1.10)
+---
+>     public static let leadingLoose = 2
+>     public static let leadingNormal = 1.5
+>     public static let leadingRelaxed = 1.7
+>     public static let leadingSnug = 1.25
+>     public static let leadingTight = 1.1
+```
+
+Exactly 5 changed lines per file, all `leading*`, all `N.dp`/`CGFloat(N)`
+collapsing to bare `N`, `leadingLoose` bare `2` not `2.00`. No other line in
+either file differs.
+
+### Step 5 — restore, remove worktree
+
+```
+$ ln -sfn /Users/jordansstudio/Dev/throughline/scripts/lib/dtcg.mjs lib/dtcg.mjs
+$ ln -sfn /Users/jordansstudio/Dev/throughline/scripts/lib/native-literal.mjs lib/native-literal.mjs
+$ ln -sfn /Users/jordansstudio/Dev/throughline/scripts/lib/sd-native.mjs lib/sd-native.mjs
+$ ln -sfn /Users/jordansstudio/Dev/throughline/scripts/lib scripts/lib
+$ git worktree remove /tmp/tl-main
+$ git worktree list
+/Users/jordansstudio/Dev/throughline  5cff43b [fix/52-unitless-dimension]
+```
+
+## Prediction vs. actual (spec §7)
+
+| Prediction | Actual |
+|---|---|
+| 195 declarations unchanged | 195 at both HEAD and `main` — match |
+| `.sp` stays 39 | 39 at both — match |
+| `.dp` goes 50 → 45 | 50 at `main`, 45 at HEAD — match |
+| exactly 5 changed lines in `Tokens.kt`, all `leading*` | 5 lines, `leadingTight/Snug/Normal/Relaxed/Loose` — match |
+| exactly 5 changed lines in `Tokens.swift`, all `leading*` | 5 lines, same five — match |
+| every other line byte-identical | confirmed by `diff -r` — match |
+| validator exits 0 both platforms | exit 0 on both at HEAD — match |
+| 5 `unitless-dimension` advisories each, naming `leading*` | 5 advisories each, all `leading*` — match |
+| `leadingLoose` emits `2`, not `2.00` | confirmed in both `Tokens.kt` and `Tokens.swift` — match |
+
+Every clause of the prediction held. Nothing was adjusted to fit.
+
+## What this run does NOT establish
+
+- **Nothing was compiled.** No `swiftc` or `kotlinc` ran; the declaration and
+  `.sp`/`.dp` counts are `grep`-based, and the advisory/diff checks are
+  textual, not a compiler's verdict on whether the bare `Int`/`Double`
+  literals actually satisfy whatever consumes them downstream.
+- **The harness's `scripts/lib` symlink is unused by this build path.** It
+  was left pointed at the live repo throughout (as found), but `build.mjs`
+  never reads it — see the correction above. Anyone reusing this harness for
+  a future differential build should repoint `<harness>/lib/*`, not
+  `<harness>/scripts/lib`.

--- a/docs/superpowers/plans/2026-08-26-unitless-dimension.md
+++ b/docs/superpowers/plans/2026-08-26-unitless-dimension.md
@@ -660,7 +660,7 @@ byte-for-byte what a correctly typed \`number\` already produced, so correcting
 the source's \`$type\` changes no output. \`tokens:validate-output\` reports it as
 a \`unitless-dimension\` advisory, which does not gate — the emitted value is
 right under the ratio reading, and only the author can say whether a ratio is
-what was meant.\`],
+what was meant.`],
 ```
 
 - [ ] **Step 2: Regenerate and verify**

--- a/docs/superpowers/plans/2026-08-26-unitless-dimension.md
+++ b/docs/superpowers/plans/2026-08-26-unitless-dimension.md
@@ -1,0 +1,830 @@
+# Unitless Dimensions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A unitless value is no longer claimed by any native size transform, so
+it emits bare — the correct native form for a ratio — and `tokens:validate-output`
+reports it as an advisory rather than passing it silently.
+
+**Architecture:** One predicate (`isRatio`) added to `scripts/lib/sd-native.mjs`
+and ANDed into the three size transforms' filters. One additive helper
+(`flattenDtcgTypes`) in `scripts/lib/dtcg.mjs` giving the validator the `$type`
+that `flattenDtcg` drops. One advisory rule in `scripts/validate-token-output.mjs`
+that consumes it. No existing helper is narrowed or re-signatured.
+
+**Tech Stack:** Node 20+ ESM, zero runtime dependencies, `node:test` +
+`node:assert/strict`. Style Dictionary 4.4.0 is a *parameter*, never an import.
+
+**Spec:** `docs/superpowers/specs/2026-08-26-unitless-dimension-design.md` — read
+it before starting. The plan argues from it and does not restate its reasoning.
+
+## Global Constraints
+
+- **Branch:** `fix/52-unitless-dimension`, already created off `main`. Do not
+  create another. Do not rebase.
+- **Zero dependencies in `scripts/lib/`.** These files install into a user's
+  `packages/tokens/scripts/`. Never add an import of `style-dictionary`.
+- **`magnitude()` must not change.** Spec §5.1. It is correct as written, and
+  changing it would put it in conflict with the validator's `expectedMagnitude`.
+- **`flattenDtcg`'s signature and return shape must not change.** Spec §6.2. It
+  has four consumers and both validators re-export it.
+- **Regenerate the config doc in the same task as any change to
+  `scripts/lib/sd-native.mjs`**, never at the end of the branch. The doc inlines
+  the module's whole body, so *any* edit to that file — code or comment — makes
+  `node scripts/build-native-adapter-config.mjs --check` fail until regenerated.
+- **Full suite green before every commit:** `node --test` (353 tests at branch
+  point).
+- **Do not touch `~/Dev/zygarden-frontend`.** It is read-only source material,
+  read with `git show <branch>:<path>`.
+- Commit message trailers, on every commit:
+  ```
+  Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_018etbNQyHfuuGWwmd88T8Zm
+  ```
+
+---
+
+## File Structure
+
+| File | Responsibility | Task |
+|---|---|---|
+| `scripts/lib/dtcg.mjs` | add `flattenDtcgTypes` — effective `$type` per dot-path | 1 |
+| `scripts/lib/dtcg.test.mjs` | tests for the above | 1 |
+| `scripts/lib/sd-native.mjs` | add `isRatio`; AND it into 3 filters; correct 3 comments | 2 |
+| `scripts/lib/sd-native.test.mjs` | filter tests, both invariant tests, zero regression | 2 |
+| `references/native-adapter-config.md` | GENERATED — regenerate, never hand-edit | 2, 4 |
+| `scripts/validate-token-output.mjs` | `unitless-dimension` advisory + report line | 3 |
+| `scripts/validate-token-output.test.mjs` | tests for the advisory | 3 |
+| `scripts/build-native-adapter-config.mjs` | generator prose: three limits become two | 4 |
+| `CHANGELOG.md` | two `Unreleased` entries | 4 |
+| `docs/superpowers/notes/2026-08-26-unitless-dimension-e2e.md` | e2e evidence | 5 |
+
+---
+
+### Task 1: `flattenDtcgTypes`
+
+Gives the validator the `$type` that `flattenDtcg` drops, without touching
+`flattenDtcg`. Spec §6.2.
+
+**Files:**
+- Modify: `scripts/lib/dtcg.mjs` (append after `flattenDtcg`, before `resolveValue`)
+- Test: `scripts/lib/dtcg.test.mjs`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `flattenDtcgTypes(obj, prefix = [], out = {}, groupType = undefined) -> Record<string, string|undefined>`
+  — maps dot-path to effective `$type`. Task 3 imports it.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/lib/dtcg.test.mjs`. Note the existing module-level `dtcg`
+fixture at the top of that file is reused by the first test.
+
+```js
+test('flattenDtcgTypes reports a token own $type', () => {
+  const types = flattenDtcgTypes(dtcg);
+  assert.equal(types['text.sm'], 'dimension');
+  assert.equal(types['color.gray.900'], 'color');
+});
+
+test('flattenDtcgTypes inherits from the nearest ancestor group', () => {
+  const types = flattenDtcgTypes({
+    leading: { $type: 'dimension', normal: { $value: '1.5' } },
+  });
+  assert.equal(types['leading.normal'], 'dimension');
+});
+
+// DTCG 6.1: a node carrying a $value is a token, not a group, so it is not an
+// inheritance source. The same rule hoistDualNodes computes as `inherited`.
+test('flattenDtcgTypes does not inherit from a $value-bearing node', () => {
+  const types = flattenDtcgTypes({
+    text: { sm: { $value: '14px', $type: 'dimension', lineHeight: { $value: '20px' } } },
+  });
+  assert.equal(types['text.sm'], 'dimension');
+  assert.equal(types['text.sm.lineHeight'], undefined);
+});
+
+test('flattenDtcgTypes keeps an enclosing group type across a dual node', () => {
+  const types = flattenDtcgTypes({
+    text: { $type: 'dimension', sm: { $value: '14px', lineHeight: { $value: '20px' } } },
+  });
+  assert.equal(types['text.sm.lineHeight'], 'dimension');
+});
+
+test('flattenDtcgTypes lets an own $type beat an inherited one', () => {
+  const types = flattenDtcgTypes({
+    g: { $type: 'dimension', a: { $value: '400', $type: 'fontWeight' } },
+  });
+  assert.equal(types['g.a'], 'fontWeight');
+});
+
+test('flattenDtcgTypes returns undefined where nothing supplies a type', () => {
+  const types = flattenDtcgTypes({ g: { a: { $value: '1.5' } } });
+  assert.equal(types['g.a'], undefined);
+});
+```
+
+Add `flattenDtcgTypes` to the import at the top of the file:
+
+```js
+import { flattenDtcg, flattenDtcgTypes, resolveValue, findModeCollisions } from './dtcg.mjs';
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `node --test scripts/lib/dtcg.test.mjs`
+Expected: FAIL — `flattenDtcgTypes is not a function`.
+
+- [ ] **Step 3: Implement**
+
+Insert into `scripts/lib/dtcg.mjs` immediately after `flattenDtcg`:
+
+```js
+// Flatten nested DTCG groups into { "dot.path": effectiveType }, applying the
+// $type resolution of DTCG 5.2.2: a token's own $type wins, otherwise the
+// nearest ancestor GROUP's. A node carrying a $value is a token, not a group
+// (DTCG 6.1), so it is not an inheritance source for its children — the same
+// rule hoistDualNodes computes as `inherited`, and the two must agree or two
+// functions in this codebase disagree about the type of the same tree.
+//
+// Separate from flattenDtcg rather than folded into it: that function has four
+// consumers and both validators re-export it, so its return shape is fixed.
+//
+// LIMIT, stated rather than hidden: this reads the RAW source, so it cannot see
+// the $type carry hoistDualNodes applies during preprocessing. An untyped child
+// of a dimension-typed dual node with no enclosing group type is a dimension to
+// the pipeline and undefined here. Reference-derived typing (5.2.2 rule 1) is
+// likewise not resolved — an alias is undefined, but its referent is typed, and
+// the referent is the token an author edits.
+export function flattenDtcgTypes(obj, prefix = [], out = {}, groupType = undefined) {
+  const inherited = '$value' in obj ? groupType : (obj.$type ?? groupType);
+  for (const [key, val] of Object.entries(obj)) {
+    if (key.startsWith('$')) continue;
+    if (!val || typeof val !== 'object') continue;
+    const path = [...prefix, key];
+    if ('$value' in val) out[path.join('.')] = val.$type ?? inherited;
+    flattenDtcgTypes(val, path, out, inherited);
+  }
+  return out;
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `node --test scripts/lib/dtcg.test.mjs`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `node --test`
+Expected: PASS, 359 tests (353 + 6).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/lib/dtcg.mjs scripts/lib/dtcg.test.mjs
+git commit -m "feat: flattenDtcgTypes — effective \$type per dot-path (#52)"
+```
+
+---
+
+### Task 2: `isRatio` and the three size-transform filters
+
+The behaviour change. Spec §5.
+
+**Files:**
+- Modify: `scripts/lib/sd-native.mjs` — add `isRatio` near the other predicates
+  (~line 507, beside `isDimension`/`isFontSize`/`hasMagnitude`); amend three
+  filters in `registerNativeTransforms`; correct three comments
+- Modify: `references/native-adapter-config.md` — GENERATED, regenerate only
+- Test: `scripts/lib/sd-native.test.mjs`
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces: no new export. `isRatio` is module-private, matching `isDimension`,
+  `isFontSize`, `hasMagnitude` and `isTextUnit`, which are all private and
+  tested through the registered transforms via the existing `collectTransforms()`
+  helper at `sd-native.test.mjs:314`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/lib/sd-native.test.mjs`. `collectTransforms()` and `stamped()`
+already exist in this file — do not redefine them.
+
+```js
+// #52. DTCG 8.2.1 requires a dimension to carry a unit; 8.7's `number` is the
+// type for a ratio, and 9.8 types lineHeight as one. A unitless value is
+// therefore malformed input, and no size transform may claim it.
+test('no size transform claims a unitless dimension', () => {
+  const t = collectTransforms();
+  const token = { $type: 'dimension', $value: '1.5', original: { $value: '1.5' } };
+  assert.equal(t.get('size/unit-aware/swift').filter(token), false);
+  assert.equal(t.get('size/unit-aware/compose-dp').filter(token), false);
+  assert.equal(t.get('size/unit-aware/compose-sp').filter(token), false);
+});
+
+test('no size transform claims a unitless fontSize', () => {
+  const t = collectTransforms();
+  const token = { $type: 'fontSize', $value: '1.5', original: { $value: '1.5' } };
+  assert.equal(t.get('size/unit-aware/swift').filter(token), false);
+  assert.equal(t.get('size/unit-aware/compose-sp').filter(token), false);
+});
+
+test('a unitless value is read from the ORIGINAL authored value', () => {
+  const t = collectTransforms();
+  const dp = t.get('size/unit-aware/compose-dp');
+  // $value rewritten by an earlier transform; original is what decides.
+  assert.equal(dp.filter({ $type: 'dimension', $value: '1.50.dp', original: { $value: '1.5' } }), false);
+  assert.equal(dp.filter({ $type: 'dimension', $value: '1.5', original: { $value: '16px' } }), true);
+});
+
+test('a united dimension is still claimed', () => {
+  const t = collectTransforms();
+  const px = { $type: 'dimension', $value: '16px', original: { $value: '16px' } };
+  assert.equal(t.get('size/unit-aware/compose-dp').filter(px), true);
+  assert.equal(t.get('size/unit-aware/swift').filter(px), true);
+});
+
+// Spec 5.2. The load-bearing claim of the design: taking the advisory's advice
+// ("type it number") must not change output.
+//
+// The SWIFT filter is what carries this — it gates on isDimension || isFontSize
+// and so is the only one of the three sensitive to $type. Measured: drop
+// !isRatio from swift alone and $type dimension emits CGFloat(1.50) while
+// $type number emits bare. Keep swift in this loop or the test stops catching
+// the variant that breaks the design.
+test('a unitless value emits identically as $type dimension and as $type number', () => {
+  const t = collectTransforms();
+  const asDimension = { $type: 'dimension', $value: '1.5', original: { $value: '1.5' } };
+  const asNumber = { $type: 'number', $value: '1.5', original: { $value: '1.5' } };
+  for (const name of ['size/unit-aware/swift', 'size/unit-aware/compose-dp', 'size/unit-aware/compose-sp']) {
+    const tr = t.get(name);
+    assert.equal(tr.filter(asDimension), tr.filter(asNumber), `${name} must treat both $types alike`);
+    assert.equal(tr.filter(asDimension), false, `${name} must claim neither`);
+  }
+});
+
+// Spec 5.2. NOT an invariant test, deliberately. The invariant holds whether or
+// not compose-sp carries !isRatio — measured, not assumed — because compose-sp
+// filters on isTextUnit, which reads the stamp rather than $type, so a stamped
+// token behaves the same under both $types either way. Only a direct
+// behavioural assertion catches a missing !isRatio here.
+//
+// What it would emit without the guard: 1.50.sp — 1.5 scale-pixels of text,
+// which is the output #51 gated ABSOLUTE_UNIT to prevent. An explicit stamp
+// must not be able to produce it either.
+test('a stamped unitless token is still declined — the override cannot manufacture a unit', () => {
+  const sp = collectTransforms().get('size/unit-aware/compose-sp');
+  assert.equal(sp.filter(stamped('1.5')), false);
+  assert.equal(sp.filter({ ...stamped('1.5'), $type: 'number' }), false);
+});
+
+// The override's scope, narrowed and pinned: it chooses between dp and sp for a
+// value that HAS a unit. It does not manufacture one.
+test('the nativeUnit override still selects sp for a united value', () => {
+  const sp = collectTransforms().get('size/unit-aware/compose-sp');
+  assert.equal(sp.filter(stamped('30px')), true);
+  assert.equal(sp.transform(stamped('30px')), '30.00.sp');
+});
+
+// Spec 5.4. A unitless zero is invalid DTCG for the same reason (8.2.1 requires
+// the unit "even if $value.value is 0"). Recorded as a test so the behaviour
+// change cannot later be reverted as though it were a bug.
+test('a unitless zero is a ratio, not a zero measurement', () => {
+  const t = collectTransforms();
+  const zero = { $type: 'dimension', $value: '0', original: { $value: '0' } };
+  assert.equal(t.get('size/unit-aware/compose-dp').filter(zero), false);
+  assert.equal(t.get('size/unit-aware/swift').filter(zero), false);
+  // "0px" is a measurement and is unaffected.
+  const zeroPx = { $type: 'dimension', $value: '0px', original: { $value: '0px' } };
+  assert.equal(t.get('size/unit-aware/compose-dp').filter(zeroPx), true);
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `node --test scripts/lib/sd-native.test.mjs`
+Expected: FAIL — the unitless filters currently return `true`.
+
+- [ ] **Step 3: Add the predicate**
+
+In `scripts/lib/sd-native.mjs`, in the `register` doc-section, immediately after
+`const hasMagnitude = (token) => authored(token) !== null;`:
+
+```js
+// A unitless value is a ratio, not a measurement. DTCG 8.2.1 requires a
+// dimension to carry a unit ("still required even if $value.value is 0"), 8.7's
+// `number` is the type for a multiplier, and 9.8 types lineHeight as one — so a
+// unitless dimension is malformed input, and appending dp/sp/CGFloat to it
+// invents a unit the source never stated. Declining it emits the raw value,
+// which is exactly what a correctly typed `number` already produces.
+//
+// Reads the ORIGINAL authored value, like authored(), and must: preprocess has
+// already resolved references by transform time, and a value transform earlier
+// in the chain may have rewritten $value.
+const RATIO = /^-?(?:\d+(?:\.\d+)?|\.\d+)$/;
+const isRatio = (token) => RATIO.test(String(token.original?.$value ?? token.$value).trim());
+```
+
+- [ ] **Step 4: Amend the three filters**
+
+In `registerNativeTransforms`, replace each `filter` line exactly:
+
+```js
+// size/unit-aware/swift
+    filter: (token) => (isDimension(token) || isFontSize(token)) && hasMagnitude(token) && !isRatio(token),
+
+// size/unit-aware/compose-dp
+    filter: (token) => isDimension(token) && !isTextUnit(token) && hasMagnitude(token) && !isRatio(token),
+
+// size/unit-aware/compose-sp
+    filter: (token) => (isTextUnit(token) || isFontSize(token)) && hasMagnitude(token) && !isRatio(token),
+```
+
+All three carry `!isRatio`, but for two different reasons, and conflating them
+is how the earlier draft of the spec went wrong:
+
+- **`swift`** carries the output-neutrality invariant. It is the only one of the
+  three that gates on `$type` (`isDimension || isFontSize`), so dropping
+  `!isRatio` here makes `dimension` emit `CGFloat(1.50)` while `number` emits
+  bare. Measured, not assumed.
+- **`compose-dp`** is the basic fix: without it a unitless dimension still emits
+  `N.dp` on Kotlin.
+- **`compose-sp`** is on the merits, not the invariant. It gates on `isTextUnit`,
+  which reads the stamp rather than `$type`, so it cannot break the invariant
+  either way. Without it a *stamped* unitless token emits `1.50.sp`.
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `node --test scripts/lib/sd-native.test.mjs`
+Expected: PASS.
+
+- [ ] **Step 6: Narrow the partition test's comment**
+
+`scripts/lib/sd-native.test.mjs:1017-1019` claims the dp/sp partition is "disjoint
+AND total". That is no longer total — a unitless dimension matches neither. The
+test itself still passes (its three fixtures all carry units); only the claim is
+now too wide. Replace the comment above `test('no dimension token matches both compose transforms'...)`:
+
+```js
+// The partition must be disjoint AND total FOR A TOKEN THAT CARRIES A UNIT:
+// exactly one of the two filters matches. Asserting `dp && sp === false` alone
+// would pass against an implementation where both always return false, so
+// assert the exclusive-or. A unitless value matches neither, deliberately (#52),
+// and is covered by its own tests rather than folded in here.
+```
+
+- [ ] **Step 7: Correct the three comments the change falsifies**
+
+**7a.** `classifyTextUnits`, the override comment (~line 267). Replace:
+
+```js
+      // A source that states the role itself wins — for a value that HAS a
+      // unit. The override chooses between dp and sp; it does not manufacture
+      // one, so a unitless value is declined by every size transform regardless
+      // of what is stamped here (see isRatio, #52). Declining to overwrite IS
+      // the feature: it costs no configuration parameter, and it is what makes
+      // the pass idempotent.
+```
+
+**7b.** The `ABSOLUTE_UNIT` comment (~line 235). Replace:
+
+```js
+// px and rem only. magnitude() reads a bare number as an unscaled ratio, so a
+// lineHeight authored "1.5" would otherwise be stamped and emit 1.50.sp —
+// which compiles and renders 1.5sp text, trading a loud failure for a silent
+// one. Since #52 a unitless value is declined by every size transform and
+// emits bare, which is what DTCG 8.7 and 9.8 say a ratio is, so this gate is
+// no longer the only thing standing between a ratio and 1.50.sp. It stays
+// because the stamp is also the override's carrier, and stamping a ratio as
+// text would still be a claim the source never made.
+```
+
+**7c.** The `platform` doc-section's limits list (~line 340). Replace the
+`Three limits remain ...` paragraph and its three bullets with:
+
+```js
+// Two limits remain, both Android-only and both measured rather than
+// theoretical — see docs/superpowers/notes/2026-08-21-native-config-e2e-results.md:
+//
+//   - A scale primitive carries no role. text.base: "16px" is a font size only
+//     to a human, so it emits as dp. The semantic tokens referencing it are
+//     correct, and those are what a consumer should reach for.
+//   - An em-valued letterSpacing is filtered out of native output entirely,
+//     rather than emitted as Compose's .em TextUnit.
+//
+// The third — a unitless ratio emitting as dp — is fixed by #52: no size
+// transform claims a unitless value, so it emits bare on both platforms, and
+// tokens:validate-output reports it as a unitless-dimension advisory.
+```
+
+- [ ] **Step 8: Regenerate the config doc**
+
+The doc inlines this module's whole body, so it is stale after any edit above.
+
+Run: `node scripts/build-native-adapter-config.mjs`
+Then: `node scripts/build-native-adapter-config.mjs --check`
+Expected: `--check` exits 0.
+
+- [ ] **Step 9: Run the full suite**
+
+Run: `node --test`
+Expected: PASS. Eight tests added in this task.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add scripts/lib/sd-native.mjs scripts/lib/sd-native.test.mjs references/native-adapter-config.md
+git commit -m "fix: a unitless value is a ratio, so no size transform claims it (#52)"
+```
+
+---
+
+### Task 3: the `unitless-dimension` advisory
+
+Spec §6. Advisory means reported and **excluded from `ok`** — it must not change
+any exit code.
+
+**Files:**
+- Modify: `scripts/validate-token-output.mjs` — import, two constants, a types
+  map, the loop check, the return object, `formatReport`
+- Test: `scripts/validate-token-output.test.mjs`
+
+**Interfaces:**
+- Consumes: `flattenDtcgTypes` from Task 1.
+- Produces: `validate()`'s return object gains `advisories: Array<{rule, symbol, token, source, emitted}>`.
+  `ok` is unchanged and does **not** consider it.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/validate-token-output.test.mjs`. The module-level `SRC`
+fixture at line 127 already contains `leading.tight: "1.1"` typed `dimension`.
+
+```js
+// #52. A unitless dimension is invalid DTCG (8.2.1). The emitted output is
+// correct under the ratio reading, so this is reported and does NOT gate.
+test('unitless-dimension is reported as an advisory', () => {
+  const r = validate({ sources: SRC, output: 'static let leadingTight = 1.1', platform: 'ios-swift' });
+  assert.equal(r.advisories.length, 1);
+  assert.equal(r.advisories[0].rule, 'unitless-dimension');
+  assert.equal(r.advisories[0].token, 'leading.tight');
+});
+
+test('unitless-dimension does not fail the gate', () => {
+  const r = validate({ sources: SRC, output: 'static let leadingTight = 1.1', platform: 'ios-swift' });
+  assert.deepEqual(r.failures, []);
+  assert.equal(r.ok, true);
+});
+
+test('unitless-dimension ignores a unitless non-dimension', () => {
+  const sources = [{ file: 't.json', dtcg: {
+    w: { bold: { $value: '700', $type: 'fontWeight' } },
+    ratio: { golden: { $value: '1.618', $type: 'number' } },
+  } }];
+  const r = validate({ sources, output: 'static let wBold = 700\nstatic let ratioGolden = 1.618', platform: 'ios-swift' });
+  assert.deepEqual(r.advisories, []);
+  assert.equal(r.ok, true);
+});
+
+test('unitless-dimension ignores a dimension that carries a unit', () => {
+  const r = validate({ sources: SRC, output: 'static let textSm = CGFloat(14.00)', platform: 'ios-swift' });
+  assert.deepEqual(r.advisories, []);
+});
+
+test('unitless-dimension fires on a type inherited from a group', () => {
+  const sources = [{ file: 't.json', dtcg: {
+    leading: { $type: 'dimension', normal: { $value: '1.5' } },
+  } }];
+  const r = validate({ sources, output: 'static let leadingNormal = 1.5', platform: 'ios-swift' });
+  assert.equal(r.advisories.length, 1);
+  assert.equal(r.advisories[0].token, 'leading.normal');
+});
+
+test('formatReport renders the advisory and names the fix', () => {
+  const r = validate({ sources: SRC, output: 'static let leadingTight = 1.1', platform: 'ios-swift' });
+  const text = formatReport(r).join('\n');
+  assert.match(text, /unitless-dimension/);
+  assert.match(text, /leadingTight/);
+  assert.match(text, /"number"/);
+});
+```
+
+Ensure `validate` and `formatReport` are imported at the top of the test file;
+add whichever is missing to the existing import from `./validate-token-output.mjs`.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `node --test scripts/validate-token-output.test.mjs`
+Expected: FAIL — `Cannot read properties of undefined (reading 'length')` on `r.advisories`.
+
+- [ ] **Step 3: Import the helper**
+
+`scripts/validate-token-output.mjs` line 10, and the re-export on line 14:
+
+```js
+import { flattenDtcg, flattenDtcgTypes, resolveValue, findModeCollisions } from './lib/dtcg.mjs';
+```
+```js
+export { flattenDtcg, flattenDtcgTypes, resolveValue, findModeCollisions };
+```
+
+- [ ] **Step 4: Add the two constants**
+
+Beside `BARE_UNIT` (~line 97):
+
+```js
+// #52. A unitless value is a ratio, not a measurement: DTCG 8.2.1 requires a
+// dimension to carry a unit, and 8.7's `number` is the type for a multiplier.
+// Distinct from BARE_UNIT, which requires a unit SUFFIX and so never matches
+// this — which is exactly why the shape passed the gate silently before.
+const UNITLESS = /^-?(?:\d+(?:\.\d+)?|\.\d+)$/;
+const DIMENSIONAL = new Set(['dimension', 'fontSize']);
+```
+
+- [ ] **Step 5: Build the types map and collect advisories**
+
+In `validate()`, after the `flat` loop (~line 128):
+
+```js
+  const types = {};
+  for (const { dtcg } of sources) Object.assign(types, flattenDtcgTypes(dtcg));
+```
+
+Declare beside `const failures = [];`:
+
+```js
+  const advisories = [];
+```
+
+Inside the declaration loop, immediately after `matched += 1;`:
+
+```js
+    // Advisory, not a failure: the emitted value is correct under the ratio
+    // reading this build applies, so it compiles and its magnitude matches.
+    // What is wrong is the SOURCE's $type, which only the author can settle.
+    if (UNITLESS.test(String(source).trim()) && DIMENSIONAL.has(types[path])) {
+      advisories.push({ rule: 'unitless-dimension', symbol, token: path, source, emitted: value });
+    }
+```
+
+- [ ] **Step 6: Return it, without touching `ok`**
+
+Amend the return statement (~line 192). `ok` is deliberately unchanged:
+
+```js
+  return { total: decls.length, matched, matchRate, failures, advisories, collisions, minMatch, ok, unparsedLines, unemittedTokens };
+```
+
+- [ ] **Step 7: Render it**
+
+In `formatReport`, immediately before the `if (r.unemittedTokens)` block:
+
+```js
+  if (r.advisories.length) {
+    lines.push(`\n${r.advisories.length} advisory note(s) — reported, not gating:`);
+    for (const a of r.advisories) {
+      lines.push(
+        `  - [${a.rule}] ${a.symbol}: source ${JSON.stringify(a.source)} for ${a.token} is a dimension with no unit, which DTCG §8.2.1 does not permit. It emitted ${a.emitted}, read as a ratio. If it is a ratio, type it "number" (§8.7); if it is a measurement, add the unit you meant.`,
+      );
+    }
+  }
+```
+
+- [ ] **Step 8: Run to verify it passes**
+
+Run: `node --test scripts/validate-token-output.test.mjs`
+Expected: PASS.
+
+- [ ] **Step 9: Run the full suite**
+
+Run: `node --test`
+Expected: PASS. Six tests added in this task.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add scripts/validate-token-output.mjs scripts/validate-token-output.test.mjs
+git commit -m "feat: report a unitless dimension as an advisory, not a gate failure (#52)"
+```
+
+---
+
+### Task 4: generator prose, changelog, regenerate
+
+Spec §9. The "three limits" claim also lives in the generator's own prose, which
+Task 2 did not touch.
+
+**Files:**
+- Modify: `scripts/build-native-adapter-config.mjs:115-141`
+- Modify: `CHANGELOG.md` — `Unreleased`
+- Modify: `references/native-adapter-config.md` — GENERATED, regenerate only
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Replace the generator's limits prose**
+
+In `scripts/build-native-adapter-config.mjs`, replace from
+``**The \`dp\`/\`sp\` split is fixed here; three narrower Android-only limits remain.**``
+through the closing ``unit.`],`` — the whole block read in spec §9 item 1 — with:
+
+```
+**The \`dp\`/\`sp\` split is fixed here; two narrower Android-only limits remain.**
+Style Dictionary's Compose transforms select on \`$type\`, and DTCG's type set
+does not line up with what they expect — there is no \`fontSize\` type, because
+DTCG types font sizes as \`dimension\`. So the role is taken instead from the
+member names DTCG §9.8 fixes for the typography composite, stamped onto
+\`$extensions\` during preprocessing, and the two Compose transforms partition on
+that stamp. Measured against a real source: 39 declarations that emitted \`dp\`
+now emit \`sp\`, with the Swift output byte-identical.
+
+What remains:
+
+- **A bare scale primitive emits as \`dp\`.** \`text.base: "16px"\` is a font size
+  only to a human — no nominal or structural signal marks it — so it is not
+  stamped. The semantic tokens that reference it are, and those are what a
+  consumer should reach for.
+- **An \`em\`-valued \`letterSpacing\` is dropped from native output entirely**
+  rather than emitted as Compose's \`.em\` TextUnit. A filter gap, not a
+  \`dp\`/\`sp\` gap.
+
+Both are Android-only. \`size/unit-aware/swift\` filters
+\`dimension || fontSize\` and emits \`CGFloat\`, which carries no unit to be wrong
+about; iOS handles Dynamic Type at the use site via \`UIFontMetrics\`.
+\`tokens:validate-output\` passes in both cases: it checks magnitude, not unit.
+
+**A unitless value is no longer one of them.** DTCG §8.2.1 requires a dimension
+to carry a unit, §8.7's \`number\` is the type for a ratio, and §9.8 types
+\`lineHeight\` as one — so \`leading.normal: "1.5"\` typed \`dimension\` is malformed
+input. No size transform claims it: it emits bare on both platforms, which is
+byte-for-byte what a correctly typed \`number\` already produced, so correcting
+the source's \`$type\` changes no output. \`tokens:validate-output\` reports it as
+a \`unitless-dimension\` advisory, which does not gate — the emitted value is
+right under the ratio reading, and only the author can say whether a ratio is
+what was meant.\`],
+```
+
+- [ ] **Step 2: Regenerate and verify**
+
+Run: `node scripts/build-native-adapter-config.mjs && node scripts/build-native-adapter-config.mjs --check`
+Expected: `--check` exits 0.
+
+- [ ] **Step 3: Add both changelog entries**
+
+Under `## [Unreleased]`, add to `### Fixed`:
+
+```markdown
+- **A unitless value no longer emits with an invented unit.** `leading.normal:
+  "1.5"` typed `dimension` emitted `1.50.dp` on Compose and `CGFloat(1.50)` on
+  Swift — the magnitude faithful, the unit meaningless. DTCG §8.2.1 requires a
+  dimension to carry a unit and §8.7's `number` is the type for a ratio, so this
+  is malformed input rather than a shape to interpret. No size transform now
+  claims a unitless value; it emits bare, which is byte-for-byte what a
+  correctly typed `number` already produced on both platforms, so correcting a
+  source's `$type` changes no output. `tokens:validate-output` reports it as a
+  `unitless-dimension` advisory, which does not gate.
+```
+
+And a `### Changed` section (create it if absent), which is where the two
+regressions belong — they are not fixes:
+
+```markdown
+### Changed
+- **A dimension whose unit was omitted by mistake now fails loudly instead of
+  working by accident.** `spacing.gutter: "16"` meant as `16px` previously
+  emitted `16.00.dp`, correct only because px and dp map 1:1 by convention. It
+  now emits bare `16`, which does not compile at a Compose `Dp` use site and
+  infers `Int` in Swift, where it will not convert at a `CGFloat` use site. A
+  unitless `0` is affected identically — DTCG §8.2.1 requires the unit "even if
+  `$value.value` is `0`". Add the unit, or type the token `number` if it really
+  is a ratio.
+- **The `nativeUnit` override no longer applies to a unitless value.** It
+  chooses between `dp` and `sp` for a value that has a unit; it does not
+  manufacture one. A source that stamped `nativeUnit: "text"` onto a unitless
+  token previously got `1.50.sp` — which compiles and renders 1.5sp text — and
+  now gets the bare value. This narrows the "a source that states the role
+  itself wins" contract introduced in 0.15.0.
+```
+
+- [ ] **Step 4: Run the full suite and every CI gate**
+
+```bash
+node --test
+node ci/validate-plugin.mjs
+node ci/validate-skills.mjs
+node scripts/adapters/generate.mjs --check
+node scripts/build-doc-card-builder.mjs --check
+node scripts/build-native-adapter-config.mjs --check
+```
+Expected: all exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/build-native-adapter-config.mjs references/native-adapter-config.md CHANGELOG.md
+git commit -m "docs: two native limits remain, not three (#52)"
+```
+
+---
+
+### Task 5: end-to-end verification against zygarden
+
+Spec §7's prediction is falsifiable; this task falsifies it or confirms it. The
+byte-level diff is the assertion — declaration counts alone would miss
+compensating changes.
+
+**Files:**
+- Create: `docs/superpowers/notes/2026-08-26-unitless-dimension-e2e.md`
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Locate or rebuild the harness**
+
+```bash
+ls -d /private/tmp/claude-501/-Users-jordansstudio-Dev-throughline/*/scratchpad/e2e
+```
+
+A live harness has `tokens/` (15 JSON files), `node_modules/style-dictionary`
+at 4.4.0, `build.mjs`, `run.sh`, and `scripts/lib` symlinked to
+`/Users/jordansstudio/Dev/throughline/scripts/lib`. If none survives, rebuild:
+`npm i style-dictionary@4.4.0` in a scratch dir, symlink `scripts/lib` and
+`scripts/validate-token-output.mjs` to the repo, and extract the token sources
+with `git show feature/apply-brandguide-styles:libs/shared/util-tokens/src/tokens/<file>`
+from `~/Dev/zygarden-frontend`. **Do not check out or modify that repo.**
+
+- [ ] **Step 2: Build at HEAD**
+
+```bash
+cd <harness> && bash run.sh out-52-head
+```
+Expected: exit 0 both platforms; `declarations 195 | .sp 39 | .dp 45`.
+
+- [ ] **Step 3: Build at `main` in a throwaway worktree**
+
+```bash
+git worktree add /tmp/tl-main main
+ln -sfn /tmp/tl-main/scripts/lib <harness>/scripts/lib
+cd <harness> && bash run.sh out-52-main
+```
+Expected: `declarations 195 | .sp 39 | .dp 50`.
+
+- [ ] **Step 4: Diff, then restore the symlink**
+
+```bash
+diff -r <harness>/out-52-main <harness>/out-52-head
+ln -sfn /Users/jordansstudio/Dev/throughline/scripts/lib <harness>/scripts/lib
+git worktree remove /tmp/tl-main
+```
+
+Expected, and **treat any deviation as a failed prediction, not a nuisance**:
+- exactly 5 changed lines in `Tokens.kt` — `leadingTight/Snug/Normal/Relaxed/Loose`, `N.dp` to bare
+- exactly 5 changed lines in `Tokens.swift` — the same five, `CGFloat(N)` to bare
+- `leadingLoose` emits `2`, not `2.00` — integral ratios infer `Int` (spec §7)
+- **no other line differs in either file**
+
+- [ ] **Step 5: Confirm the advisory fires and does not gate**
+
+Re-run `run.sh out-52-head` and read the validator output.
+Expected: exit 0 on both platforms, each reporting **5** `unitless-dimension`
+advisory notes naming `leading*`.
+
+- [ ] **Step 6: Write the evidence note**
+
+Create `docs/superpowers/notes/2026-08-26-unitless-dimension-e2e.md` following
+`docs/superpowers/notes/2026-08-24-hoist-dual-nodes-e2e.md`: date, what the run
+gates, the verdict, the harness description, the numbered procedure with real
+pasted output, and the prediction-vs-actual table. If any prediction missed,
+record what actually happened and **stop** — do not adjust the note to match.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/superpowers/notes/2026-08-26-unitless-dimension-e2e.md
+git commit -m "docs: e2e evidence for the unitless-dimension fix (#52)"
+```
+
+- [ ] **Step 8: Push and open the PR**
+
+```bash
+git push -u origin fix/52-unitless-dimension
+```
+
+PR body must state: the measured blast radius (5 orphaned tokens), the two
+behaviour changes from the changelog's `Changed` section, and the §6.2 carry
+limit with its follow-up. Target `main`.
+
+---
+
+## Follow-ups to file after the PR opens
+
+Per spec §10 — file, do not absorb:
+
+1. **The advisory cannot see the hoist's `$type` carry.** A unitless, untyped
+   child of a `dimension`-typed dual node with no enclosing group type is
+   flipped to bare by Task 2 and not flagged by Task 3. That is #60's
+   genuinely-silent shape. Fixing it means deciding whether
+   `validate-token-output.mjs` may read a preprocessed tree, which trades away
+   its property of checking output against what the author actually wrote.
+2. **The `number` type is unreachable from a Figma-derived source.** Figma emits
+   no DTCG `number` tokens, so every ratio arrives mistyped and every user of
+   this pipeline meets the advisory. Whether throughline's extraction should
+   type ratios as `number` at the source is the item that would close this class.

--- a/docs/superpowers/specs/2026-08-26-unitless-dimension-design.md
+++ b/docs/superpowers/specs/2026-08-26-unitless-dimension-design.md
@@ -234,24 +234,40 @@ contract:
   unitless token.** See below.
 
 **The explicit override on a unitless token: `!isRatio` goes on `compose-sp`
-too, and this is a behaviour change.**
+too — but not for the reason an earlier draft of this section gave.**
 
-`isTextUnit` reads the stamp, not `$type`, so a manually stamped token reaches
-`compose-sp` whatever its `$type` is. That makes this the case that decides the
-invariant, and the two placements are not symmetric:
+An earlier draft claimed `compose-sp`'s `!isRatio` was what held the invariant,
+and that omitting it broke Swift. **That was wrong, and it was wrong in the way
+this project keeps rediscovering: it was reasoned, not executed.** Built in
+isolation across three filter variants, the actual behaviour is:
 
-| | `compose-sp` keeps `!isRatio` | `compose-sp` omits it |
-|---|---|---|
-| `$type: dimension`, stamped, `"1.5"` | bare / bare | `1.50.sp` / `CGFloat(1.50)` |
-| `$type: number`, stamped, `"1.5"` | bare / bare | `1.50.sp` / **`1.5`** |
+| variant | stamped `dimension` `"1.5"` | stamped `number` `"1.5"` | invariant |
+|---|---|---|---|
+| all three carry `!isRatio` | bare / bare | bare / bare | **holds** |
+| `compose-sp` omits it | `1.50.sp` / bare | `1.50.sp` / bare | **holds** |
+| `swift` omits it | — / `CGFloat(1.50)` | — / bare | **breaks** |
 
-Omitting it **breaks the invariant on Swift**, because `size/unit-aware/swift`
-filters on `isDimension || isFontSize` and never consults the stamp — so the
-`number` form falls through to bare while the `dimension` form wraps. Keeping it
-holds the invariant on both platforms.
+So the invariant is carried by **`size/unit-aware/swift`**, whose filter is
+`isDimension || isFontSize` and therefore *is* sensitive to `$type`.
+`compose-sp` filters on `isTextUnit || isFontSize`, and `isTextUnit` reads the
+stamp rather than `$type` — so a stamped token behaves identically under both
+`$type`s whatever `compose-sp` does. It cannot break the invariant, and it
+cannot save it.
 
-Keeping it also costs something real, and #51 must be answered rather than
-quietly overridden. #51 §7 accepted that "a tool that second-guesses an explicit
+**`!isRatio` still belongs on `compose-sp`, on the merits rather than on the
+invariant.** Without it, a stamped unitless token emits `1.50.sp` — 1.5
+scale-pixels of text. That is precisely the output #51 gated `ABSOLUTE_UNIT` to
+prevent, described there as "a loud failure traded for a silent one, which is
+precisely the failure class this module exists to prevent." An explicit stamp
+should not be able to produce it either.
+
+The consequence for §7 matters: **an invariant test cannot catch a missing
+`!isRatio` on `compose-sp`**, because the invariant holds without it. That
+placement needs its own direct behavioural assertion — a stamped unitless token
+emits bare — and §7 specifies both.
+
+Narrowing the override costs something real, and #51 must be answered rather
+than quietly overridden. #51 §7 accepted that "a tool that second-guesses an explicit
 declaration has no override at all," and `classifyTextUnits`' own comment says
 "A source that states the role itself wins" (`sd-native.mjs:267-270`). Under
 this change that sentence stops being true for unitless values.
@@ -457,12 +473,16 @@ review.
 - `lib/sd-native.test.mjs` — **the output-neutrality invariant of §5.2**, as an
   executed assertion: the same value authored as `$type: dimension` and as
   `$type: number` emits identical output on both platforms.
-- `lib/sd-native.test.mjs` — **the invariant again, with an explicit
-  `nativeUnit: "text"` stamp on both forms.** This is the case that decides
-  where `!isRatio` goes, and the plain invariant test above passes even if
-  `compose-sp` omits it. Without this case the suite would not catch the one
-  filter placement that breaks the design. It doubles as the pin on the narrowed
-  override contract, which no test currently holds.
+- `lib/sd-native.test.mjs` — **a direct assertion that a stamped unitless token
+  emits bare**, i.e. that `compose-sp` declines it. This is *not* an invariant
+  test, and the distinction is the point: §5.2 measured that the invariant holds
+  whether or not `compose-sp` carries `!isRatio`, so an invariant test cannot
+  catch that placement. Only a behavioural assertion can. It doubles as the pin
+  on the narrowed override contract, which no test currently holds.
+- `lib/sd-native.test.mjs` — **the invariant test must exercise the Swift
+  filter**, since §5.2 measured that as the one that actually carries it. A test
+  that only compares Compose output would pass against the variant that breaks
+  the design.
 - `lib/sd-native.test.mjs` — **the unitless-zero regression of §5.4**, asserted
   explicitly, so the cost is recorded in a test and cannot later be reverted as
   though it were a bug.

--- a/docs/superpowers/specs/2026-08-26-unitless-dimension-design.md
+++ b/docs/superpowers/specs/2026-08-26-unitless-dimension-design.md
@@ -54,6 +54,13 @@ Android-only ... `CGFloat`, which carries no unit to be wrong about" — so it i
 the issue text, not the codebase, that overstates. Swift is nonetheless changed
 here, for a different reason: §5.2.
 
+**That framing has a shelf life, and §5.5 is where it expires.** "No unit to be
+wrong about" holds only while the `CGFloat` wrapper is present. Once it is
+removed the constant carries a Swift *type* instead of a unit, and an `Int`
+mismatch at a `CGFloat` use site is a real failure. This is therefore the first
+item in the family whose behaviour change is **not** Android-only, and §5.5
+states the regression for both platforms rather than inheriting §4's framing.
+
 **2.2 It is not the silent half of the family.** The #60 handoff's open question
 assumed #60 established this as the silent case, which argued it up the ranking.
 Measured, that is wrong. `1.50.dp` is a `Dp`, and Compose's `TextStyle` takes
@@ -132,6 +139,28 @@ contradict #51's own reasoning and re-open the problem #63 exists to track.
 is why the answer is not a cleverer classifier. §5 picks the reading the spec
 mandates; §6 tells the author what was assumed so they can correct it.
 
+### 4.1 Rejected: a `preprocess` throw
+
+Since §3 places this input in the same category as the dual node in #55, and
+#55 answers its unrepairable case with a throw naming both paths, the throw
+option needs an explicit rejection rather than an allusion.
+
+**Rejected, on one measured difference.** #55's throw fires on **zero**
+zygarden tokens — the collision it detects is not authored anywhere in the real
+source, so the throw is a guard against a shape that does not occur. This throw
+would fire on **five, immediately**, breaking the flagship Figma-derived source
+on first run, and Figma emits no DTCG `number` tokens at all (§10), so every
+source reaching this pipeline carries the shape.
+
+The second difference is what is at stake. #55's collision **silently discards a
+token** — a build that appears to succeed has lost data, and stopping is the
+only way to surface it. Here nothing is lost: output is produced for every
+token, with one reading of an ambiguous type. A fatal error for a token that
+emits correctly under the mandated reading is disproportionate to the harm.
+
+The throw remains the right answer for the case where output cannot be produced
+at all. That is not this case.
+
 ## 5. The transform change
 
 ### 5.1 Placement: the transform filters, not `magnitude()`
@@ -190,7 +219,9 @@ Taking the advice becomes a no-op. This is the load-bearing claim of the design,
 so §7 makes it a test rather than a sentence.
 
 Cases hunted for a counterexample, per the #60 lesson that the tidiest sentence
-in a spec is the one most worth executing — all four hold:
+in a spec is the one most worth executing — all five hold, but the fifth holds
+only because of a deliberate choice, and that choice changes a documented
+contract:
 
 - a numeric (non-string) `$value`: `magnitude()` stringifies, so it is caught.
 - `$type: fontSize` with a unitless value: excluded from `compose-sp` and
@@ -199,6 +230,51 @@ in a spec is the one most worth executing — all four hold:
   it is unstamped under either `$type`.
 - `$type: number` reaching a size transform at all: it cannot —
   `isDimension`/`isFontSize` both false.
+- **a source that sets `$extensions[EXT_NS].nativeUnit = "text"` itself on a
+  unitless token.** See below.
+
+**The explicit override on a unitless token: `!isRatio` goes on `compose-sp`
+too, and this is a behaviour change.**
+
+`isTextUnit` reads the stamp, not `$type`, so a manually stamped token reaches
+`compose-sp` whatever its `$type` is. That makes this the case that decides the
+invariant, and the two placements are not symmetric:
+
+| | `compose-sp` keeps `!isRatio` | `compose-sp` omits it |
+|---|---|---|
+| `$type: dimension`, stamped, `"1.5"` | bare / bare | `1.50.sp` / `CGFloat(1.50)` |
+| `$type: number`, stamped, `"1.5"` | bare / bare | `1.50.sp` / **`1.5`** |
+
+Omitting it **breaks the invariant on Swift**, because `size/unit-aware/swift`
+filters on `isDimension || isFontSize` and never consults the stamp — so the
+`number` form falls through to bare while the `dimension` form wraps. Keeping it
+holds the invariant on both platforms.
+
+Keeping it also costs something real, and #51 must be answered rather than
+quietly overridden. #51 §7 accepted that "a tool that second-guesses an explicit
+declaration has no override at all," and `classifyTextUnits`' own comment says
+"A source that states the role itself wins" (`sd-native.mjs:267-270`). Under
+this change that sentence stops being true for unitless values.
+
+**It is still the right call, and the reason completes #51's argument rather
+than reversing it.** #51 gated the *automatic* stamp on `ABSOLUTE_UNIT`
+precisely because `1.50.sp` compiles and renders 1.5sp text — "a loud failure
+traded for a silent one, which is precisely the failure class this module exists
+to prevent." That reasoning is about the *value*, not about who did the
+stamping: 1.5 scale-pixels of text is nonsense no matter who declared it. #51
+simply did not extend the gate to the manual stamp.
+
+So the override's scope is narrowed, and stated explicitly:
+
+> The `nativeUnit` override chooses between `dp` and `sp` for a value that
+> **has** a unit. It does not manufacture one. On a unitless value it is
+> declined, because there is no magnitude for `sp` to scale.
+
+This is an unrecorded behaviour change today; §7 gives it a test, §9 lists the
+comment that must be corrected, and the changelog carries it. **No existing test
+pins the old behaviour** — `sd-native.test.mjs:1035` covers only the
+no-magnitude stamp — so nothing forces an implementer to confront this unless
+the spec says so.
 
 ### 5.3 `ABSOLUTE_UNIT` is unchanged, and this resolves a tension #51 carried
 
@@ -220,8 +296,9 @@ bare `0`. zygarden has none, but other sources will.
 DTCG anticipated exactly this — §8.2.1's "still required even if
 `$value.value` is `0`" exists for this case — so the input is invalid and §6
 flags it. In Compose it fails loudly: `Modifier.padding(0)` does not compile
-without `.dp`. It is a real behaviour change and §7 gives it a test and a
-changelog line.
+without `.dp`. On Swift it emits `0`, which infers `Int` and will not convert at
+a `CGFloat` use site — see §5.5. It is a real behaviour change on both platforms
+and §7 gives it a test and a changelog line.
 
 ### 5.5 The trade being made, named honestly
 
@@ -230,11 +307,18 @@ Today a *forgotten unit* — `spacing.gutter: "16"` meant as `16px` — emits
 convention. Under this change it emits bare `16`, which is wrong, and fails at
 any Compose `Dp` use site.
 
-So this trades accidental-correctness for loud-failure-plus-advice. That is the
-right trade — it is the module's stated thesis, #53 made the identical trade for
-invalid literals, and the correctness was luck rather than design — but it is a
-regression for anyone relying on it, and it is recorded as one rather than
-presented as a pure win.
+**This regression lands on Swift too, and §2.1 does not cover it.** "CGFloat
+carries no unit to be wrong about" is true only while the wrapper is there. Once
+`CGFloat(16.00)` becomes bare `16`, the constant infers **`Int`**, and Swift
+does not implicitly convert an `Int` constant at a `CGFloat` use site. So the
+forgotten-unit case is a real Swift-side regression, not an Android-only one —
+the first in this family that is not. The same applies to §5.4's zero.
+
+So this trades accidental-correctness for loud-failure-plus-advice, on both
+platforms. That is the right trade — it is the module's stated thesis, #53 made
+the identical trade for invalid literals, and the correctness was luck rather
+than design — but it is a regression for anyone relying on it, and it is
+recorded as one rather than presented as a pure win.
 
 ## 6. The gate rule
 
@@ -244,21 +328,30 @@ Fires when a source token's effective `$type` is `dimension` or `fontSize` and
 its resolved value is a bare number. Reports the token path, the emitted symbol,
 and the fix: *type it `number`, or add the unit you meant.*
 
-**Severity: advisory — reported, excluded from `ok`.** The principled line is
-that **the gate judges output, and this is a source problem.** Every existing
-fatal rule concerns output that will not compile (`invalid-literal`,
-`no-bare-units`, `no-foreign-syntax`) or that does not match its source
-magnitude (`unit-fidelity`, `unverifiable-dimension`). A unitless dimension
-under §5 emits output that compiles *and* matches its magnitude. Putting source
-hygiene in the fatal set changes the gate's contract.
+**Severity: advisory — reported, excluded from `ok`.**
 
-It would also relocate rather than avoid the cost that disqualified a
-preprocess throw: zygarden trips this on five tokens on day one, and a red gate
-is a red gate wherever it fires.
+An earlier draft rested this on a general principle — "the gate judges output,
+and this is a source problem." **That principle is false in this codebase and is
+withdrawn.** Mode collisions are fatal in `validate()` today
+(`validate-token-output.mjs:185`) and are purely a source-list problem, so the
+gate's actual contract already includes fatal source rules. The argument is the
+narrower one, which does not need the principle:
 
-Precedent exists in the same function: `unparsedLines` and `unemittedTokens` are
-both reported and both excluded from `ok` — zygarden shows 19 unemitted tokens
-today at exit 0.
+- **The output is correct.** Under §5 a unitless dimension emits the ratio
+  reading, which compiles and matches its magnitude. Failing a gate on output
+  that is right — under the reading the spec itself mandates — inverts what the
+  gate is for. Mode collisions are fatal because they mean output is *missing*
+  a whole mode; nothing is missing or wrong here.
+- **It relocates rather than avoids the cost that disqualifies a throw** (§4.1):
+  zygarden trips this on five tokens on day one, and a red gate is a red gate
+  wherever it fires.
+- **Precedent exists in the same function.** `unparsedLines` and
+  `unemittedTokens` are both reported and both excluded from `ok` — zygarden
+  shows 19 unemitted tokens today at exit 0.
+
+The claim is therefore about *this* source problem, not about source problems in
+general: it is diagnosable, it does not corrupt output, and its own fix is a
+one-line `$type` edit.
 
 ### 6.2 Where the type comes from
 
@@ -275,9 +368,36 @@ and returning `{ path: effectiveType }`:
 - otherwise the nearest ancestor **group**'s `$type`;
 - a `$value`-bearing node is **not** an inheritance source for its children.
 
-That third rule is the same one `hoistDualNodes` computes as `inherited`, and it
-must match, or two functions in this codebase disagree about the type of the
-same tree.
+That third rule is the same one `hoistDualNodes` computes as `inherited`
+(`sd-native.mjs:139`), and it must match, or two functions in this codebase
+disagree about the type of the same tree.
+
+**But matching `inherited` is not matching the pipeline, and the spec must not
+claim otherwise.** `hoistDualNodes` types a child by *two* mechanisms. The
+second is the **carry** (`sd-native.mjs:189-196`): where no group supplies a
+type, the dual node's own `$type` is stamped onto an untyped hoisted child.
+`flattenDtcgTypes` reads the **raw source**, where the hoist has not run, so it
+cannot see the carry.
+
+The consequence, stated as a limit:
+
+> A unitless child with no own `$type`, under a `dimension`-typed dual node with
+> no enclosing group type, is a `dimension` to the pipeline via the carry — so
+> §5 flips it from `N.dp` to bare — but `flattenDtcgTypes` returns `undefined`
+> for it and the advisory does **not** fire.
+
+This is the worst-placed limit in the design, and it is recorded rather than
+buried: that shape is exactly #60's "genuinely silent" case, the one this rule
+most wants to catch. It is not reachable in zygarden — every dual-node child
+there carries its own `$type` — so it is a stated limit here and a filed
+follow-up (§10) rather than scope absorbed into this item.
+
+Resolving it properly means running the advisory against the **preprocessed**
+tree rather than the raw source, which is a larger change to how
+`validate-token-output.mjs` reads its input: the gate deliberately validates
+emitted output against the *authored* source, and pointing it at a preprocessed
+tree would mean it no longer checks what the author wrote. That trade is not
+this item's to make.
 
 ### 6.3 Deliberately not implemented
 
@@ -312,11 +432,20 @@ at HEAD against zygarden's real source:**
 | Changed lines, Kotlin | — | **5** (`leading*`, `N.dp` -> bare) |
 | Changed lines, Swift | — | **5** (`CGFloat(N)` -> bare) |
 | Every other line, both files | — | **byte-identical** |
-| `tokens:validate-output` exit | 0 | 0, with 5 advisories |
+| `tokens:validate-output` exit | 0 | 0, with 5 advisories **per platform run** |
 
 If `.dp` does not land on exactly 45, something moved that should not have, and
 the diff says what. Counting declarations alone would miss compensating changes;
 the byte-level diff is the assertion.
+
+**One shift inside the ramp the §1 table does not show.** `leading.loose: "2"`
+emits bare `2`, which infers `Int` in both languages, while its four siblings
+emit `Double`. Today all five are `2.00.dp` / `CGFloat(2.00)` and uniformly
+floating-point. This is consistent with the design rather than an exception — a
+`number`-typed `2` emits `2` today, so the §5.2 invariant holds — but it means
+the five emitted constants are no longer of one type, which a consumer iterating
+the ramp would notice before we did. Recorded here rather than discovered in
+review.
 
 **Tests.**
 
@@ -328,6 +457,12 @@ the byte-level diff is the assertion.
 - `lib/sd-native.test.mjs` — **the output-neutrality invariant of §5.2**, as an
   executed assertion: the same value authored as `$type: dimension` and as
   `$type: number` emits identical output on both platforms.
+- `lib/sd-native.test.mjs` — **the invariant again, with an explicit
+  `nativeUnit: "text"` stamp on both forms.** This is the case that decides
+  where `!isRatio` goes, and the plain invariant test above passes even if
+  `compose-sp` omits it. Without this case the suite would not catch the one
+  filter placement that breaks the design. It doubles as the pin on the narrowed
+  override contract, which no test currently holds.
 - `lib/sd-native.test.mjs` — **the unitless-zero regression of §5.4**, asserted
   explicitly, so the cost is recorded in a test and cannot later be reverted as
   though it were a bug.
@@ -372,13 +507,23 @@ freshness in CI:
 2. `scripts/lib/sd-native.mjs` — the same list in the `platform` doc-section's
    comment, plus the `ABSOLUTE_UNIT` comment at ~line 235, whose reasoning
    about the unitless case is superseded by §5.3.
-3. `references/native-adapter-config.md` — regenerated.
+3. **`scripts/lib/sd-native.mjs:267-270`** — `classifyTextUnits`' comment "A
+   source that states the role itself wins. This is the override, and it costs
+   no configuration parameter: declining to overwrite IS the feature." That
+   sentence becomes false for unitless values under §5.2 and must be narrowed to
+   match the stated scope: the override chooses between `dp` and `sp` for a
+   value that has a unit; it does not manufacture one. This comment feeds the
+   generated doc, so leaving it would ship a documented contract the code no
+   longer honours.
+4. `references/native-adapter-config.md` — regenerated.
 
 Three remaining limits become two: the bare scale primitive (#63) and the
 `em`-valued `letterSpacing` (#64).
 
-**Changelog.** The `Unreleased` section gets the §5.5 trade stated as a
-regression, not only as a fix.
+**Changelog.** The `Unreleased` section gets **two** entries, not one: the §5.5
+trade stated as a regression rather than only as a fix, and the §5.2 narrowing
+of the `nativeUnit` override, which is a behaviour change to a contract #51
+documented.
 
 ## 10. Follow-ups to file
 
@@ -387,5 +532,12 @@ regression, not only as a fix.
   this pipeline will meet the §6 advisory. Whether throughline's Figma
   extraction should type ratios as `number` at the source is a separate item,
   and the one that would actually close this class.
+- **The advisory cannot see the hoist's `$type` carry** (§6.2). A unitless,
+  untyped child of a `dimension`-typed dual node with no enclosing group type is
+  flipped to bare by §5 and not flagged by §6 — and that shape is #60's
+  genuinely-silent case, so it is the token the rule most wants. Fixing it means
+  deciding whether `validate-token-output.mjs` may read a preprocessed tree,
+  which trades away its property of checking emitted output against what the
+  author actually wrote. A real decision, and not this item's.
 - Anything the implementation turns up that is out of scope here — filed rather
   than absorbed, per #60 and #67.

--- a/docs/superpowers/specs/2026-08-26-unitless-dimension-design.md
+++ b/docs/superpowers/specs/2026-08-26-unitless-dimension-design.md
@@ -420,8 +420,10 @@ this item's to make.
 **DTCG §5.2.2 rule 1** — a reference-valued token takes its referent's type — is
 not resolved here. An alias to a unitless dimension is not flagged; its
 *referent* is, and the referent is the token the author edits. Flagging both
-would be noise. Stated as a limit, in the manner of #63 and #64, rather than
-hidden.
+would be noise, so a token whose RAW authored `$value` is a whole-value
+reference (`^\{...\}$`) is excluded from the check even when it restates
+`$type: dimension` itself — which zygarden's aliases do universally. Stated as
+a limit, in the manner of #63 and #64, rather than hidden.
 
 **#36's blind spot is inherited, not worsened.** The rule maps symbol to source
 through the same `byKey` map, so a `normalizeKey` collision affects it exactly

--- a/docs/superpowers/specs/2026-08-26-unitless-dimension-design.md
+++ b/docs/superpowers/specs/2026-08-26-unitless-dimension-design.md
@@ -1,0 +1,391 @@
+# Unitless dimensions — design
+
+**Issue:** [#52](https://github.com/jrpease/throughline/issues/52) — unitless
+ratios emit as `.dp` / `CGFloat` with no unit semantics
+**Date:** 2026-08-26
+**Base branch:** `main`. #68 is merged and no native branch is open, so this
+does not stack — the first item in this sequence that does not. See §8.
+
+## 1. The measured problem
+
+Built zygarden's real DTCG source through the live module (Style Dictionary
+4.4.0, scratch harness, `libs/shared/util-tokens/src/tokens`,
+`feature/apply-brandguide-styles`, light + mobile axes). Baseline reproduced
+exactly: **195 declarations, 39 `.sp`, 50 `.dp`.**
+
+Enumerating every token whose post-`preprocess` value is a bare number:
+
+| | |
+|---|---|
+| Unitless-valued source tokens | 23 |
+| Of those, `$type: fontWeight` (emit as bare integers — correct) | 18 |
+| Of those, `$type: dimension` | **5** |
+
+The five are the whole `leading.*` ramp:
+
+```
+val leadingTight   = 1.10.dp        public static let leadingTight   = CGFloat(1.10)
+val leadingSnug    = 1.25.dp        public static let leadingSnug    = CGFloat(1.25)
+val leadingNormal  = 1.50.dp        public static let leadingNormal  = CGFloat(1.50)
+val leadingRelaxed = 1.70.dp        public static let leadingRelaxed = CGFloat(1.70)
+val leadingLoose   = 2.00.dp        public static let leadingLoose   = CGFloat(2.00)
+```
+
+`1.50.dp` is one and a half density-independent pixels. The token means
+"1.5x the font size."
+
+**All five are orphaned.** Nothing in zygarden's source references `leading.*`;
+every semantic `lineHeight` routes through `text.*.lineHeight`, which are
+px-valued dual-node children that #51 already moved to `.sp`. So no consumer's
+needs constrain the answer, and the blast radius of getting it wrong is small.
+
+`tokens:validate-output` exits 0 on both platforms, as #52 predicted.
+
+## 2. Three corrections to the issue's own text
+
+All three measured, all three change what this spec must do.
+
+**2.1 The Swift half is not the same defect.** #52 says the Swift path "has the
+same problem in a different costume." It does not. A real dimension emits
+`spacingSpace4 = CGFloat(16.00)`; Swift's `CGFloat` carries no unit claim about
+*anything*, so for a ratio it is already an appropriate type.
+`references/native-adapter-config.md` §4 states this correctly — "all three are
+Android-only ... `CGFloat`, which carries no unit to be wrong about" — so it is
+the issue text, not the codebase, that overstates. Swift is nonetheless changed
+here, for a different reason: §5.2.
+
+**2.2 It is not the silent half of the family.** The #60 handoff's open question
+assumed #60 established this as the silent case, which argued it up the ranking.
+Measured, that is wrong. `1.50.dp` is a `Dp`, and Compose's `TextStyle` takes
+`TextUnit` for `lineHeight` with no `Dp` overload — so using `leadingNormal` for
+its actual purpose is a **compile error**. #60's genuinely-silent case was a
+*bare* `1.5` `Double` emitted on an untyped child, which is a different shape.
+
+The ranking argument that put #52 in this slot therefore does not survive
+contact with the output. The defect is real and worth fixing; it is smaller than
+advertised, and this spec is sized to what was measured rather than to the
+issue's framing.
+
+**2.3 The issue's four options are the wrong four.** #52 offers: emit bare, emit
+`.em`, filter out, or decide by role. Each is framed as inventing a native form
+for a legal input. §3 shows the input is not legal, which reframes the question
+entirely.
+
+## 3. What DTCG actually says
+
+Verified against the Format Module draft, not inherited from repo comments — the
+same discipline #55 applied after finding two comments asserting a falsehood
+about dual nodes.
+
+- **§8.2 / §8.2.1 — a dimension MUST carry a unit.** `$value` "MUST be an object
+  containing a numeric `value` ... and `unit` of measurement (`"px"` or
+  `"rem"`)", and "`$value.unit` is still required even if `$value.value` is
+  `0`."
+- **§8.7 — `number` is the unitless type**, whose own stated example uses are
+  "gradient stop positions or unitless line heights."
+- **§9.8 — `lineHeight` MUST be a `number`** or a reference to one, "interpreted
+  as a multiplier of the fontSize."
+
+**A unitless `dimension` is invalid DTCG at MUST level.** This is the same
+category as the dual node in #55: malformed input, not a legal shape being
+interpreted. As with #55, this does not change what throughline must *do* —
+Figma-derived sources emit the shape regardless — but it means behaviour here is
+a judgment about malformed input and must not be argued as spec interpretation.
+
+**The spec-correct authoring already works, unchanged.** Measured through the
+real pipeline:
+
+```
+$type: number,    $value 1.5     ->  Kotlin: 1.5          Swift: 1.5
+$type: number,    $value "1.5"   ->  Kotlin: 1.5          Swift: 1.5
+$type: dimension, $value "1.5"   ->  Kotlin: 1.50.dp      Swift: CGFloat(1.50)
+$type: dimension, $value "16"    ->  Kotlin: 16.00.dp     Swift: CGFloat(16.00)
+$type: dimension, $value "16px"  ->  Kotlin: 16.00.dp     Swift: CGFloat(16.00)
+```
+
+`number` falls through every size transform and emits its raw value — which is
+exactly the correct native form for a multiplier on both platforms. Nothing
+needs to be built for the correct input. The work is entirely about the
+incorrect one.
+
+## 4. The irreducible ambiguity
+
+Rows three and four above are the design problem. `"1.5"` and `"16"`, both typed
+`dimension`, are **structurally identical inputs demanding opposite outputs**:
+
+- `"1.5"` is a ratio. Correct output: bare.
+- `"16"` is a forgotten `px`. Correct output: `16.00.dp`.
+
+No property of the token separates them.
+
+**Rejected: a magnitude threshold.** "Ratios are small, measurements are large"
+breaks on `leading.loose: 2` against `spacing.hairline: 1`, and on any aspect
+ratio stored as `16`.
+
+**Rejected: a name heuristic.** `leading`/`lineHeight` implies ratio. But #51
+established that this module takes typographic roles *only* from the member
+names DTCG §9.8 fixes at MUST level, precisely to avoid guessing from arbitrary
+names — and `leading` is not one of them. Adding a name heuristic here would
+contradict #51's own reasoning and re-open the problem #63 exists to track.
+
+**Only the author knows.** That is the finding this design is built on, and it
+is why the answer is not a cleverer classifier. §5 picks the reading the spec
+mandates; §6 tells the author what was assumed so they can correct it.
+
+## 5. The transform change
+
+### 5.1 Placement: the transform filters, not `magnitude()`
+
+The minimal-looking change is to make `magnitude()` return `null` for a bare
+number, so `hasMagnitude` goes false and the transforms decline. Rejected.
+
+`magnitude()` answers "what is this value's native magnitude," and for `1.5`
+the honest answer *is* `1.5`, unscaled. The validator's `expectedMagnitude()`
+answers the same question and returns `{ magnitude: 1.5 }`. Making the two
+disagree creates a fourth divergent definition of a shared concept in this
+codebase — which is exactly what [#57](https://github.com/jrpease/throughline/issues/57)
+is already open to reconcile. `magnitude()` is left alone.
+
+Instead, a predicate, stated precisely because the plan will transcribe it: a
+token is a **ratio** when its authored value matches `magnitude()`'s own
+number-and-optional-unit grammar *and the unit group is empty*. It reads
+`token.original?.$value ?? token.$value` — the same accessor `authored()` uses,
+and it must be the same one: `preprocess` resolves references in place before
+Style Dictionary sees the tree, so `original.$value` already holds the resolved
+literal, and reading the post-transform `$value` instead would test a value some
+other transform may already have rewritten.
+
+The three size transforms then exclude it:
+
+```
+size/unit-aware/swift       filter: (isDimension || isFontSize) && hasMagnitude && !isRatio
+size/unit-aware/compose-dp  filter: isDimension && !isTextUnit && hasMagnitude && !isRatio
+size/unit-aware/compose-sp  filter: (isTextUnit || isFontSize) && hasMagnitude && !isRatio
+```
+
+The token falls through untransformed and emits its raw value.
+
+`magnitude()`'s consumers were enumerated before proposing this: `authored()`
+in `sd-native.mjs`, feeding exactly these three transforms, plus its own tests.
+It is not used by `validate-token-output.mjs`. Narrowing a shared helper without
+accounting for every consumer caused review defects on both #53 and #55; the
+enumeration is recorded here so the plan does not have to re-derive it.
+
+### 5.2 Applied to Swift as well, for output-neutrality
+
+§2.1 establishes Swift's `CGFloat(1.50)` is not wrong. It is changed anyway, and
+the reason is not consistency for its own sake.
+
+The advisory in §6 tells the author: *this is mistyped; make it
+`$type: number`.* If they do that while Swift still wraps, Swift output changes
+from `CGFloat(1.50)` to `1.5` as a side effect of taking our advice. Advice that
+silently alters output is a trap.
+
+With Swift declining too, the invariant holds:
+
+> For a unitless value, `$type: dimension` and `$type: number` produce
+> **identical output on both platforms.**
+
+Taking the advice becomes a no-op. This is the load-bearing claim of the design,
+so §7 makes it a test rather than a sentence.
+
+Cases hunted for a counterexample, per the #60 lesson that the tidiest sentence
+in a spec is the one most worth executing — all four hold:
+
+- a numeric (non-string) `$value`: `magnitude()` stringifies, so it is caught.
+- `$type: fontSize` with a unitless value: excluded from `compose-sp` and
+  `swift` alike, so bare on both, matching `number`.
+- a typography-named member: `classifyTextUnits` requires an absolute unit, so
+  it is unstamped under either `$type`.
+- `$type: number` reaching a size transform at all: it cannot —
+  `isDimension`/`isFontSize` both false.
+
+### 5.3 `ABSOLUTE_UNIT` is unchanged, and this resolves a tension #51 carried
+
+#51 §6.3 declined to stamp a bare-valued `lineHeight` because both available
+outputs were bad: `.dp` is a `Dp` where a `TextUnit` belongs, and `.sp` compiles
+and renders 1.5sp text — a loud failure traded for a silent one.
+
+This change introduces the third option. A unitless `lineHeight` is still not
+stamped (`ABSOLUTE_UNIT` still requires `px`/`rem`, unmodified), is now also
+declined by `compose-dp`, and emits bare — a Kotlin `Double`, which is what
+DTCG §9.8 says a `lineHeight` is and what Compose's multiplier idiom wants.
+`ABSOLUTE_UNIT` needs no change; its reasoning simply stops being a compromise.
+
+### 5.4 The unitless-zero cost, stated rather than smoothed
+
+`spacing.none: { $value: "0", $type: "dimension" }` flips from `0.00.dp` to
+bare `0`. zygarden has none, but other sources will.
+
+DTCG anticipated exactly this — §8.2.1's "still required even if
+`$value.value` is `0`" exists for this case — so the input is invalid and §6
+flags it. In Compose it fails loudly: `Modifier.padding(0)` does not compile
+without `.dp`. It is a real behaviour change and §7 gives it a test and a
+changelog line.
+
+### 5.5 The trade being made, named honestly
+
+Today a *forgotten unit* — `spacing.gutter: "16"` meant as `16px` — emits
+`16.00.dp`, which is **accidentally correct**, because px and dp map 1:1 by
+convention. Under this change it emits bare `16`, which is wrong, and fails at
+any Compose `Dp` use site.
+
+So this trades accidental-correctness for loud-failure-plus-advice. That is the
+right trade — it is the module's stated thesis, #53 made the identical trade for
+invalid literals, and the correctness was luck rather than design — but it is a
+regression for anyone relying on it, and it is recorded as one rather than
+presented as a pure win.
+
+## 6. The gate rule
+
+### 6.1 `unitless-dimension`, advisory
+
+Fires when a source token's effective `$type` is `dimension` or `fontSize` and
+its resolved value is a bare number. Reports the token path, the emitted symbol,
+and the fix: *type it `number`, or add the unit you meant.*
+
+**Severity: advisory — reported, excluded from `ok`.** The principled line is
+that **the gate judges output, and this is a source problem.** Every existing
+fatal rule concerns output that will not compile (`invalid-literal`,
+`no-bare-units`, `no-foreign-syntax`) or that does not match its source
+magnitude (`unit-fidelity`, `unverifiable-dimension`). A unitless dimension
+under §5 emits output that compiles *and* matches its magnitude. Putting source
+hygiene in the fatal set changes the gate's contract.
+
+It would also relocate rather than avoid the cost that disqualified a
+preprocess throw: zygarden trips this on five tokens on day one, and a red gate
+is a red gate wherever it fires.
+
+Precedent exists in the same function: `unparsedLines` and `unemittedTokens` are
+both reported and both excluded from `ok` — zygarden shows 19 unemitted tokens
+today at exit 0.
+
+### 6.2 Where the type comes from
+
+`flattenDtcg` returns `{ path: rawValue }` and drops `$type`. It has four
+consumers — `validate-crosswalk.mjs`, `validate-token-output.mjs`,
+`findModeCollisions`, and `sd-native.mjs`'s `preprocess` — and both validators
+re-export it for the installed-file pattern. **Changing its return shape is out
+of the question**; this is strictly additive.
+
+A new `flattenDtcgTypes(obj)` in `lib/dtcg.mjs`, mirroring `flattenDtcg`'s walk
+and returning `{ path: effectiveType }`:
+
+- a token's own `$type` wins;
+- otherwise the nearest ancestor **group**'s `$type`;
+- a `$value`-bearing node is **not** an inheritance source for its children.
+
+That third rule is the same one `hoistDualNodes` computes as `inherited`, and it
+must match, or two functions in this codebase disagree about the type of the
+same tree.
+
+### 6.3 Deliberately not implemented
+
+**DTCG §5.2.2 rule 1** — a reference-valued token takes its referent's type — is
+not resolved here. An alias to a unitless dimension is not flagged; its
+*referent* is, and the referent is the token the author edits. Flagging both
+would be noise. Stated as a limit, in the manner of #63 and #64, rather than
+hidden.
+
+**#36's blind spot is inherited, not worsened.** The rule maps symbol to source
+through the same `byKey` map, so a `normalizeKey` collision affects it exactly
+as it affects the existing rules. The two items now touch the same file; #36
+remains the place that is fixed.
+
+## 7. Behaviour change and falsifiable prediction
+
+The rule, in full:
+
+> A token whose authored value parses as a bare number carrying no unit is not
+> claimed by any size transform, on either platform. It emits its raw value.
+> `tokens:validate-output` reports it as `unitless-dimension` when its effective
+> `$type` is `dimension` or `fontSize`, without failing the gate.
+
+**Prediction, to be checked by `diff -r` between a build at `main` and a build
+at HEAD against zygarden's real source:**
+
+| | before | after |
+|---|---|---|
+| Kotlin declarations | 195 | 195 |
+| Containing `.sp` | 39 | 39 |
+| Containing `.dp` | 50 | **45** |
+| Changed lines, Kotlin | — | **5** (`leading*`, `N.dp` -> bare) |
+| Changed lines, Swift | — | **5** (`CGFloat(N)` -> bare) |
+| Every other line, both files | — | **byte-identical** |
+| `tokens:validate-output` exit | 0 | 0, with 5 advisories |
+
+If `.dp` does not land on exactly 45, something moved that should not have, and
+the diff says what. Counting declarations alone would miss compensating changes;
+the byte-level diff is the assertion.
+
+**Tests.**
+
+- `lib/dtcg.test.mjs` — `flattenDtcgTypes`: own type; inherited from a group;
+  a `$value`-bearing node not acting as an inheritance source; nested groups;
+  no type at all.
+- `lib/sd-native.test.mjs` — the ratio predicate; each of the three size
+  transforms declining a unitless value.
+- `lib/sd-native.test.mjs` — **the output-neutrality invariant of §5.2**, as an
+  executed assertion: the same value authored as `$type: dimension` and as
+  `$type: number` emits identical output on both platforms.
+- `lib/sd-native.test.mjs` — **the unitless-zero regression of §5.4**, asserted
+  explicitly, so the cost is recorded in a test and cannot later be reverted as
+  though it were a bug.
+- `validate-token-output.test.mjs` — the rule fires on a unitless dimension;
+  does **not** fire on a unitless `number` or `fontWeight` (all 18 of zygarden's
+  unitless non-dimensions are `fontWeight`); `ok` stays `true`; the advisory
+  renders in `formatReport`.
+
+## 8. Constraints
+
+**Branch off `main`.** #68 is merged and no native branch is open. This is the
+first item in the sequence that does not stack — #53, #55, #51 and #60 all had
+to, because `scripts/lib/sd-native.mjs` generates
+`references/native-adapter-config.md` from its whole body and concurrent
+branches conflict guaranteed. If another native branch opens before this lands,
+stack on it and retarget this PR to `main` **before** the parent merges: merging
+a parent with `--delete-branch` auto-closes a stacked PR that cannot be reopened
+once its head has been rebased, which cost PR #65.
+
+**Regenerate the doc as part of the task, not at the end of the branch.** A
+freshness test goes red the moment the module changes, and a suite with a known
+failure is one a real regression hides behind.
+
+**The e2e harness is scratchpad-only.** It survives at
+`<scratchpad>/e2e` with Style Dictionary 4.4.0 and `scripts/lib` symlinked to
+the repo's live tree. Rebuilding is the first step of any e2e run. No token
+source is vendored: zygarden is external at `~/Dev/zygarden-frontend`, branch
+`feature/apply-brandguide-styles`, read with `git show <branch>:<path>`. **Do
+not check it out or modify it.**
+
+**Verify at the emitted-output layer.** Executing the preprocessor is not
+executing the pipeline. Every severity claim in §1 and §2 was measured on
+emitted Kotlin and Swift, and every claim the plan adds must be too.
+
+## 9. Documentation to update
+
+The "three limits remain" list exists in **two** places that both feed the
+generated doc, and `node scripts/build-native-adapter-config.mjs --check` gates
+freshness in CI:
+
+1. `scripts/build-native-adapter-config.mjs` — the prose list at ~line 133.
+2. `scripts/lib/sd-native.mjs` — the same list in the `platform` doc-section's
+   comment, plus the `ABSOLUTE_UNIT` comment at ~line 235, whose reasoning
+   about the unitless case is superseded by §5.3.
+3. `references/native-adapter-config.md` — regenerated.
+
+Three remaining limits become two: the bare scale primitive (#63) and the
+`em`-valued `letterSpacing` (#64).
+
+**Changelog.** The `Unreleased` section gets the §5.5 trade stated as a
+regression, not only as a fix.
+
+## 10. Follow-ups to file
+
+- **The `number` type is unreachable from a Figma-derived source.** Figma emits
+  no DTCG `number` tokens, so every ratio arrives mistyped and every user of
+  this pipeline will meet the §6 advisory. Whether throughline's Figma
+  extraction should type ratios as `number` at the source is a separate item,
+  and the one that would actually close this class.
+- Anything the implementation turns up that is out of scope here — filed rather
+  than absorbed, per #60 and #67.

--- a/references/native-adapter-config.md
+++ b/references/native-adapter-config.md
@@ -303,10 +303,12 @@ export const EXT_NS = 'com.radicool.throughline';
 
 // px and rem only. magnitude() reads a bare number as an unscaled ratio, so a
 // lineHeight authored "1.5" would otherwise be stamped and emit 1.50.sp —
-// which compiles and renders 1.5sp text. That trades a loud failure (a Dp
-// where a TextUnit is required) for a silent one, which is the failure class
-// this module exists to prevent. A ratio keeps today's behaviour and stays the
-// separate defect it already is.
+// which compiles and renders 1.5sp text, trading a loud failure for a silent
+// one. Since #52 a unitless value is declined by every size transform and
+// emits bare, which is what DTCG 8.7 and 9.8 say a ratio is, so this gate is
+// no longer the only thing standing between a ratio and 1.50.sp. It stays
+// because the stamp is also the override's carrier, and stamping a ratio as
+// text would still be a claim the source never made.
 const ABSOLUTE_UNIT = /^-?(?:\d+(?:\.\d+)?|\.\d+)(?:px|rem)$/;
 
 // Runs AFTER resolveInPlace and BEFORE hoistDualNodes. Both halves matter.
@@ -333,9 +335,12 @@ function classifyTextUnits(node) {
       val.$extensions ??= {};
       val.$extensions[EXT_NS] ??= {};
       const ns = val.$extensions[EXT_NS];
-      // A source that states the role itself wins. This is the override, and
-      // it costs no configuration parameter: declining to overwrite IS the
-      // feature. It is also what makes the pass idempotent.
+      // A source that states the role itself wins — for a value that HAS a
+      // unit. The override chooses between dp and sp; it does not manufacture
+      // one, so a unitless value is declined by every size transform regardless
+      // of what is stamped here (see isRatio, #52). Declining to overwrite IS
+      // the feature: it costs no configuration parameter, and it is what makes
+      // the pass idempotent.
       if (!('nativeUnit' in ns)) ns.nativeUnit = 'text';
     }
     classifyTextUnits(val);
@@ -419,7 +424,7 @@ unit.
 // That last one is fixed for tokens whose role a DTCG source actually states:
 // classifyTextUnits stamps fontSize, letterSpacing and lineHeight members, and
 // the sp transform gates on the stamp rather than on a $type DTCG never emits.
-// Three limits remain, all Android-only and all measured rather than
+// Two limits remain, both Android-only and both measured rather than
 // theoretical — see docs/superpowers/notes/2026-08-21-native-config-e2e-results.md:
 //
 //   - A scale primitive carries no role. text.base: "16px" is a font size only
@@ -427,12 +432,10 @@ unit.
 //     correct, and those are what a consumer should reach for.
 //   - An em-valued letterSpacing is filtered out of native output entirely,
 //     rather than emitted as Compose's .em TextUnit.
-//   - A unitless ratio emits as dp. leading.normal: "1.5" gives 1.50.dp, but
-//     that token is excluded twice over — its key is not a typography member
-//     AND its value has no absolute unit. The gate that carries the weight is
-//     the second one: a lineHeight-keyed "1.5" is deliberately NOT stamped,
-//     because 1.50.sp would compile and render 1.5sp text, turning a loud
-//     failure into a silent one.
+//
+// The third — a unitless ratio emitting as dp — is fixed by #52: no size
+// transform claims a unitless value, so it emits bare on both platforms, and
+// tokens:validate-output reports it as a unitless-dimension advisory.
 //
 // Stock, from SD 4.4.0:
 //   ios-swift: attribute/cti name/camel color/UIColorSwift
@@ -625,6 +628,18 @@ const authored = (token) => magnitude(token.original?.$value ?? token.$value);
 const isDimension = (token) => token.$type === 'dimension';
 const isFontSize = (token) => token.$type === 'fontSize';
 const hasMagnitude = (token) => authored(token) !== null;
+// A unitless value is a ratio, not a measurement. DTCG 8.2.1 requires a
+// dimension to carry a unit ("still required even if $value.value is 0"), 8.7's
+// `number` is the type for a multiplier, and 9.8 types lineHeight as one — so a
+// unitless dimension is malformed input, and appending dp/sp/CGFloat to it
+// invents a unit the source never stated. Declining it emits the raw value,
+// which is exactly what a correctly typed `number` already produces.
+//
+// Reads the ORIGINAL authored value, like authored(), and must: preprocess has
+// already resolved references by transform time, and a value transform earlier
+// in the chain may have rewritten $value.
+const RATIO = /^-?(?:\d+(?:\.\d+)?|\.\d+)$/;
+const isRatio = (token) => RATIO.test(String(token.original?.$value ?? token.$value).trim());
 // The role preprocess stamped. $type cannot carry it — see classifyTextUnits.
 const isTextUnit = (token) => token.$extensions?.[EXT_NS]?.nativeUnit === 'text';
 
@@ -680,7 +695,7 @@ export function registerNativeTransforms(StyleDictionary) {
     name: 'size/unit-aware/swift',
     type: 'value',
     transitive: true,
-    filter: (token) => (isDimension(token) || isFontSize(token)) && hasMagnitude(token),
+    filter: (token) => (isDimension(token) || isFontSize(token)) && hasMagnitude(token) && !isRatio(token),
     transform: (token) => `CGFloat(${authored(token).toFixed(2)})`,
   });
 
@@ -694,7 +709,7 @@ export function registerNativeTransforms(StyleDictionary) {
     name: 'size/unit-aware/compose-dp',
     type: 'value',
     transitive: true,
-    filter: (token) => isDimension(token) && !isTextUnit(token) && hasMagnitude(token),
+    filter: (token) => isDimension(token) && !isTextUnit(token) && hasMagnitude(token) && !isRatio(token),
     transform: (token) => `${authored(token).toFixed(2)}.dp`,
   });
 
@@ -702,7 +717,7 @@ export function registerNativeTransforms(StyleDictionary) {
     name: 'size/unit-aware/compose-sp',
     type: 'value',
     transitive: true,
-    filter: (token) => (isTextUnit(token) || isFontSize(token)) && hasMagnitude(token),
+    filter: (token) => (isTextUnit(token) || isFontSize(token)) && hasMagnitude(token) && !isRatio(token),
     transform: (token) => `${authored(token).toFixed(2)}.sp`,
   });
 

--- a/references/native-adapter-config.md
+++ b/references/native-adapter-config.md
@@ -385,7 +385,7 @@ Build the transform list from Style Dictionary's **stock group**, replacing only
 the rem-assuming size transforms. A hand-picked list silently drops whatever it
 forgets — three real defects arose exactly that way.
 
-**The `dp`/`sp` split is fixed here; three narrower Android-only limits remain.**
+**The `dp`/`sp` split is fixed here; two narrower Android-only limits remain.**
 Style Dictionary's Compose transforms select on `$type`, and DTCG's type set
 does not line up with what they expect — there is no `fontSize` type, because
 DTCG types font sizes as `dimension`. So the role is taken instead from the
@@ -403,16 +403,21 @@ What remains:
 - **An `em`-valued `letterSpacing` is dropped from native output entirely**
   rather than emitted as Compose's `.em` TextUnit. A filter gap, not a
   `dp`/`sp` gap.
-- **A unitless ratio emits as `dp`.** `leading.normal: "1.5"`, typed
-  `dimension`, emits `1.50.dp`. The magnitude is faithful; the unit is
-  semantically wrong. It is deliberately not stamped — `1.50.sp` would compile
-  and render 1.5sp text, turning a loud failure into a silent one.
 
-All three are Android-only. `size/unit-aware/swift` filters
+Both are Android-only. `size/unit-aware/swift` filters
 `dimension || fontSize` and emits `CGFloat`, which carries no unit to be wrong
 about; iOS handles Dynamic Type at the use site via `UIFontMetrics`.
-`tokens:validate-output` passes in all three cases: it checks magnitude, not
-unit.
+`tokens:validate-output` passes in both cases: it checks magnitude, not unit.
+
+**A unitless value is no longer one of them.** DTCG §8.2.1 requires a dimension
+to carry a unit, §8.7's `number` is the type for a ratio, and §9.8 types
+`lineHeight` as one — so `leading.normal: "1.5"` typed `dimension` is malformed
+input. No size transform claims it: it emits bare on both platforms, which is
+byte-for-byte what a correctly typed `number` already produced, so correcting
+the source's `$type` changes no output. `tokens:validate-output` reports it as
+a `unitless-dimension` advisory, which does not gate — the emitted value is
+right under the ratio reading, and only the author can say whether a ratio is
+what was meant.
 
 ```js
 // Build each platform's transform list from Style Dictionary's STOCK group,

--- a/references/sync-adapters.md
+++ b/references/sync-adapters.md
@@ -78,8 +78,8 @@ line heights whose role a DTCG source states — the `fontSize`, `letterSpacing`
 and `lineHeight` member names of §9.8's typography composite — now emit as
 `sp`. What remains is narrower and documented in
 `${CLAUDE_PLUGIN_ROOT}/references/native-adapter-config.md`: a bare scale
-primitive carries no role and stays `dp`, an `em` letterSpacing is filtered
-out rather than emitted as `.em`, and a unitless ratio still emits as `dp`.
+primitive carries no role and stays `dp`, and an `em` letterSpacing is
+filtered out rather than emitted as `.em`.
 `tokens:validate-output` remains what decides whether any adapter can be
 trusted, and re-promotion is available to any adapter that passes it against a
 real source.

--- a/scripts/build-native-adapter-config.mjs
+++ b/scripts/build-native-adapter-config.mjs
@@ -112,7 +112,7 @@ Build the transform list from Style Dictionary's **stock group**, replacing only
 the rem-assuming size transforms. A hand-picked list silently drops whatever it
 forgets — three real defects arose exactly that way.
 
-**The \`dp\`/\`sp\` split is fixed here; three narrower Android-only limits remain.**
+**The \`dp\`/\`sp\` split is fixed here; two narrower Android-only limits remain.**
 Style Dictionary's Compose transforms select on \`$type\`, and DTCG's type set
 does not line up with what they expect — there is no \`fontSize\` type, because
 DTCG types font sizes as \`dimension\`. So the role is taken instead from the
@@ -130,16 +130,21 @@ What remains:
 - **An \`em\`-valued \`letterSpacing\` is dropped from native output entirely**
   rather than emitted as Compose's \`.em\` TextUnit. A filter gap, not a
   \`dp\`/\`sp\` gap.
-- **A unitless ratio emits as \`dp\`.** \`leading.normal: "1.5"\`, typed
-  \`dimension\`, emits \`1.50.dp\`. The magnitude is faithful; the unit is
-  semantically wrong. It is deliberately not stamped — \`1.50.sp\` would compile
-  and render 1.5sp text, turning a loud failure into a silent one.
 
-All three are Android-only. \`size/unit-aware/swift\` filters
+Both are Android-only. \`size/unit-aware/swift\` filters
 \`dimension || fontSize\` and emits \`CGFloat\`, which carries no unit to be wrong
 about; iOS handles Dynamic Type at the use site via \`UIFontMetrics\`.
-\`tokens:validate-output\` passes in all three cases: it checks magnitude, not
-unit.`],
+\`tokens:validate-output\` passes in both cases: it checks magnitude, not unit.
+
+**A unitless value is no longer one of them.** DTCG §8.2.1 requires a dimension
+to carry a unit, §8.7's \`number\` is the type for a ratio, and §9.8 types
+\`lineHeight\` as one — so \`leading.normal: "1.5"\` typed \`dimension\` is malformed
+input. No size transform claims it: it emits bare on both platforms, which is
+byte-for-byte what a correctly typed \`number\` already produced, so correcting
+the source's \`$type\` changes no output. \`tokens:validate-output\` reports it as
+a \`unitless-dimension\` advisory, which does not gate — the emitted value is
+right under the ratio reading, and only the author can say whether a ratio is
+what was meant.`],
   ['sources', `## 5. Guard the per-mode source list
 
 Style Dictionary deduplicates by dot-path, so one build over both a light and a

--- a/scripts/lib/dtcg.mjs
+++ b/scripts/lib/dtcg.mjs
@@ -23,6 +23,34 @@ export function flattenDtcg(obj, prefix = [], out = {}) {
   return out;
 }
 
+// Flatten nested DTCG groups into { "dot.path": effectiveType }, applying the
+// $type resolution of DTCG 5.2.2: a token's own $type wins, otherwise the
+// nearest ancestor GROUP's. A node carrying a $value is a token, not a group
+// (DTCG 6.1), so it is not an inheritance source for its children — the same
+// rule hoistDualNodes computes as `inherited`, and the two must agree or two
+// functions in this codebase disagree about the type of the same tree.
+//
+// Separate from flattenDtcg rather than folded into it: that function has four
+// consumers and both validators re-export it, so its return shape is fixed.
+//
+// LIMIT, stated rather than hidden: this reads the RAW source, so it cannot see
+// the $type carry hoistDualNodes applies during preprocessing. An untyped child
+// of a dimension-typed dual node with no enclosing group type is a dimension to
+// the pipeline and undefined here. Reference-derived typing (5.2.2 rule 1) is
+// likewise not resolved — an alias is undefined, but its referent is typed, and
+// the referent is the token an author edits.
+export function flattenDtcgTypes(obj, prefix = [], out = {}, groupType = undefined) {
+  const inherited = '$value' in obj ? groupType : (obj.$type ?? groupType);
+  for (const [key, val] of Object.entries(obj)) {
+    if (key.startsWith('$')) continue;
+    if (!val || typeof val !== 'object') continue;
+    const path = [...prefix, key];
+    if ('$value' in val) out[path.join('.')] = val.$type ?? inherited;
+    flattenDtcgTypes(val, path, out, inherited);
+  }
+  return out;
+}
+
 // Follow {alias} chains to a leaf literal. Throws on missing or circular refs.
 export function resolveValue(name, flat, seen = new Set()) {
   if (!(name in flat)) throw new Error(`token "${name}" not found in DTCG source`);

--- a/scripts/lib/dtcg.test.mjs
+++ b/scripts/lib/dtcg.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { flattenDtcg, resolveValue, findModeCollisions } from './dtcg.mjs';
+import { flattenDtcg, flattenDtcgTypes, resolveValue, findModeCollisions } from './dtcg.mjs';
 
 // text.sm is a DUAL-NODE token: it carries its own $value AND a child.
 const dtcg = {
@@ -92,4 +92,46 @@ test('findModeCollisions sees dual-node children', () => {
   ]);
   assert.equal(collisions.length, 1);
   assert.equal(collisions[0].path, 'text.sm.lineHeight');
+});
+
+test('flattenDtcgTypes reports a token own $type', () => {
+  const types = flattenDtcgTypes(dtcg);
+  assert.equal(types['text.sm'], 'dimension');
+  assert.equal(types['color.gray.900'], 'color');
+});
+
+test('flattenDtcgTypes inherits from the nearest ancestor group', () => {
+  const types = flattenDtcgTypes({
+    leading: { $type: 'dimension', normal: { $value: '1.5' } },
+  });
+  assert.equal(types['leading.normal'], 'dimension');
+});
+
+// DTCG 6.1: a node carrying a $value is a token, not a group, so it is not an
+// inheritance source. The same rule hoistDualNodes computes as `inherited`.
+test('flattenDtcgTypes does not inherit from a $value-bearing node', () => {
+  const types = flattenDtcgTypes({
+    text: { sm: { $value: '14px', $type: 'dimension', lineHeight: { $value: '20px' } } },
+  });
+  assert.equal(types['text.sm'], 'dimension');
+  assert.equal(types['text.sm.lineHeight'], undefined);
+});
+
+test('flattenDtcgTypes keeps an enclosing group type across a dual node', () => {
+  const types = flattenDtcgTypes({
+    text: { $type: 'dimension', sm: { $value: '14px', lineHeight: { $value: '20px' } } },
+  });
+  assert.equal(types['text.sm.lineHeight'], 'dimension');
+});
+
+test('flattenDtcgTypes lets an own $type beat an inherited one', () => {
+  const types = flattenDtcgTypes({
+    g: { $type: 'dimension', a: { $value: '400', $type: 'fontWeight' } },
+  });
+  assert.equal(types['g.a'], 'fontWeight');
+});
+
+test('flattenDtcgTypes returns undefined where nothing supplies a type', () => {
+  const types = flattenDtcgTypes({ g: { a: { $value: '1.5' } } });
+  assert.equal(types['g.a'], undefined);
 });

--- a/scripts/lib/sd-native.mjs
+++ b/scripts/lib/sd-native.mjs
@@ -234,10 +234,12 @@ export const EXT_NS = 'com.radicool.throughline';
 
 // px and rem only. magnitude() reads a bare number as an unscaled ratio, so a
 // lineHeight authored "1.5" would otherwise be stamped and emit 1.50.sp —
-// which compiles and renders 1.5sp text. That trades a loud failure (a Dp
-// where a TextUnit is required) for a silent one, which is the failure class
-// this module exists to prevent. A ratio keeps today's behaviour and stays the
-// separate defect it already is.
+// which compiles and renders 1.5sp text, trading a loud failure for a silent
+// one. Since #52 a unitless value is declined by every size transform and
+// emits bare, which is what DTCG 8.7 and 9.8 say a ratio is, so this gate is
+// no longer the only thing standing between a ratio and 1.50.sp. It stays
+// because the stamp is also the override's carrier, and stamping a ratio as
+// text would still be a claim the source never made.
 const ABSOLUTE_UNIT = /^-?(?:\d+(?:\.\d+)?|\.\d+)(?:px|rem)$/;
 
 // Runs AFTER resolveInPlace and BEFORE hoistDualNodes. Both halves matter.
@@ -264,9 +266,12 @@ function classifyTextUnits(node) {
       val.$extensions ??= {};
       val.$extensions[EXT_NS] ??= {};
       const ns = val.$extensions[EXT_NS];
-      // A source that states the role itself wins. This is the override, and
-      // it costs no configuration parameter: declining to overwrite IS the
-      // feature. It is also what makes the pass idempotent.
+      // A source that states the role itself wins — for a value that HAS a
+      // unit. The override chooses between dp and sp; it does not manufacture
+      // one, so a unitless value is declined by every size transform regardless
+      // of what is stamped here (see isRatio, #52). Declining to overwrite IS
+      // the feature: it costs no configuration parameter, and it is what makes
+      // the pass idempotent.
       if (!('nativeUnit' in ns)) ns.nativeUnit = 'text';
     }
     classifyTextUnits(val);
@@ -315,7 +320,7 @@ export function preprocess(dict) {
 // That last one is fixed for tokens whose role a DTCG source actually states:
 // classifyTextUnits stamps fontSize, letterSpacing and lineHeight members, and
 // the sp transform gates on the stamp rather than on a $type DTCG never emits.
-// Three limits remain, all Android-only and all measured rather than
+// Two limits remain, both Android-only and both measured rather than
 // theoretical — see docs/superpowers/notes/2026-08-21-native-config-e2e-results.md:
 //
 //   - A scale primitive carries no role. text.base: "16px" is a font size only
@@ -323,12 +328,10 @@ export function preprocess(dict) {
 //     correct, and those are what a consumer should reach for.
 //   - An em-valued letterSpacing is filtered out of native output entirely,
 //     rather than emitted as Compose's .em TextUnit.
-//   - A unitless ratio emits as dp. leading.normal: "1.5" gives 1.50.dp, but
-//     that token is excluded twice over — its key is not a typography member
-//     AND its value has no absolute unit. The gate that carries the weight is
-//     the second one: a lineHeight-keyed "1.5" is deliberately NOT stamped,
-//     because 1.50.sp would compile and render 1.5sp text, turning a loud
-//     failure into a silent one.
+//
+// The third — a unitless ratio emitting as dp — is fixed by #52: no size
+// transform claims a unitless value, so it emits bare on both platforms, and
+// tokens:validate-output reports it as a unitless-dimension advisory.
 //
 // Stock, from SD 4.4.0:
 //   ios-swift: attribute/cti name/camel color/UIColorSwift
@@ -508,6 +511,18 @@ const authored = (token) => magnitude(token.original?.$value ?? token.$value);
 const isDimension = (token) => token.$type === 'dimension';
 const isFontSize = (token) => token.$type === 'fontSize';
 const hasMagnitude = (token) => authored(token) !== null;
+// A unitless value is a ratio, not a measurement. DTCG 8.2.1 requires a
+// dimension to carry a unit ("still required even if $value.value is 0"), 8.7's
+// `number` is the type for a multiplier, and 9.8 types lineHeight as one — so a
+// unitless dimension is malformed input, and appending dp/sp/CGFloat to it
+// invents a unit the source never stated. Declining it emits the raw value,
+// which is exactly what a correctly typed `number` already produces.
+//
+// Reads the ORIGINAL authored value, like authored(), and must: preprocess has
+// already resolved references by transform time, and a value transform earlier
+// in the chain may have rewritten $value.
+const RATIO = /^-?(?:\d+(?:\.\d+)?|\.\d+)$/;
+const isRatio = (token) => RATIO.test(String(token.original?.$value ?? token.$value).trim());
 // The role preprocess stamped. $type cannot carry it — see classifyTextUnits.
 const isTextUnit = (token) => token.$extensions?.[EXT_NS]?.nativeUnit === 'text';
 
@@ -563,7 +578,7 @@ export function registerNativeTransforms(StyleDictionary) {
     name: 'size/unit-aware/swift',
     type: 'value',
     transitive: true,
-    filter: (token) => (isDimension(token) || isFontSize(token)) && hasMagnitude(token),
+    filter: (token) => (isDimension(token) || isFontSize(token)) && hasMagnitude(token) && !isRatio(token),
     transform: (token) => `CGFloat(${authored(token).toFixed(2)})`,
   });
 
@@ -577,7 +592,7 @@ export function registerNativeTransforms(StyleDictionary) {
     name: 'size/unit-aware/compose-dp',
     type: 'value',
     transitive: true,
-    filter: (token) => isDimension(token) && !isTextUnit(token) && hasMagnitude(token),
+    filter: (token) => isDimension(token) && !isTextUnit(token) && hasMagnitude(token) && !isRatio(token),
     transform: (token) => `${authored(token).toFixed(2)}.dp`,
   });
 
@@ -585,7 +600,7 @@ export function registerNativeTransforms(StyleDictionary) {
     name: 'size/unit-aware/compose-sp',
     type: 'value',
     transitive: true,
-    filter: (token) => (isTextUnit(token) || isFontSize(token)) && hasMagnitude(token),
+    filter: (token) => (isTextUnit(token) || isFontSize(token)) && hasMagnitude(token) && !isRatio(token),
     transform: (token) => `${authored(token).toFixed(2)}.sp`,
   });
 

--- a/scripts/lib/sd-native.test.mjs
+++ b/scripts/lib/sd-native.test.mjs
@@ -708,13 +708,19 @@ test('an enclosing group $type is not shadowed by the dual node $type', () => {
 // badly. b inherits color before the hoist — a is a token, so g is b's closest
 // group either way — and carrying dimension here would be the hoist inventing a
 // better answer than the source states.
-// The variant with teeth, and the reason this is worth fixing rather than
-// documenting. Measured end-to-end through Style Dictionary against the real
-// Compose config: with the carry, this emits `val textSmLineHeight = 1.5` — a
-// Double where a Dp belongs, which compiles and passes tokens:validate-output
-// clean, because no-bare-units fires only on a unit-suffixed literal. Without
-// it, 1.50.dp. The issue's own 20px example is the LOUD one: it emits a bare
-// `20px` the gate catches under no-bare-units and unverifiable-dimension.
+// The variant with teeth when this was written, and the reason it was worth
+// fixing rather than documenting. Measured end-to-end through Style
+// Dictionary against the real Compose config: with the carry (the bug),
+// $type stays 'number' and this emits `val textSmLineHeight = 1.5` — a
+// Double where a Dp belongs, which compiled and passed
+// tokens:validate-output clean, because no-bare-units fires only on a
+// unit-suffixed literal. Without it, $type resolves to 'dimension' via the
+// enclosing group — which, since #52, ALSO emits bare `1.5`: a unitless
+// dimension now declines every size transform, so this shape no longer has
+// output-level teeth and the assertion below (no `$type` stamped) is what
+// still pins it. The issue's own 20px example is the LOUD one: it emits a
+// bare `20px` the gate catches under no-bare-units and
+// unverifiable-dimension.
 test('an enclosing group is not shadowed where the shadowed output would compile', () => {
   const out = preprocess({
     text: {
@@ -817,10 +823,12 @@ test('the reference tag does not leak into output', () => {
   assert.equal(JSON.stringify(out).includes('was-reference'), false);
 });
 
-// #55's fix widens #52 rather than masking it: an untyped unitless literal child
-// under a dimension-typed dual node now becomes dimension, which is exactly
-// #52's shape. Asserted so the widening is recorded, not discovered later.
-test('the $type rule widens #52 — recorded, not masked', () => {
+// The carry widens the shape #52 fixes, rather than masking it: an untyped
+// unitless literal child under a dimension-typed dual node becomes dimension
+// too — and since #52, a unitless dimension declines every size transform
+// and emits bare, so the widened shape gets #52's fix rather than #52's old
+// defect. Asserted so the widening is recorded, not discovered later.
+test('the $type rule widens the #52 shape — recorded, not masked', () => {
   const out = preprocess({
     leading: { base: { $value: '16px', $type: 'dimension', normal: { $value: '1.5' } } },
   });

--- a/scripts/lib/sd-native.test.mjs
+++ b/scripts/lib/sd-native.test.mjs
@@ -1013,9 +1013,11 @@ test('the compose transforms split sp from dp by the text-unit stamp', () => {
   assert.equal(dp.transform(device), '16.00.dp');
 });
 
-// The partition must be disjoint AND total: exactly one of the two filters
-// matches. Asserting `dp && sp === false` alone would pass against an
-// implementation where both always return false, so assert the exclusive-or.
+// The partition must be disjoint AND total FOR A TOKEN THAT CARRIES A UNIT:
+// exactly one of the two filters matches. Asserting `dp && sp === false` alone
+// would pass against an implementation where both always return false, so
+// assert the exclusive-or. A unitless value matches neither, deliberately (#52),
+// and is covered by its own tests rather than folded in here.
 test('no dimension token matches both compose transforms', () => {
   const t = collectTransforms();
   const dp = t.get('size/unit-aware/compose-dp');
@@ -1057,4 +1059,92 @@ test('a resolved semantic fontSize reaches the sp transform', () => {
   const sp = collectTransforms().get('size/unit-aware/compose-sp');
   assert.equal(sp.filter(token), true);
   assert.equal(sp.transform(token), '30.00.sp');
+});
+
+// #52. DTCG 8.2.1 requires a dimension to carry a unit; 8.7's `number` is the
+// type for a ratio, and 9.8 types lineHeight as one. A unitless value is
+// therefore malformed input, and no size transform may claim it.
+test('no size transform claims a unitless dimension', () => {
+  const t = collectTransforms();
+  const token = { $type: 'dimension', $value: '1.5', original: { $value: '1.5' } };
+  assert.equal(t.get('size/unit-aware/swift').filter(token), false);
+  assert.equal(t.get('size/unit-aware/compose-dp').filter(token), false);
+  assert.equal(t.get('size/unit-aware/compose-sp').filter(token), false);
+});
+
+test('no size transform claims a unitless fontSize', () => {
+  const t = collectTransforms();
+  const token = { $type: 'fontSize', $value: '1.5', original: { $value: '1.5' } };
+  assert.equal(t.get('size/unit-aware/swift').filter(token), false);
+  assert.equal(t.get('size/unit-aware/compose-sp').filter(token), false);
+});
+
+test('a unitless value is read from the ORIGINAL authored value', () => {
+  const t = collectTransforms();
+  const dp = t.get('size/unit-aware/compose-dp');
+  // $value rewritten by an earlier transform; original is what decides.
+  assert.equal(dp.filter({ $type: 'dimension', $value: '1.50.dp', original: { $value: '1.5' } }), false);
+  assert.equal(dp.filter({ $type: 'dimension', $value: '1.5', original: { $value: '16px' } }), true);
+});
+
+test('a united dimension is still claimed', () => {
+  const t = collectTransforms();
+  const px = { $type: 'dimension', $value: '16px', original: { $value: '16px' } };
+  assert.equal(t.get('size/unit-aware/compose-dp').filter(px), true);
+  assert.equal(t.get('size/unit-aware/swift').filter(px), true);
+});
+
+// Spec 5.2. The load-bearing claim of the design: taking the advisory's advice
+// ("type it number") must not change output.
+//
+// The SWIFT filter is what carries this — it gates on isDimension || isFontSize
+// and so is the only one of the three sensitive to $type. Measured: drop
+// !isRatio from swift alone and $type dimension emits CGFloat(1.50) while
+// $type number emits bare. Keep swift in this loop or the test stops catching
+// the variant that breaks the design.
+test('a unitless value emits identically as $type dimension and as $type number', () => {
+  const t = collectTransforms();
+  const asDimension = { $type: 'dimension', $value: '1.5', original: { $value: '1.5' } };
+  const asNumber = { $type: 'number', $value: '1.5', original: { $value: '1.5' } };
+  for (const name of ['size/unit-aware/swift', 'size/unit-aware/compose-dp', 'size/unit-aware/compose-sp']) {
+    const tr = t.get(name);
+    assert.equal(tr.filter(asDimension), tr.filter(asNumber), `${name} must treat both $types alike`);
+    assert.equal(tr.filter(asDimension), false, `${name} must claim neither`);
+  }
+});
+
+// Spec 5.2. NOT an invariant test, deliberately. The invariant holds whether or
+// not compose-sp carries !isRatio — measured, not assumed — because compose-sp
+// filters on isTextUnit, which reads the stamp rather than $type, so a stamped
+// token behaves the same under both $types either way. Only a direct
+// behavioural assertion catches a missing !isRatio here.
+//
+// What it would emit without the guard: 1.50.sp — 1.5 scale-pixels of text,
+// which is the output #51 gated ABSOLUTE_UNIT to prevent. An explicit stamp
+// must not be able to produce it either.
+test('a stamped unitless token is still declined — the override cannot manufacture a unit', () => {
+  const sp = collectTransforms().get('size/unit-aware/compose-sp');
+  assert.equal(sp.filter(stamped('1.5')), false);
+  assert.equal(sp.filter({ ...stamped('1.5'), $type: 'number' }), false);
+});
+
+// The override's scope, narrowed and pinned: it chooses between dp and sp for a
+// value that HAS a unit. It does not manufacture one.
+test('the nativeUnit override still selects sp for a united value', () => {
+  const sp = collectTransforms().get('size/unit-aware/compose-sp');
+  assert.equal(sp.filter(stamped('30px')), true);
+  assert.equal(sp.transform(stamped('30px')), '30.00.sp');
+});
+
+// Spec 5.4. A unitless zero is invalid DTCG for the same reason (8.2.1 requires
+// the unit "even if $value.value is 0"). Recorded as a test so the behaviour
+// change cannot later be reverted as though it were a bug.
+test('a unitless zero is a ratio, not a zero measurement', () => {
+  const t = collectTransforms();
+  const zero = { $type: 'dimension', $value: '0', original: { $value: '0' } };
+  assert.equal(t.get('size/unit-aware/compose-dp').filter(zero), false);
+  assert.equal(t.get('size/unit-aware/swift').filter(zero), false);
+  // "0px" is a measurement and is unaffected.
+  const zeroPx = { $type: 'dimension', $value: '0px', original: { $value: '0px' } };
+  assert.equal(t.get('size/unit-aware/compose-dp').filter(zeroPx), true);
 });

--- a/scripts/validate-token-output.mjs
+++ b/scripts/validate-token-output.mjs
@@ -103,6 +103,12 @@ const BARE_UNIT = /^-?(?:\d+(?:\.\d+)?|\.\d+)(?:px|rem|em|%)$/;
 const UNITLESS = /^-?(?:\d+(?:\.\d+)?|\.\d+)$/;
 const DIMENSIONAL = new Set(['dimension', 'fontSize']);
 
+// A token whose RAW authored $value is itself a whole-value reference is not
+// flagged: its referent is (per DTCG 5.2.2, an alias takes the referent's
+// type), and `source` above is already the RESOLVED value, so testing it
+// alone would flag both the alias and its referent for the same problem.
+const WHOLE_REF = /^\{[^}]+\}$/;
+
 // Lines that are obviously not a would-be token declaration: braces-only,
 // comments, imports/package/annotations, or the container declarations
 // (enum/object/class) themselves. Anything else that DECL failed to match is
@@ -183,7 +189,11 @@ export function validate({ sources, output, platform, minMatch = 0.5 }) {
     // Advisory, not a failure: the emitted value is correct under the ratio
     // reading this build applies, so it compiles and its magnitude matches.
     // What is wrong is the SOURCE's $type, which only the author can settle.
-    if (UNITLESS.test(String(source).trim()) && DIMENSIONAL.has(types[path])) {
+    if (
+      UNITLESS.test(String(source).trim()) &&
+      DIMENSIONAL.has(types[path]) &&
+      !WHOLE_REF.test(String(flat[path]).trim())
+    ) {
       advisories.push({ rule: 'unitless-dimension', symbol, token: path, source, emitted: value });
     }
 

--- a/scripts/validate-token-output.mjs
+++ b/scripts/validate-token-output.mjs
@@ -7,11 +7,11 @@
 import { readFileSync } from 'node:fs';
 import { parseArgs } from 'node:util';
 import { pathToFileURL } from 'node:url';
-import { flattenDtcg, resolveValue, findModeCollisions } from './lib/dtcg.mjs';
+import { flattenDtcg, flattenDtcgTypes, resolveValue, findModeCollisions } from './lib/dtcg.mjs';
 import { parseLiteral, isValidLiteral, GRAMMAR } from './lib/native-literal.mjs';
 
 // Re-exported so consumers (and the test file) keep one import surface.
-export { flattenDtcg, resolveValue, findModeCollisions };
+export { flattenDtcg, flattenDtcgTypes, resolveValue, findModeCollisions };
 
 // Declaration patterns per platform. Coupled to the ios-swift/enum.swift and
 // compose/object output formats; a different format needs a different pattern,
@@ -96,6 +96,13 @@ export function expectedMagnitude(sourceValue) {
 const FOREIGN = /(?:color-mix|calc|var)\s*\(/;
 const BARE_UNIT = /^-?(?:\d+(?:\.\d+)?|\.\d+)(?:px|rem|em|%)$/;
 
+// #52. A unitless value is a ratio, not a measurement: DTCG 8.2.1 requires a
+// dimension to carry a unit, and 8.7's `number` is the type for a multiplier.
+// Distinct from BARE_UNIT, which requires a unit SUFFIX and so never matches
+// this — which is exactly why the shape passed the gate silently before.
+const UNITLESS = /^-?(?:\d+(?:\.\d+)?|\.\d+)$/;
+const DIMENSIONAL = new Set(['dimension', 'fontSize']);
+
 // Lines that are obviously not a would-be token declaration: braces-only,
 // comments, imports/package/annotations, or the container declarations
 // (enum/object/class) themselves. Anything else that DECL failed to match is
@@ -127,11 +134,15 @@ export function validate({ sources, output, platform, minMatch = 0.5 }) {
   const flat = {};
   for (const { dtcg } of sources) Object.assign(flat, flattenDtcg(dtcg));
 
+  const types = {};
+  for (const { dtcg } of sources) Object.assign(types, flattenDtcgTypes(dtcg));
+
   const byKey = new Map();
   for (const path of Object.keys(flat)) byKey.set(normalizeKey(path), path);
 
   const decls = extractDeclarations(output, platform);
   const failures = [];
+  const advisories = [];
   let matched = 0;
 
   for (const { symbol, value } of decls) {
@@ -169,6 +180,13 @@ export function validate({ sources, output, platform, minMatch = 0.5 }) {
     }
     matched += 1;
 
+    // Advisory, not a failure: the emitted value is correct under the ratio
+    // reading this build applies, so it compiles and its magnitude matches.
+    // What is wrong is the SOURCE's $type, which only the author can settle.
+    if (UNITLESS.test(String(source).trim()) && DIMENSIONAL.has(types[path])) {
+      advisories.push({ rule: 'unitless-dimension', symbol, token: path, source, emitted: value });
+    }
+
     const expected = expectedMagnitude(source);
     if (expected.skip) continue;
     const actual = magnitudeOf(value);
@@ -189,7 +207,7 @@ export function validate({ sources, output, platform, minMatch = 0.5 }) {
   let unemittedTokens = 0;
   for (const key of byKey.keys()) if (!emittedKeys.has(key)) unemittedTokens += 1;
 
-  return { total: decls.length, matched, matchRate, failures, collisions, minMatch, ok, unparsedLines, unemittedTokens };
+  return { total: decls.length, matched, matchRate, failures, advisories, collisions, minMatch, ok, unparsedLines, unemittedTokens };
 }
 
 export function formatReport(r) {
@@ -228,6 +246,14 @@ export function formatReport(r) {
   }
   if (r.unparsedLines) {
     lines.push(`\n${r.unparsedLines} unparsed line(s) — declaration-shaped lines the extractor could not read; they count in neither the numerator nor the denominator above.`);
+  }
+  if (r.advisories?.length) {
+    lines.push(`\n${r.advisories.length} advisory note(s) — reported, not gating:`);
+    for (const a of r.advisories) {
+      lines.push(
+        `  - [${a.rule}] ${a.symbol}: source ${JSON.stringify(a.source)} for ${a.token} is a dimension with no unit, which DTCG §8.2.1 does not permit. It emitted ${a.emitted}, read as a ratio. If it is a ratio, type it "number" (§8.7); if it is a measurement, add the unit you meant.`,
+      );
+    }
   }
   if (r.unemittedTokens) {
     lines.push(`\n${r.unemittedTokens} source token(s) had no matching emitted symbol.`);

--- a/scripts/validate-token-output.test.mjs
+++ b/scripts/validate-token-output.test.mjs
@@ -149,6 +149,53 @@ test('unit-fidelity never scales a unitless ratio', () => {
   assert.equal(bad.failures[0].rule, 'unit-fidelity');
 });
 
+// #52. A unitless dimension is invalid DTCG (8.2.1). The emitted output is
+// correct under the ratio reading, so this is reported and does NOT gate.
+test('unitless-dimension is reported as an advisory', () => {
+  const r = validate({ sources: SRC, output: 'static let leadingTight = 1.1', platform: 'ios-swift' });
+  assert.equal(r.advisories.length, 1);
+  assert.equal(r.advisories[0].rule, 'unitless-dimension');
+  assert.equal(r.advisories[0].token, 'leading.tight');
+});
+
+test('unitless-dimension does not fail the gate', () => {
+  const r = validate({ sources: SRC, output: 'static let leadingTight = 1.1', platform: 'ios-swift' });
+  assert.deepEqual(r.failures, []);
+  assert.equal(r.ok, true);
+});
+
+test('unitless-dimension ignores a unitless non-dimension', () => {
+  const sources = [{ file: 't.json', dtcg: {
+    w: { bold: { $value: '700', $type: 'fontWeight' } },
+    ratio: { golden: { $value: '1.618', $type: 'number' } },
+  } }];
+  const r = validate({ sources, output: 'static let wBold = 700\nstatic let ratioGolden = 1.618', platform: 'ios-swift' });
+  assert.deepEqual(r.advisories, []);
+  assert.equal(r.ok, true);
+});
+
+test('unitless-dimension ignores a dimension that carries a unit', () => {
+  const r = validate({ sources: SRC, output: 'static let textSm = CGFloat(14.00)', platform: 'ios-swift' });
+  assert.deepEqual(r.advisories, []);
+});
+
+test('unitless-dimension fires on a type inherited from a group', () => {
+  const sources = [{ file: 't.json', dtcg: {
+    leading: { $type: 'dimension', normal: { $value: '1.5' } },
+  } }];
+  const r = validate({ sources, output: 'static let leadingNormal = 1.5', platform: 'ios-swift' });
+  assert.equal(r.advisories.length, 1);
+  assert.equal(r.advisories[0].token, 'leading.normal');
+});
+
+test('formatReport renders the advisory and names the fix', () => {
+  const r = validate({ sources: SRC, output: 'static let leadingTight = 1.1', platform: 'ios-swift' });
+  const text = formatReport(r).join('\n');
+  assert.match(text, /unitless-dimension/);
+  assert.match(text, /leadingTight/);
+  assert.match(text, /"number"/);
+});
+
 test('no-foreign-syntax catches leaked color-mix', () => {
   const out = 'static let textSm = color-mix(in srgb, UIColor(red: 1, green: 1, blue: 1, alpha: 1) 4%, transparent)';
   const r = validate({ sources: SRC, output: out, platform: 'ios-swift' });

--- a/scripts/validate-token-output.test.mjs
+++ b/scripts/validate-token-output.test.mjs
@@ -204,6 +204,21 @@ test('unitless-dimension does not double-fire on a typed alias — only the refe
   assert.equal(r.advisories[0].token, 'spacing.space4');
 });
 
+// §6.2: flattenDtcgTypes reads the RAW source, where hoistDualNodes' $type
+// carry has not run yet. A unitless, untyped child of a dimension-typed dual
+// node with no enclosing group $type is flipped from N.dp to bare by the
+// size transforms (§5), but flattenDtcgTypes returns undefined for it here,
+// so DIMENSIONAL.has(undefined) is false and the advisory does not fire.
+// Recorded as a documented limit (spec §6.2), not desired behaviour — a
+// future fix should flip this test rather than go unnoticed.
+test('unitless-dimension misses the hoist carry — documented §6.2 limit', () => {
+  const sources = [{ file: 't.json', dtcg: {
+    leading: { base: { $value: '16px', $type: 'dimension', normal: { $value: '1.5' } } },
+  } }];
+  const r = validate({ sources, output: 'static let leadingBaseNormal = 1.5', platform: 'ios-swift' });
+  assert.deepEqual(r.advisories, []);
+});
+
 test('formatReport renders the advisory and names the fix', () => {
   const r = validate({ sources: SRC, output: 'static let leadingTight = 1.1', platform: 'ios-swift' });
   const text = formatReport(r).join('\n');

--- a/scripts/validate-token-output.test.mjs
+++ b/scripts/validate-token-output.test.mjs
@@ -188,6 +188,22 @@ test('unitless-dimension fires on a type inherited from a group', () => {
   assert.equal(r.advisories[0].token, 'leading.normal');
 });
 
+// A typed alias restates $type on the reference node itself (zygarden authors
+// every alias this way). `source` is the RESOLVED referent value; flagging on
+// that alone would advise both the alias and its referent for the same
+// problem. Only the referent — the token the author would actually edit —
+// should be flagged.
+test('unitless-dimension does not double-fire on a typed alias — only the referent is named', () => {
+  const sources = [{ file: 't.json', dtcg: {
+    spacing: { space4: { $value: '1.5', $type: 'dimension' } },
+    alias: { spacing4: { $value: '{spacing.space4}', $type: 'dimension' } },
+  } }];
+  const out = 'static let spacingSpace4 = 1.5\nstatic let aliasSpacing4 = 1.5';
+  const r = validate({ sources, output: out, platform: 'ios-swift' });
+  assert.equal(r.advisories.length, 1);
+  assert.equal(r.advisories[0].token, 'spacing.space4');
+});
+
 test('formatReport renders the advisory and names the fix', () => {
   const r = validate({ sources: SRC, output: 'static let leadingTight = 1.1', platform: 'ios-swift' });
   const text = formatReport(r).join('\n');

--- a/scripts/validate-token-output.test.mjs
+++ b/scripts/validate-token-output.test.mjs
@@ -492,8 +492,12 @@ test('valid native output produces no invalid-literal failure', () => {
   assert.equal(r.ok, true);
 });
 
-// #52 is open and must stay reachable: this change must not mask it.
-test('a unitless ratio emitted as .dp still passes — #52 is not masked', () => {
+// #52 is now closed — the pipeline itself no longer emits `.dp` for a
+// unitless dimension — but the validator's magnitude checks are unit-agnostic
+// and never depended on that shape: they check magnitude and literal
+// validity against whatever the OUTPUT actually is, not what the current
+// pipeline would produce. Pins that tolerance.
+test('a unitless ratio manually emitted as .dp still passes — the validator only checks magnitude', () => {
   const r = validate({
     sources: srcOf({ leading: { normal: { $value: '1.5', $type: 'dimension' } } }),
     output: 'val leadingNormal = 1.50.dp',


### PR DESCRIPTION
Closes #52.

A unitless DTCG value — `leading.normal: "1.5"` typed `dimension` — emitted `1.50.dp` on Compose and `CGFloat(1.50)` on Swift. One and a half density-independent pixels, for a token that means "1.5× the font size". The magnitude was faithful; the unit was invented.

## What the measurement changed

Measured on zygarden's real source **before** the spec argued anything, per the standing lesson that severity gets read off emitted output rather than an intermediate tree. Three claims in the issue text did not survive:

- **The blast radius is 5 tokens, not a class.** 23 unitless tokens; 18 are `fontWeight` emitting correct bare integers. The 5 are the whole `leading.*` ramp, and **nothing in the source references them**.
- **The Swift half was not the same defect.** `CGFloat` carries no unit claim about anything — `references/native-adapter-config.md` §4 already said so. Swift is changed here for a different reason (below).
- **It was not the "silent half" of the family.** `1.50.dp` is a `Dp`, and Compose's `TextStyle` takes `TextUnit` with no `Dp` overload — so using the token for its actual purpose is a compile error. That was the argument that ranked this item up, and it was wrong.

## The reframing

DTCG **§8.2.1** requires a dimension to carry a unit ("still required even if `$value.value` is `0`"), **§8.7** makes `number` the type for a ratio, and **§9.8** requires `lineHeight` be a `number`. A unitless `dimension` is **invalid DTCG at MUST level** — the same category as the dual node in #55, not a legal shape being interpreted.

And the spec-correct authoring already worked: `$type: number` falls through every size transform and emits bare. Nothing needed building for the correct input.

The hard part is that `"1.5"` (a ratio) and `"16"` (a forgotten `px`) are structurally identical inputs demanding opposite outputs. A magnitude threshold breaks on `leading.loose: 2` vs `spacing.hairline: 1`; a name heuristic contradicts #51's own reasoning. **Only the author knows.** So the transforms decline, and the gate asks.

## The change

- `isRatio` — the authored value parses as a bare number with no unit — ANDed into all three size transforms. Placed in the filters, **not** in `magnitude()`, which stays correct and stays consistent with the validator's `expectedMagnitude` (see #57).
- Applied to Swift too, for **output-neutrality**: for a unitless value, `$type: dimension` and `$type: number` now produce identical output on both platforms, so taking the advisory's advice changes nothing.
- `flattenDtcgTypes` in `lib/dtcg.mjs` — additive; `flattenDtcg` has four consumers and is untouched.
- `unitless-dimension` advisory in `tokens:validate-output` — **reported, excluded from `ok`**. The output is correct under the ratio reading; the source `$type` is what's wrong.

## Behaviour changes, stated as regressions

Both in the changelog under `### Changed`, not dressed as fixes:

- A **forgotten unit** — `"16"` meant as `16px` — previously emitted `16.00.dp`, *accidentally correct* because px and dp map 1:1. It now emits bare `16`: no `Dp` at a Compose use site, and `Int` in Swift which won't convert at a `CGFloat` site. Unitless `0` likewise.
- The **`nativeUnit` override no longer applies to a unitless value**. It chooses between `dp` and `sp` for a value that has a unit; it does not manufacture one. This narrows a contract #51 documented.

## Verification

`diff -r` between a build at `main` and at HEAD against zygarden's 322-token source. Every prediction held:

| | before | after |
|---|---|---|
| declarations | 195 | 195 |
| `.sp` | 39 | 39 |
| `.dp` | 50 | **45** |
| changed lines, Kotlin / Swift | — | **5 / 5**, all `leading*` |
| every other line | — | **byte-identical** |
| `tokens:validate-output` | exit 0 | exit 0, 5 advisories per platform |

Evidence: `docs/superpowers/notes/2026-08-26-unitless-dimension-e2e.md`. 375 tests, five CI gates green.

## Known gaps, documented not hidden

- The advisory **cannot see `hoistDualNodes`' `$type` carry** (spec §6.2) — an untyped unitless child of a `dimension`-typed dual node is flipped but not flagged. That's #60's silent shape. Pinned by a test so a future fix flips it rather than going unnoticed.
- DTCG **§5.2.2 rule 1** (reference-derived typing) is not resolved (spec §6.3).
- A **leading-dot** unitless dimension (`".5"`) emits bare `.5`, which compiles on neither platform, and the gate does not catch it. Deliberately **not** fixed by tightening `RATIO`: that predicate mirrors `magnitude()` by design (spec §5.1), and the actual hole is in `native-literal.mjs`'s shared `NUMBER` grammar — pre-existing, and narrowing a shared helper is what produced review defects on #53 and #55. Follow-up issue instead.

## Review note

The spec was corrected twice before implementation began — once from an independent review, once because writing the plan's tests **falsified a claim in it**: §5.2 had credited `compose-sp`'s `!isRatio` with holding the invariant, when the filter that actually carries it is `size/unit-aware/swift`. The test specified to catch that placement would have passed against the variant it was written to reject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018etbNQyHfuuGWwmd88T8Zm