### PR TITLE
feat: account for every Style Dictionary stock transform (#54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Added
+- **Style Dictionary's stock transform groups are now accounted for rather than
+  transcribed.** `PLATFORMS` claimed to mirror the stock lists, but nothing
+  checked it and the four rem-assuming transforms it declines existed only as
+  an absence from an array — indistinguishable from an oversight. Each platform
+  now records the stock group it mirrors, the exclusions are a declared list
+  with reasons, and `auditStockGroups` reports at registration any transform in
+  the live stock group that is neither run nor declined. It warns via
+  `console.warn` and never throws, and never changes an exit code: a new stock
+  transform is usually harmless, while the fatal direction — a transform we run
+  being removed — already makes Style Dictionary throw on an unknown name. The
+  check runs in your build because ThroughLine declares no dependency on Style
+  Dictionary, so that is the only place the installed version is knowable.
+  Verified silent against Style Dictionary 4.4.0 and 5.5.2, whose `ios-swift`
+  and `compose` groups are byte-identical.
+
 ### Fixed
 - **Compose font sizes and line heights emit as `sp` rather than `dp`.**
   `size/unit-aware/compose-sp` gated on `$type === "fontSize"`, which DTCG

--- a/docs/superpowers/notes/2026-08-27-stacked-native-prs-handoff.md
+++ b/docs/superpowers/notes/2026-08-27-stacked-native-prs-handoff.md
@@ -84,10 +84,15 @@ on 2026-08-26.
   native tail — #62, #63, #64, #67, #70, #71, #72 — is individually small, and
   #71/#72 are the same underlying gap in the advisory's type resolution and
   should be done as one item.
-- **#54's own recorded limits** are in the spec's §12 rather than solved: a
-  transform that is both run *and* declined is invisible; `REAL_STOCK` in the
-  test file is a version-stamped literal needing re-blessing when a stock group
-  next changes; the incomplete-preset message ships unasserted.
+- **#54's own recorded limits** are in the spec's §12 rather than solved. One
+  is now tracked as [#75](https://github.com/jrpease/throughline/issues/75) —
+  a transform that is both run *and* declined is invisible, and because the
+  decline reasons ship in `references/native-adapter-config.md`, a contradiction
+  there is published documentation disagreeing with what runs. Two were left
+  untracked by choice: `REAL_STOCK` in the test file is a version-stamped
+  literal that will need re-blessing when a stock group next changes, and the
+  incomplete-preset message ships unasserted (deliberately — reaching it would
+  need a test-only injection parameter).
 
 ## Working note
 

--- a/docs/superpowers/notes/2026-08-27-stacked-native-prs-handoff.md
+++ b/docs/superpowers/notes/2026-08-27-stacked-native-prs-handoff.md
@@ -1,0 +1,104 @@
+# Two stacked native PRs — handoff
+
+**Date:** 2026-08-27
+**Supersedes:** `2026-08-24-native-backlog-handoff.md`
+
+## Read this first — there is an ordering constraint with a known cost
+
+Two PRs are open and **stacked**:
+
+| PR | issue | branch | base |
+|---|---|---|---|
+| [#69](https://github.com/jrpease/throughline/pull/69) | #52 unitless ratios | `fix/52-unitless-dimension` | `main` |
+| [#74](https://github.com/jrpease/throughline/pull/74) | #54 stock transform accounting | `feat/54-stock-transform-accounting` | **`fix/52-unitless-dimension`** |
+
+**#74 must be retargeted to `main` BEFORE #69 merges:**
+
+```
+gh pr edit 74 --base main
+gh pr merge 69            # WITHOUT --delete-branch
+git push origin --delete fix/52-unitless-dimension   # by hand, after
+```
+
+Merging the parent with `--delete-branch` auto-closes the stacked child, and
+once the child's head has been rebased it **cannot be reopened** — GitHub
+refuses even after the base branch is restored. That cost PR #65 on 2026-08-24
+and its content had to be reopened as #66.
+
+Both are stacked rather than parallel because `scripts/lib/sd-native.mjs`
+generates `references/native-adapter-config.md` from its whole body, so two
+branches off `main` that both touch it conflict guaranteed.
+
+## What shipped
+
+**#54 — stock transform accounting.** `PLATFORMS` claimed to mirror Style
+Dictionary's stock transform groups but nothing checked it, and the four
+rem-assuming transforms it declines existed only as an *absence* from an array.
+Now each preset carries `stockGroup`, the exclusions are a declared map with
+reasons, and `auditStockGroups` warns at registration about any stock transform
+neither run nor declined. Warns, never throws; never changes an exit code.
+
+The design inverts what the issue proposed. Rather than snapshotting the stock
+lists and asserting live-vs-snapshot, it asks whether anything in the live group
+is unaccounted for — which needs **no snapshot**, so there is nothing to keep
+fresh and no way to confuse "our snapshot is stale" with "Style Dictionary
+drifted." Spec: `docs/superpowers/specs/2026-08-27-stock-transform-accounting-design.md`.
+
+## The measured drift table, because it took two installs to get
+
+Read from real installs via `StyleDictionary.hooks.transformGroups`:
+
+| group | 4.4.0 | 5.5.2 |
+|---|---|---|
+| `ios-swift` | 6 names | **identical** |
+| `compose` | 6 names | **identical** |
+| `ios` | …`size/remToPt` | …`size/remToFloat` — **renamed** |
+| transforms registered | 55 | 62 — **+7** |
+
+Both drift directions are real in Style Dictionary; they have simply not landed
+on the two groups we consume. `hooks.transformGroups` is readable **statically
+on the class** in both versions, and on an instance too.
+
+**The Style Dictionary installs live in the session scratchpad and will not
+survive.** Rebuild with
+`npm install style-dictionary@<v> --prefix <dir> --no-save` — never into the
+repo, which declares zero dependencies deliberately.
+
+## What is unfinished
+
+**Nothing has been released since 0.15.0.** Eight items now sit unreleased:
+#34, #50, #53, #55, #51, #60, #52, #54. A version cut was deferred once already
+on 2026-08-26.
+
+## Open questions for the next session
+
+- **#73 — was #55's and #60's e2e evidence vacuous?** Filed 2026-08-26. The
+  #52 cycle found that the documented symlink swap targets `scripts/lib`, while
+  `build.mjs` imports a *different* top-level `lib/` of per-file symlinks —
+  so following the note literally builds "main" from HEAD's code and produces a
+  false byte-identical pass. Whether the earlier runs hit that is unverified.
+  Worth answering before leaning on that harness again.
+- **Which backlog slot is next.** #36 (validator silently drops a token to a key
+  collision) is the last of the "instruments" items. The consumption-layer epic
+  (#39–#44) has been parked pending a clean native base, which it now has. The
+  native tail — #62, #63, #64, #67, #70, #71, #72 — is individually small, and
+  #71/#72 are the same underlying gap in the advisory's type resolution and
+  should be done as one item.
+- **#54's own recorded limits** are in the spec's §12 rather than solved: a
+  transform that is both run *and* declined is invisible; `REAL_STOCK` in the
+  test file is a version-stamped literal needing re-blessing when a stock group
+  next changes; the incomplete-preset message ships unasserted.
+
+## Working note
+
+The #54 cycle cost **zero** string-mismatch fix rounds, against one each in
+#52, #55 and #60. The difference was executing the plan's own implementation
+code against the plan's own test literals *before committing the plan* — ten
+verbatim assertions, one tool call. A plan that specifies both code and exact
+expected strings is itself runnable, and nothing else catches that class of
+defect: both halves read as correct in isolation and reviewers pass them.
+
+The second habit worth keeping: **pair every negative control with a positive
+one.** "Zero warnings" and "the check never runs" are indistinguishable. #54's
+guard was proven by mutating a real Style Dictionary object to inject the
+failure and confirming the exact expected warning fired once.

--- a/docs/superpowers/plans/2026-08-27-stock-transform-accounting.md
+++ b/docs/superpowers/plans/2026-08-27-stock-transform-accounting.md
@@ -1,0 +1,806 @@
+# Stock Transform Accounting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make it impossible for a Style Dictionary stock transform to be
+silently dropped from ThroughLine's native transform lists, by requiring every
+stock transform to be either run or declined in writing, and warning at
+registration when one is neither.
+
+**Architecture:** One pure exported function, `auditStockGroups`, walks each
+platform's stock transform group and reports names accounted for by neither the
+platform's own `transforms` array nor a new `DECLINED_STOCK_TRANSFORMS` map. The
+stock group name each platform mirrors moves *into* `PLATFORMS` so there is no
+parallel constant to drift. `registerNativeTransforms` — which already receives
+the `StyleDictionary` class, on which `hooks.transformGroups` is readable
+statically — calls it and `console.warn`s each result. Nothing that runs
+changes.
+
+**Tech Stack:** Node ≥20 ESM, zero dependencies, `node:test` +
+`node:assert/strict`. Style Dictionary is passed in as an argument and never
+imported.
+
+**Spec:** `docs/superpowers/specs/2026-08-27-stock-transform-accounting-design.md`
+
+## Global Constraints
+
+- **Zero dependencies.** `scripts/` is a zero-dependency zone. `node:` built-ins
+  only. No npm packages, ever. Style Dictionary is passed in as an argument and
+  never imported.
+- **Pure functions are the tested surface.** `auditStockGroups` is pure;
+  `registerNativeTransforms` stays the only side-effecting export in this area.
+- **Non-gating.** Nothing added here throws, and nothing changes an exit code.
+  `console.warn` only.
+- **`scripts/lib/sd-native.mjs` generates a CI-gated document.**
+  `references/native-adapter-config.md` is built from that file's body via
+  `@doc-section` markers. **Every task that edits `sd-native.mjs` or
+  `scripts/build-native-adapter-config.mjs` must run
+  `node scripts/build-native-adapter-config.mjs` and commit the regenerated
+  `references/native-adapter-config.md` in the same commit.** CI gates it with
+  `node scripts/build-native-adapter-config.mjs --check`.
+- **The full test suite is `node --test` run from the repo root** — bare, with no
+  path argument. `node --test scripts/lib/` fails with `MODULE_NOT_FOUND` and is
+  not a real failure.
+- **Message strings are asserted verbatim by tests.** Reword nothing without
+  updating both sides. There is no `transform(s)` anywhere — singular and plural
+  are separate strings.
+- **Every commit ends with these two trailers, exactly:**
+  ```
+  Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_018etbNQyHfuuGWwmd88T8Zm
+  ```
+- **Branch:** `feat/54-stock-transform-accounting`, stacked on
+  `fix/52-unitless-dimension`. Do not rebase onto `main`; do not merge anything.
+
+---
+
+## File Structure
+
+| File | Responsibility in this change |
+|---|---|
+| `scripts/lib/sd-native.mjs` | `stockGroup` added to each `PLATFORMS` preset; new `DECLINED_STOCK_TRANSFORMS` map; new exported `auditStockGroups`; call site in `registerNativeTransforms`; the stale `// Stock, from SD 4.4.0:` comment replaced |
+| `scripts/lib/sd-native.test.mjs` | 13 new tests; the six existing `registerNativeTransforms` fakes consolidated onto one factory that carries `hooks` |
+| `scripts/build-native-adapter-config.mjs` | `PROSE['platform']` gains one paragraph describing the audit |
+| `references/native-adapter-config.md` | Regenerated — never hand-edited |
+| `CHANGELOG.md` | One `### Added` entry under `## [Unreleased]` |
+
+---
+
+## Task 1: The audit function and its data
+
+**Files:**
+- Modify: `scripts/lib/sd-native.mjs` — `PLATFORMS` at `341-369`; insert new code immediately after line `369` (`};`) and before the `// % and em are container- or parent-relative` comment at `371`. Both insertions must land **inside** the `@doc-section platform` block, which opens at `313` and closes at `455`.
+- Modify: `scripts/lib/sd-native.test.mjs` — add tests; extend the import list at the top.
+- Regenerate: `references/native-adapter-config.md`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces:
+  - `export function auditStockGroups(transformGroups: unknown): string[]` — pure; returns formatted warning strings, empty array when everything is accounted for. Task 2 calls it.
+  - `PLATFORMS` presets each gain a `stockGroup: string` field. Module-private.
+  - `DECLINED_STOCK_TRANSFORMS` — module-private object, transform name → reason string.
+
+---
+
+- [ ] **Step 1: Add `stockGroup` to both `PLATFORMS` presets**
+
+In `scripts/lib/sd-native.mjs`, add one line as the **first** property of each
+preset. Change nothing else about them.
+
+```js
+const PLATFORMS = {
+  'ios-swift': {
+    stockGroup: 'ios-swift',
+    transforms: [
+      'attribute/cti',
+      'name/camel',
+      'value/color-mix-to-hex8',
+      'color/UIColorSwift',
+      'content/swift/literal',
+      'asset/swift/literal',
+      'size/unit-aware/swift',
+      'value/swift-string-literal',
+    ],
+    destination: 'Tokens.swift',
+    format: 'ios-swift/enum.swift',
+  },
+  'android-kotlin': {
+    stockGroup: 'compose',
+    transforms: [
+      'attribute/cti',
+      'name/camel',
+      'value/color-mix-to-hex8',
+      'color/composeColor',
+      'size/unit-aware/compose-dp',
+      'size/unit-aware/compose-sp',
+      'value/kotlin-string-literal',
+    ],
+    destination: 'Tokens.kt',
+    format: 'compose/object',
+  },
+};
+```
+
+**Why this and not a separate `STOCK_GROUP` constant:** a parallel map with the
+same two keys means an implementation looping over it instead of over
+`PLATFORMS` behaves identically until someone adds a third platform — a bug no
+test can discriminate. One constant makes the mistake unwriteable. `stockGroup`
+is safe to add because `nativePlatform` (line `435-453`) builds its return value
+field by field rather than spreading the preset, so it is never emitted into the
+Style Dictionary platform config.
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to `scripts/lib/sd-native.test.mjs`. First add `auditStockGroups` to the
+existing import block at the top of the file (it imports from
+`'./sd-native.mjs'`).
+
+```js
+// Style Dictionary's stock transform groups, read from real installs of 4.4.0
+// and 5.5.2 via StyleDictionary.hooks.transformGroups. Both groups are
+// byte-identical across those versions, so one literal covers both; asserting
+// the same array twice would be duplication, not coverage.
+const REAL_STOCK = {
+  'ios-swift': [
+    'attribute/cti',
+    'name/camel',
+    'color/UIColorSwift',
+    'content/swift/literal',
+    'asset/swift/literal',
+    'size/swift/remToCGFloat',
+  ],
+  compose: [
+    'attribute/cti',
+    'name/camel',
+    'color/composeColor',
+    'size/compose/em',
+    'size/compose/remToSp',
+    'size/compose/remToDp',
+  ],
+};
+
+const UNREADABLE =
+  "throughline: could not read Style Dictionary's stock transform groups " +
+  '(hooks.transformGroups is not an object), so this adapter cannot check ' +
+  'whether its transform lists are still complete.';
+
+const NO_COMPOSE_GROUP =
+  'throughline: Style Dictionary has no "compose" transform group, which ' +
+  "PLATFORMS['android-kotlin'] mirrors. The stock group may have been renamed " +
+  'or removed. Upgrade @radicool/throughline, or report your Style Dictionary ' +
+  'version.';
+
+const NO_IOS_GROUP =
+  'throughline: Style Dictionary has no "ios-swift" transform group, which ' +
+  "PLATFORMS['ios-swift'] mirrors. The stock group may have been renamed " +
+  'or removed. Upgrade @radicool/throughline, or report your Style Dictionary ' +
+  'version.';
+
+test('auditStockGroups is silent on the real stock groups', () => {
+  assert.deepEqual(auditStockGroups(REAL_STOCK), []);
+});
+
+test('auditStockGroups reports one stock transform that is neither run nor declined', () => {
+  const groups = { ...REAL_STOCK, compose: [...REAL_STOCK.compose, 'size/compose/foo'] };
+  assert.deepEqual(auditStockGroups(groups), [
+    'throughline: Style Dictionary\'s "compose" transform group has 1 transform ' +
+      'this adapter neither runs nor declined: size/compose/foo. Native output ' +
+      'may be incomplete. Upgrade @radicool/throughline, or report your Style ' +
+      'Dictionary version. (Maintainer repair: add each to ' +
+      "PLATFORMS['android-kotlin'].transforms, or to DECLINED_STOCK_TRANSFORMS " +
+      'with a reason.)',
+  ]);
+});
+
+test('auditStockGroups reports two unaccounted names in ONE message, in stock order', () => {
+  const groups = {
+    ...REAL_STOCK,
+    compose: [...REAL_STOCK.compose, 'size/compose/foo', 'size/compose/bar'],
+  };
+  assert.deepEqual(auditStockGroups(groups), [
+    'throughline: Style Dictionary\'s "compose" transform group has 2 transforms ' +
+      'this adapter neither runs nor declined: size/compose/foo, size/compose/bar. ' +
+      'Native output may be incomplete. Upgrade @radicool/throughline, or report ' +
+      'your Style Dictionary version. (Maintainer repair: add each to ' +
+      "PLATFORMS['android-kotlin'].transforms, or to DECLINED_STOCK_TRANSFORMS " +
+      'with a reason.)',
+  ]);
+});
+
+test('auditStockGroups reports each platform independently', () => {
+  const groups = {
+    'ios-swift': [...REAL_STOCK['ios-swift'], 'size/swift/newThing'],
+    compose: [...REAL_STOCK.compose, 'size/compose/foo'],
+  };
+  const out = auditStockGroups(groups);
+  assert.equal(out.length, 2);
+  assert.ok(out[0].includes('"ios-swift" transform group has 1 transform'));
+  assert.ok(out[0].includes('size/swift/newThing'));
+  assert.ok(out[1].includes('"compose" transform group has 1 transform'));
+  assert.ok(out[1].includes('size/compose/foo'));
+});
+
+test('auditStockGroups is silent on a group holding only declined transforms', () => {
+  const groups = { ...REAL_STOCK, compose: ['size/compose/em', 'size/compose/remToDp'] };
+  assert.deepEqual(auditStockGroups(groups), []);
+});
+
+test('auditStockGroups ignores stock ORDER', () => {
+  const groups = { ...REAL_STOCK, compose: [...REAL_STOCK.compose].reverse() };
+  assert.deepEqual(auditStockGroups(groups), []);
+});
+
+test('auditStockGroups ignores a REMOVED declined transform', () => {
+  const groups = {
+    ...REAL_STOCK,
+    compose: REAL_STOCK.compose.filter((n) => n !== 'size/compose/em'),
+  };
+  assert.deepEqual(auditStockGroups(groups), []);
+});
+
+test('auditStockGroups reports a stock group that is absent entirely', () => {
+  assert.deepEqual(auditStockGroups({ 'ios-swift': REAL_STOCK['ios-swift'] }), [
+    NO_COMPOSE_GROUP,
+  ]);
+});
+
+test('auditStockGroups reports unreadable transformGroups', () => {
+  for (const bad of [undefined, null, 'nope', 42]) {
+    assert.deepEqual(auditStockGroups(bad), [UNREADABLE], `input: ${String(bad)}`);
+  }
+});
+
+test('auditStockGroups treats an array as a readable object with no groups', () => {
+  assert.deepEqual(auditStockGroups([]), [NO_IOS_GROUP, NO_COMPOSE_GROUP]);
+});
+```
+
+**Note on test 4 (`reports each platform independently`)** — it asserts on
+fragments rather than two full strings on purpose: the two verbatim forms are
+already pinned in full by tests 2 and 3, and what this test exists to
+discriminate is that a finding for one platform does not suppress the other.
+Repeating both full strings here would be duplication without added
+discrimination.
+
+**Note on test 10 (`treats an array as a readable object`)** — an array *is* a
+non-null object, so it passes the readability check and falls through to the
+per-platform loop. Two different implementations would otherwise both satisfy
+the contract; this pins the chosen one.
+
+**There is deliberately no test for the fourth message form** — the
+`declares no stockGroup` warning added in Step 4. It cannot be reached from
+outside the module: `PLATFORMS` is module-private and `auditStockGroups` takes
+no injectable platform map, and adding a test-only injection parameter to a
+diagnostic would be configurability nothing asked for. Test 1 guards the
+*behaviour* — a platform added without a `stockGroup` makes it fail — while the
+wording ships unasserted. This is recorded in the spec at §9.1 and §12. Do not
+add an injection parameter to close it.
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `node --test`
+
+Expected: FAIL. The first error is a `SyntaxError` about
+`auditStockGroups` not being exported by `./sd-native.mjs` — the import is
+unresolvable, so the whole test file fails to load rather than failing test by
+test. That is the expected shape at this step.
+
+- [ ] **Step 4: Write the implementation**
+
+In `scripts/lib/sd-native.mjs`, insert immediately after `PLATFORMS`' closing
+`};` (line `369`) and before the blank line preceding the
+`// % and em are container- or parent-relative` comment:
+
+```js
+
+// Stock transforms this config deliberately does NOT run. The reason is the
+// point: an entry here is a decision on the record, where an absence from
+// PLATFORMS is indistinguishable from an oversight.
+//
+// Keyed by transform name alone, with no platform qualifier. That is safe only
+// because every name here is platform-prefixed, so no cross-platform collision
+// is expressible. Declining an unprefixed name — a hypothetical shared
+// "size/px" — would widen silently across both platforms and must convert this
+// to a per-platform map.
+const DECLINED_STOCK_TRANSFORMS = {
+  'size/swift/remToCGFloat': 'rem-assuming — replaced by size/unit-aware/swift',
+  'size/compose/remToDp': 'rem-assuming — replaced by size/unit-aware/compose-dp',
+  'size/compose/remToSp': 'rem-assuming — replaced by size/unit-aware/compose-sp',
+  'size/compose/em': 'em is not representable in native output — filtered out',
+};
+
+// Report every transform in a platform's live stock group that this config
+// neither runs nor explicitly declined. Pure: it takes Style Dictionary's
+// hooks.transformGroups and returns formatted warning strings, so the wording
+// is what the tests assert and the caller is a bare loop.
+//
+// Warns, never throws. The dangerous direction is an ADDITION we never learned
+// about, which is usually harmless and occasionally important — throwing would
+// break a build over a change the consumer cannot fix. The fatal direction, a
+// transform we run being removed, already makes Style Dictionary throw on an
+// unknown transform name.
+//
+// Order is never compared: our lists are hand-ordered for our own reasons and
+// do not inherit stock order. Removals are never reported: a declined name
+// disappearing is a non-event.
+export function auditStockGroups(transformGroups) {
+  if (typeof transformGroups !== 'object' || transformGroups === null) {
+    return [
+      "throughline: could not read Style Dictionary's stock transform groups " +
+        '(hooks.transformGroups is not an object), so this adapter cannot check ' +
+        'whether its transform lists are still complete.',
+    ];
+  }
+  const warnings = [];
+  for (const [platform, preset] of Object.entries(PLATFORMS)) {
+    const group = preset.stockGroup;
+    if (!group) {
+      warnings.push(
+        `throughline: PLATFORMS['${platform}'] declares no stockGroup, so its ` +
+          "transform list cannot be checked against Style Dictionary's stock " +
+          'groups. This is a throughline packaging defect — please report it.',
+      );
+      continue;
+    }
+    const stock = transformGroups[group];
+    if (!Array.isArray(stock)) {
+      warnings.push(
+        `throughline: Style Dictionary has no "${group}" transform group, which ` +
+          `PLATFORMS['${platform}'] mirrors. The stock group may have been ` +
+          'renamed or removed. Upgrade @radicool/throughline, or report your ' +
+          'Style Dictionary version.',
+      );
+      continue;
+    }
+    const unaccounted = stock.filter(
+      (name) =>
+        !preset.transforms.includes(name) &&
+        !Object.hasOwn(DECLINED_STOCK_TRANSFORMS, name),
+    );
+    if (unaccounted.length) {
+      const n = unaccounted.length;
+      warnings.push(
+        `throughline: Style Dictionary's "${group}" transform group has ${n} ` +
+          `transform${n === 1 ? '' : 's'} this adapter neither runs nor declined: ` +
+          `${unaccounted.join(', ')}. Native output may be incomplete. Upgrade ` +
+          '@radicool/throughline, or report your Style Dictionary version. ' +
+          `(Maintainer repair: add each to PLATFORMS['${platform}'].transforms, ` +
+          'or to DECLINED_STOCK_TRANSFORMS with a reason.)',
+      );
+    }
+  }
+  return warnings;
+}
+```
+
+`Object.hasOwn` rather than `name in DECLINED_STOCK_TRANSFORMS`: `in` also
+matches inherited `Object.prototype` keys, so a stock transform named
+`constructor` or `toString` would be treated as declined.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `node --test`
+
+Expected: PASS, 385 tests, 0 failures. (375 before this task, plus the 10 added
+here.)
+
+- [ ] **Step 6: Regenerate the reference doc**
+
+Run: `node scripts/build-native-adapter-config.mjs`
+
+Then verify the gate: `node scripts/build-native-adapter-config.mjs --check`
+
+Expected: exit 0, no output. `git status` should show
+`references/native-adapter-config.md` modified — the new constants and function
+are inside `@doc-section platform`, so they now appear in the shipped doc.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/lib/sd-native.mjs scripts/lib/sd-native.test.mjs references/native-adapter-config.md
+git commit -F - <<'MSG'
+feat: account for every Style Dictionary stock transform (#54)
+
+PLATFORMS claimed to mirror Style Dictionary's stock transform groups but
+nothing checked it, and the four rem-assuming transforms it declines existed
+only as an absence from an array — indistinguishable from an oversight.
+
+auditStockGroups reports any transform in a platform's live stock group that
+is neither run nor listed in the new DECLINED_STOCK_TRANSFORMS map. The stock
+group name lives inside PLATFORMS rather than in a parallel constant, so there
+is nothing to fall out of sync with and no wrong thing to iterate.
+
+Silent against Style Dictionary 4.4.0 and 5.5.2, whose ios-swift and compose
+groups are byte-identical.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_018etbNQyHfuuGWwmd88T8Zm
+MSG
+```
+
+---
+
+## Task 2: Wire the audit into registration
+
+**Files:**
+- Modify: `scripts/lib/sd-native.mjs` — `registerNativeTransforms`, which opens at `562` and closes at `625`.
+- Modify: `scripts/lib/sd-native.test.mjs` — the six fakes at `256`, `275`, `284`, `302`, `309`, and the `collectTransforms` helper at `316`.
+- Regenerate: `references/native-adapter-config.md`
+
+**Interfaces:**
+- Consumes: `auditStockGroups(transformGroups) → string[]` from Task 1, and the module-private `PLATFORMS` presets, each of which now carries `stockGroup`.
+- Produces: nothing later tasks consume.
+
+**Context you need that the brief cannot know:** Task 1 added a test-file
+constant `REAL_STOCK` — an object with keys `'ios-swift'` and `compose`, each an
+array of six stock transform names — and a constant `UNREADABLE` holding the
+exact unreadable-input warning string. Both already exist near the other new
+tests; reuse them, do not redefine them.
+
+---
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/lib/sd-native.test.mjs`:
+
+```js
+// Swap console.warn for the duration of fn and return everything it emitted.
+// Restored in a finally so a throwing fn cannot leak the stub into later tests.
+function captureWarnings(fn) {
+  const original = console.warn;
+  const seen = [];
+  console.warn = (...args) => seen.push(args.join(' '));
+  try {
+    fn();
+  } finally {
+    console.warn = original;
+  }
+  return seen;
+}
+
+test('registerNativeTransforms is silent when the stock groups are accounted for', () => {
+  const seen = captureWarnings(() => registerNativeTransforms(fakeStyleDictionary()));
+  assert.deepEqual(seen, []);
+});
+
+test('registerNativeTransforms warns when it cannot read the stock transform groups', () => {
+  const seen = captureWarnings(() =>
+    registerNativeTransforms({ registerPreprocessor() {}, registerTransform() {} }),
+  );
+  assert.deepEqual(seen, [UNREADABLE]);
+});
+```
+
+The second test is the one that pins the design decision: a caller with no
+`hooks` gets told the check has gone blind, rather than the check quietly
+switching itself off.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `node --test`
+
+Expected: FAIL — `fakeStyleDictionary is not defined` in the first test, and the
+second fails its assertion with `actual: []` because nothing warns yet.
+
+- [ ] **Step 3: Add the fake factory and route every existing fake through it**
+
+Add this helper to `scripts/lib/sd-native.test.mjs`, replacing the existing
+`collectTransforms` helper and its comment at lines `314-324`:
+
+```js
+// One fake Style Dictionary for every registerNativeTransforms call in this
+// file. It carries hooks.transformGroups because registration now audits them,
+// and a fake without hooks warns by design.
+function fakeStyleDictionary({ onPreprocessor = () => {}, onTransform = () => {} } = {}) {
+  return {
+    hooks: { transformGroups: REAL_STOCK },
+    registerPreprocessor: onPreprocessor,
+    registerTransform: onTransform,
+  };
+}
+
+// Collect the transforms registerNativeTransforms registers, keyed by name.
+function collectTransforms() {
+  const registered = new Map();
+  registerNativeTransforms(
+    fakeStyleDictionary({ onTransform: (t) => registered.set(t.name, t) }),
+  );
+  return registered;
+}
+```
+
+Then rewrite the five inline fakes. Each currently builds a `transforms` array
+and calls `.find(...)`; each becomes a `collectTransforms().get(...)`.
+
+At line `253`, the preprocessor test keeps its own fake because it needs both
+recorders:
+
+```js
+test('registerNativeTransforms registers the preprocessor and six transforms', () => {
+  const preprocessors = [];
+  const transforms = [];
+  registerNativeTransforms(
+    fakeStyleDictionary({
+      onPreprocessor: (p) => preprocessors.push(p),
+      onTransform: (t) => transforms.push(t),
+    }),
+  );
+
+  assert.deepEqual(preprocessors.map((p) => p.name), ['dtcg/resolve-dual-node']);
+  assert.deepEqual(transforms.map((t) => t.name).sort(), [
+    'size/unit-aware/compose-dp',
+    'size/unit-aware/compose-sp',
+    'size/unit-aware/swift',
+    'value/color-mix-to-hex8',
+    'value/kotlin-string-literal',
+    'value/swift-string-literal',
+  ]);
+  for (const t of transforms) assert.equal(t.type, 'value');
+});
+
+test('the registered swift transform converts a px dimension 1:1', () => {
+  const swift = collectTransforms().get('size/unit-aware/swift');
+  const token = { $type: 'dimension', $value: '14px', original: { $value: '14px' } };
+  assert.equal(swift.filter(token), true);
+  assert.equal(swift.transform(token), 'CGFloat(14.00)');
+});
+
+test('the registered compose transforms still split sp from dp by the legacy $type gate', () => {
+  const registered = collectTransforms();
+  const dp = registered.get('size/unit-aware/compose-dp');
+  const sp = registered.get('size/unit-aware/compose-sp');
+
+  const dimension = { $type: 'dimension', $value: '16px', original: { $value: '16px' } };
+  const fontSize = { $type: 'fontSize', $value: '14px', original: { $value: '14px' } };
+
+  assert.equal(dp.filter(dimension), true);
+  assert.equal(dp.filter(fontSize), false);
+  assert.equal(dp.transform(dimension), '16.00.dp');
+
+  assert.equal(sp.filter(fontSize), true);
+  assert.equal(sp.filter(dimension), false);
+  assert.equal(sp.transform(fontSize), '14.00.sp');
+});
+
+test('the registered swift transform also handles fontSize, matching stock', () => {
+  const swift = collectTransforms().get('size/unit-aware/swift');
+  assert.equal(swift.filter({ $type: 'fontSize', $value: '14px', original: { $value: '14px' } }), true);
+});
+
+test('the registered size transforms skip a value with no native magnitude', () => {
+  const swift = collectTransforms().get('size/unit-aware/swift');
+  assert.equal(swift.filter({ $type: 'dimension', $value: '100%', original: { $value: '100%' } }), false);
+});
+```
+
+`collectTransforms` must be **declared before** the tests that call it, or moved
+to the top of the file — function declarations hoist within a module, so leaving
+it where it is also works; do not spend time relocating it.
+
+Assertions inside these five tests are unchanged. Only how the fake is
+constructed changes. If any assertion needs editing to pass, stop and report it
+— that would mean the refactor altered behaviour, which it must not.
+
+- [ ] **Step 4: Add the call site**
+
+In `scripts/lib/sd-native.mjs`, at the **end** of `registerNativeTransforms` —
+after the final `StyleDictionary.registerTransform({...})` call and before the
+closing `}` at line `625`:
+
+```js
+
+  // Last, so every registration side effect has completed before anything is
+  // printed. Fires once per REGISTRATION — typically once per process, not once
+  // per build: the documented usage registers once and then constructs one
+  // StyleDictionary per mode, and the stock groups cannot change between modes.
+  //
+  // The ?. chain is what turns a caller with no hooks into undefined, which
+  // auditStockGroups reports as unreadable rather than silently skipping.
+  for (const warning of auditStockGroups(StyleDictionary?.hooks?.transformGroups)) {
+    console.warn(warning);
+  }
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `node --test`
+
+Expected: PASS, 387 tests, 0 failures. **No warning text may appear in the test
+output** — if `throughline: could not read…` prints during the run, a fake was
+missed in Step 3.
+
+- [ ] **Step 6: Regenerate the reference doc**
+
+Run: `node scripts/build-native-adapter-config.mjs`
+
+Then verify: `node scripts/build-native-adapter-config.mjs --check`
+
+Expected: exit 0. `references/native-adapter-config.md` is modified — the call
+site is inside `@doc-section register`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/lib/sd-native.mjs scripts/lib/sd-native.test.mjs references/native-adapter-config.md
+git commit -F - <<'MSG'
+feat: run the stock transform audit at registration (#54)
+
+registerNativeTransforms already holds the StyleDictionary class, on which
+hooks.transformGroups is readable statically, so the audit runs in the
+consumer's own build — the only place the installed Style Dictionary version
+is knowable, since throughline declares no dependency on it.
+
+A caller that exposes no hooks is warned that the check has gone blind rather
+than having it silently switch off; the six test fakes in this file therefore
+carry hooks, and now share one factory.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_018etbNQyHfuuGWwmd88T8Zm
+MSG
+```
+
+---
+
+## Task 3: Retire the transcribed snapshot and document the audit
+
+**Files:**
+- Modify: `scripts/lib/sd-native.mjs:336-340` — the `// Stock, from SD 4.4.0:` comment block.
+- Modify: `scripts/build-native-adapter-config.mjs` — `PROSE['platform']`, which opens at `109` and ends at the closing `` `], `` before `['sources', ...` at `148`.
+- Modify: `CHANGELOG.md` — under `## [Unreleased]` at line `7`, above the existing `### Fixed` at line `9`.
+- Regenerate: `references/native-adapter-config.md`
+
+**Interfaces:**
+- Consumes: `auditStockGroups` and `DECLINED_STOCK_TRANSFORMS` from Task 1 — referenced by name in prose only.
+- Produces: nothing.
+
+**Why this is a task and not a step:** the comment block in `sd-native.mjs` and
+`PROSE['platform']` are both **shipped documentation** — they are the body of
+`references/native-adapter-config.md`, which is published in the npm package.
+A reviewer can reasonably reject the prose while approving the code.
+
+---
+
+- [ ] **Step 1: Replace the transcribed stock snapshot**
+
+In `scripts/lib/sd-native.mjs`, replace these five lines (`336-340`) exactly:
+
+```js
+// Stock, from SD 4.4.0:
+//   ios-swift: attribute/cti name/camel color/UIColorSwift
+//              content/swift/literal asset/swift/literal size/swift/remToCGFloat
+//   compose:   attribute/cti name/camel color/composeColor
+//              size/compose/em size/compose/remToSp size/compose/remToDp
+```
+
+with:
+
+```js
+// The lists below mirror Style Dictionary's stock groups, and nothing derives
+// them at runtime — what runs stays deliberate and reviewable. But nothing is
+// transcribed either: auditStockGroups checks at registration that every name
+// in the live stock group is either run here or declined in writing, so a
+// stock transform this config has never made a decision about is loud rather
+// than silently dropped.
+//
+// Both groups were verified byte-identical in SD 4.4.0 and 5.5.2. The `ios`
+// group was not — it renamed size/remToPt to size/remToFloat between them, and
+// 5.x added seven transforms overall. The drift this guards against is real;
+// it has simply not landed on the two groups we build from.
+```
+
+The old block is a version-stamped snapshot that will go stale with nothing to
+notice — precisely the liability the audit exists to remove. Do not keep it
+alongside the new text.
+
+- [ ] **Step 2: Add the prose paragraph to the generator**
+
+In `scripts/build-native-adapter-config.mjs`, inside the `['platform', ...]`
+entry, append this paragraph as the **last** paragraph of the template literal,
+immediately before the closing `` `], ``:
+
+```
+**The stock list is accounted for, not transcribed.** \`PLATFORMS\` records the
+stock group each platform mirrors, and \`auditStockGroups\` checks at
+registration that every transform in that live group is either run here or
+declined in writing, with a reason. A stock transform this config has never
+decided about warns; it is never silently dropped. The check warns and never
+throws — a new stock transform is usually harmless, and the fatal direction, a
+transform we run being removed, already makes Style Dictionary throw on an
+unknown name. It runs in your build because that is the only place the
+installed Style Dictionary version is knowable: ThroughLine declares no
+dependency on it.
+```
+
+Note the escaped backticks (`` \` ``) — this is inside a JavaScript template
+literal, and an unescaped backtick terminates it and breaks the file.
+
+Do **not** restate the warning message text here. That would be a second copy
+to drift, and the messages are already asserted verbatim by tests.
+
+- [ ] **Step 3: Add the CHANGELOG entry**
+
+In `CHANGELOG.md`, insert a new `### Added` section immediately after
+`## [Unreleased]` (line `7`) and before the existing `### Fixed` (line `9`):
+
+```markdown
+### Added
+- **Style Dictionary's stock transform groups are now accounted for rather than
+  transcribed.** `PLATFORMS` claimed to mirror the stock lists, but nothing
+  checked it and the four rem-assuming transforms it declines existed only as
+  an absence from an array — indistinguishable from an oversight. Each platform
+  now records the stock group it mirrors, the exclusions are a declared list
+  with reasons, and `auditStockGroups` reports at registration any transform in
+  the live stock group that is neither run nor declined. It warns via
+  `console.warn` and never throws, and never changes an exit code: a new stock
+  transform is usually harmless, while the fatal direction — a transform we run
+  being removed — already makes Style Dictionary throw on an unknown name. The
+  check runs in your build because ThroughLine declares no dependency on Style
+  Dictionary, so that is the only place the installed version is knowable.
+  Verified silent against Style Dictionary 4.4.0 and 5.5.2, whose `ios-swift`
+  and `compose` groups are byte-identical.
+```
+
+- [ ] **Step 4: Regenerate the reference doc and run every gate**
+
+```bash
+node scripts/build-native-adapter-config.mjs
+node --test
+node ci/validate-plugin.mjs
+node ci/validate-skills.mjs
+node scripts/adapters/generate.mjs --check
+node scripts/build-doc-card-builder.mjs --check
+node scripts/build-native-adapter-config.mjs --check
+```
+
+Expected: `node --test` reports 387 tests, 0 failures. Every other command exits
+0 and prints no failure line. These are exactly the six steps in
+`.github/workflows/ci.yml`.
+
+Run each command separately. Quoting the whole string as one argument — e.g.
+`node "scripts/adapters/generate.mjs --check"` — makes Node treat it as a
+filename and report a spurious failure.
+
+- [ ] **Step 5: Verify the regenerated doc actually changed**
+
+Run: `git diff --stat references/native-adapter-config.md`
+
+Expected: the file appears with a non-zero change count, and
+`git diff references/native-adapter-config.md` shows both the replaced comment
+block and the new prose paragraph. If it shows nothing, the generator did not
+pick up the edits and Step 2's paragraph is in the wrong place.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/lib/sd-native.mjs scripts/build-native-adapter-config.mjs references/native-adapter-config.md CHANGELOG.md
+git commit -F - <<'MSG'
+docs: retire the transcribed stock snapshot (#54)
+
+The `// Stock, from SD 4.4.0:` comment was a hand-transcribed snapshot with
+nothing to keep it fresh — the same liability the audit exists to remove. It
+is replaced by a note on what the audit guarantees, plus the measured fact
+that motivates it: SD's ios group renamed size/remToPt to size/remToFloat
+between 4.4.0 and 5.5.2, and 5.x added seven transforms.
+
+PROSE['platform'] gains a matching paragraph so the shipped reference explains
+the audit next to the code that performs it, per the generator's own rule that
+prose sits adjacent to what it describes.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_018etbNQyHfuuGWwmd88T8Zm
+MSG
+```
+
+---
+
+## Done when
+
+- `node --test` reports **387 tests, 0 failures**, with no `throughline:` warning
+  text in the output.
+- All six CI gates pass.
+- `git status` is clean.
+- `references/native-adapter-config.md` contains `auditStockGroups`,
+  `DECLINED_STOCK_TRANSFORMS`, `stockGroup` in both presets, and the new prose
+  paragraph — and contains **no** `Stock, from SD 4.4.0` text.
+- Three commits on `feat/54-stock-transform-accounting`, each carrying both
+  required trailers.

--- a/docs/superpowers/specs/2026-08-27-stock-transform-accounting-design.md
+++ b/docs/superpowers/specs/2026-08-27-stock-transform-accounting-design.md
@@ -1,0 +1,420 @@
+# Stock transform accounting — design
+
+**Issue:** [#54](https://github.com/jrpease/throughline/issues/54) — `PLATFORMS`
+is a hand-transcribed snapshot of Style Dictionary's stock transform groups
+**Date:** 2026-08-27
+**File:** `scripts/lib/sd-native.mjs`
+
+---
+
+## 1. The measured problem
+
+`scripts/lib/sd-native.mjs:314` states the module's design rule:
+
+> Build each platform's transform list from Style Dictionary's **STOCK** group,
+> replacing only the rem-assuming size transforms […] A hand-picked list
+> silently drops whatever it forgets.
+
+The rule is right — it is how #50 found three real defects, including Compose
+font sizes rendered in `dp` instead of `sp`. But nothing enforces it. `PLATFORMS`
+(`sd-native.mjs:341`) is a hand-written literal, and the stock lists it claims to
+mirror exist only as **prose** at `sd-native.mjs:336-340`:
+
+```
+// Stock, from SD 4.4.0:
+//   ios-swift: attribute/cti name/camel color/UIColorSwift
+//              content/swift/literal asset/swift/literal size/swift/remToCGFloat
+//   compose:   attribute/cti name/camel color/composeColor
+//              size/compose/em size/compose/remToSp size/compose/remToDp
+```
+
+There is no machine-comparable record and no test. So the failure mode the
+comment indicts is reintroduced one version later.
+
+### 1.1 Both directions of drift are real, measured
+
+Measured against real installs of Style Dictionary **4.4.0** and **5.5.2**
+(the current latest), reading `StyleDictionary.hooks.transformGroups`:
+
+| group | 4.4.0 | 5.5.2 | drift |
+|---|---|---|---|
+| `ios-swift` | 6 names | 6 names | **none — byte-identical** |
+| `compose` | 6 names | 6 names | **none — byte-identical** |
+| `ios` | …`size/remToPt` | …`size/remToFloat` | **renamed** |
+| `android` | 5 names | 5 names | none |
+| transforms registered | 55 | 62 | **+7 added** |
+
+The two groups this module consumes have not drifted across thirteen months and
+a major version. But Style Dictionary demonstrably does rename names inside a
+stock group (`ios`) and does add transforms (+7). The risk is real; it has
+simply not landed on us yet.
+
+### 1.2 Why our CI cannot be the guard
+
+`package.json` declares **no dependencies of any kind** — not even a peer
+dependency on Style Dictionary. The rule is explicit in this project's own
+plans: *"`scripts/` is a zero-dependency zone. `node:` built-ins only. No npm
+packages, ever. Style Dictionary is passed in as an argument."*
+
+Consequence: **the Style Dictionary a consumer runs is invisible to us.** There
+is no lockfile to bump, no version to pin, and no natural trigger for a
+version-pinned CI test. A guard that lives in our CI asserts something about a
+version no consumer is guaranteed to run.
+
+The only place the truth is known is the consumer's own build process — which
+is exactly where `registerNativeTransforms(StyleDictionary)` already stands.
+
+### 1.3 The asymmetry that decides the severity
+
+- **A rename or removal of a transform we run fails loudly.** Style Dictionary
+  throws on an unknown transform name at build time.
+- **An addition is dropped silently.** A new stock transform we never learn
+  about simply does not run, and the output is incomplete in whatever way that
+  transform existed to prevent.
+
+The second is the one worth guarding, and it is the one nothing catches today.
+
+---
+
+## 2. Three corrections to the issue text
+
+**2.1 "Style Dictionary is a peer dependency" is not what `package.json` says.**
+There is no `peerDependencies` block. It is an *implicit* peer, supplied by the
+caller as a function argument. The practical effect is the same or stronger: we
+have no declared version range at all, so we cannot even express a floor.
+
+**2.2 The issue's third option — a version-pinned CI test — is not viable
+alone.** §1.2: there is no dependency to pin and no natural trigger. It would
+test a version we chose, not one a consumer runs. Rejected.
+
+**2.3 The issue's recommended option (snapshot + assert) carries a liability the
+issue does not price.** A hardcoded `STOCK_FROM_4_4_0` constant must be
+re-blessed on every Style Dictionary release, and no test can distinguish
+"our snapshot is stale" from "Style Dictionary drifted" — both present as
+inequality. §3 avoids needing a snapshot at all.
+
+---
+
+## 3. The rule
+
+Invert the comparison. Do not ask *"does live stock match what we recorded?"*
+Ask the question the design rule actually poses:
+
+> **Is there a stock transform this config neither runs nor explicitly declined?**
+
+Answering it needs no snapshot. For each platform, take its stock group from the
+live `transformGroups` and report every name that is **neither** in that
+platform's own `transforms` array **nor** a declared exclusion.
+
+This requires making the exclusions explicit. Today they are an *absence* from
+the `PLATFORMS` arrays, which is indistinguishable from an oversight — issue
+item 4. They become data:
+
+```js
+// Which Style Dictionary stock transform group each platform is built from.
+// Held as data so auditStockGroups() can find it; nativePlatform() still emits
+// an explicit transform list and never a transformGroup key.
+const STOCK_GROUP = {
+  'ios-swift': 'ios-swift',
+  'android-kotlin': 'compose',
+};
+
+// Stock transforms this config deliberately does NOT run. The reason is the
+// point: an entry here is a decision on the record, where an absence from
+// PLATFORMS is indistinguishable from an oversight.
+const DECLINED_STOCK_TRANSFORMS = {
+  'size/swift/remToCGFloat': 'rem-assuming — replaced by size/unit-aware/swift',
+  'size/compose/remToDp': 'rem-assuming — replaced by size/unit-aware/compose-dp',
+  'size/compose/remToSp': 'rem-assuming — replaced by size/unit-aware/compose-sp',
+  'size/compose/em': 'em is not representable in native output — filtered out',
+};
+```
+
+### 3.1 Why this beats the snapshot approach
+
+- **Nothing to keep fresh.** No version-stamped constant, so no re-blessing
+  ritual and no stale-vs-drifted ambiguity.
+- **It states the actual rule.** "A hand-picked list silently drops whatever it
+  forgets" becomes mechanically impossible: every stock name must be run or
+  declined *in writing*.
+- **It discharges issue item 4** — the exclusions stop being implicit.
+- **It fits the module's existing principle.** From
+  `2026-08-21-native-adapter-config-module-design.md:95-109`: *"Pure functions are
+  the tested surface… testable without Style Dictionary present."* The check
+  takes a plain object and tests against literals.
+- **It catches renames too.** A renamed stock transform arrives as an
+  unaccounted name.
+
+### 3.2 What runs does not change
+
+`PLATFORMS` stays the deliberate, reviewable literal. `nativePlatform()` returns
+the same arrays it returns today. This is a diagnostic, not a behaviour change.
+Deriving the list at runtime instead — the issue's first option — was rejected:
+it trades a silent *omission* for a silent *inclusion*, and every native defect
+this project has found (#50's three, #51, #52) was a size/unit transform doing
+the wrong thing to a value. Auto-admitting an unknown transform into the
+pipeline is the more dangerous half of that trade.
+
+### 3.3 The mapping enforces itself
+
+`auditStockGroups` iterates `PLATFORMS`, not `STOCK_GROUP`. A third platform
+added without a stock-group mapping produces a lookup miss, which is reported as
+a **group missing** finding. Forgetting the mapping is therefore loud, not
+silent.
+
+---
+
+## 4. Deliberate non-rules
+
+Three things the check must **not** report. Each is pinned by a test (§8) so a
+later change cannot quietly widen the rule.
+
+**4.1 Order is never compared.** Our transform lists are hand-ordered for our own
+reasons — `value/color-mix-to-hex8` must precede the colour transform, and there
+is a test for it. That order does not derive from stock order. A pure reorder in
+a stock group is therefore not actionable for us, and reporting it would be
+noise.
+
+**4.2 Removals are never reported.** A stock name we already declined
+disappearing is a non-event. A stock name we actually *run* disappearing already
+makes Style Dictionary throw on an unknown transform (§1.3), so we add nothing.
+
+**4.3 Ungrouped transforms are out of scope.** Style Dictionary registered 62
+transforms in 5.5.2; only six are in `compose`. A transform registered but placed
+in no stock group is invisible to this check — correctly, because this module
+mirrors *groups*, not the registry. Filed as a known limit (§11).
+
+---
+
+## 5. Severity: warn, never throw
+
+The check **warns and never throws, and never changes an exit code.**
+
+- The dangerous direction is an *addition*, which is almost always harmless —
+  Style Dictionary 5.x added seven transforms, none touching our groups.
+  Throwing would break a consumer's build over a change that is probably
+  nothing, in a library they cannot edit, and would push them to pin an old
+  Style Dictionary — the opposite of the goal.
+- The direction that genuinely is fatal already throws inside Style Dictionary
+  (§1.3).
+- It matches the precedent set twice in this codebase: #52's unitless-dimension
+  advisory and the doc lint are both non-gating by design.
+
+Delivery: `console.warn('throughline: …')`, matching the existing convention at
+`scripts/install.mjs:58`. It fires once per build, at registration.
+
+---
+
+## 6. The blind spot, and the decision on it
+
+`registerNativeTransforms` is tested against a fake recorder —
+`{ registerPreprocessor, registerTransform }` — at six call sites in
+`sd-native.test.mjs`. None carries `hooks`.
+
+**Decision: an unreadable `transformGroups` warns.** The six fakes gain `hooks`.
+
+Reasoning: this whole issue is that *silent* is the dangerous direction. A guard
+that can quietly switch itself off has precisely the defect it was built to fix.
+The cost is six mechanical test edits; real consumers pass the real class, which
+exposes `hooks.transformGroups` **statically, before instantiation**, in both
+4.4.0 and 5.5.2 (measured).
+
+The counter-argument, recorded because it is not weak: the module's own design
+doc says `registerNativeTransforms` "is tested against a fake recorder object
+with the same method names," and warning on an absent `hooks` makes that fake
+incomplete by definition. The risk guarded is also narrow —
+`registerTransform` and `registerPreprocessor` are statics too, so a Style
+Dictionary that moved `hooks` would very likely fail loudly on those first. The
+decision is a judgement that a self-disabling guard is the worse outcome, not a
+claim that the counter-argument is wrong.
+
+To keep the six fakes honest without pasting the same literal six times, the
+test file routes them through a single fake factory — the pattern already used
+near `sd-native.test.mjs:314`.
+
+---
+
+## 7. Who the message is addressed to
+
+The warning prints in the **consumer's** build output, but both repairs it names
+— edit `PLATFORMS`, or add to `DECLINED_STOCK_TRANSFORMS` — are edits to
+**our** source. A consumer can act on neither.
+
+So the message leads with the action the reader can take and names the
+maintainer repair second, as the explanation. Without that ordering it is a
+warning that blames the reader for something they cannot fix.
+
+The three message forms, asserted verbatim by tests:
+
+**Unaccounted** (`n` names, correctly singular/plural — no `transform(s)`):
+
+```
+throughline: Style Dictionary's "compose" transform group has 2 transforms this
+adapter neither runs nor declined: size/compose/foo, size/compose/bar. Native
+output may be incomplete. Upgrade @radicool/throughline, or report your Style
+Dictionary version. (Maintainer repair: add each to
+PLATFORMS['android-kotlin'].transforms, or to DECLINED_STOCK_TRANSFORMS with a
+reason.)
+```
+
+**Group missing:**
+
+```
+throughline: Style Dictionary has no "compose" transform group, which
+PLATFORMS['android-kotlin'] mirrors. The stock group may have been renamed or
+removed. Upgrade @radicool/throughline, or report your Style Dictionary version.
+```
+
+**Unreadable:**
+
+```
+throughline: could not read Style Dictionary's stock transform groups
+(hooks.transformGroups is not an object), so this adapter cannot check whether
+its transform lists are still complete.
+```
+
+The singular form of the unaccounted message reads `has 1 transform this
+adapter neither runs nor declined:` — no `transform(s)` anywhere.
+
+Each is emitted as a single-line string; the wrapping above is presentational.
+
+---
+
+## 8. Code shape
+
+One exported pure function, returning **formatted strings** rather than
+structured findings, so the wording is what the tests assert and the caller is
+a bare loop:
+
+```js
+export function auditStockGroups(transformGroups) // → string[]
+```
+
+Contract:
+
+- `transformGroups` is not a non-null object → `[unreadable message]`, length 1.
+- Otherwise, for each entry of `PLATFORMS` in declaration order:
+  - `transformGroups[STOCK_GROUP[platform]]` is not an array → group-missing
+    message for that platform.
+  - Otherwise collect every name in that array that is neither in the
+    platform's `transforms` nor a key of `DECLINED_STOCK_TRANSFORMS`. If the
+    collection is non-empty, emit **one** unaccounted message listing all of
+    them, comma-separated, in stock order.
+- No findings → `[]`.
+
+Each platform is evaluated independently: a finding for `compose` must not
+suppress evaluation of `ios-swift`.
+
+Call site, inside `registerNativeTransforms`:
+
+```js
+for (const w of auditStockGroups(StyleDictionary?.hooks?.transformGroups)) {
+  console.warn(w);
+}
+```
+
+The `?.` chain is what turns a fake with no `hooks` into `undefined`, which the
+function reports as unreadable per §6.
+
+---
+
+## 9. Tests
+
+All in `scripts/lib/sd-native.test.mjs`. The function takes a literal, so every
+case is cheap and needs no Style Dictionary installed.
+
+**Silence on reality**
+
+1. The real stock arrays produce `[]`. One literal, commented as verified
+   byte-identical in 4.4.0 and 5.5.2 — asserting the same array twice would be
+   duplication, not coverage.
+
+**The rule**
+
+2. One unaccounted name → exactly one message, matching §7 verbatim.
+3. Two unaccounted names in one group → **one** message listing both, not two
+   messages.
+4. Both platforms unaccounted → two messages, one per platform.
+5. A declined name present in stock → `[]`. Proves the deny-list works.
+
+**The non-rules of §4**
+
+6. A stock group reordered, same names → `[]`.
+7. A declined name removed from stock → `[]`.
+
+**Degenerate inputs**
+
+8. Group absent from `transformGroups` → group-missing message.
+9. `undefined`, `null`, and a non-object (e.g. a string) → the unreadable
+   message, length 1, in each case.
+
+**Through the side-effecting caller**
+
+10. `registerNativeTransforms` with a fake carrying correct `hooks` emits no
+    warning (capture `console.warn`, restore in a `finally`).
+11. `registerNativeTransforms` with a fake lacking `hooks` emits exactly one
+    unreadable warning. This pins the §6 decision.
+
+**Not broken**
+
+12. The existing assertions at `sd-native.test.mjs:118-164` still pass
+    unchanged — `nativePlatform`'s emitted arrays are untouched (§3.2).
+
+---
+
+## 10. Docs and generated output
+
+The new constants and function sit inside the `@doc-section platform` block
+(`sd-native.mjs:313-455`), so `references/native-adapter-config.md` **must be
+regenerated**:
+
+```
+node scripts/build-native-adapter-config.mjs
+```
+
+CI gates freshness with `node scripts/build-native-adapter-config.mjs --check`.
+Every task that touches `sd-native.mjs` regenerates and commits the doc in the
+same commit.
+
+**The `// Stock, from SD 4.4.0:` comment block is replaced.** Once the check
+exists, that hand-transcribed prose is exactly the stale-snapshot liability §2.3
+rejects — it will drift and nothing will notice. It becomes a short note stating
+that the lists mirror Style Dictionary's stock groups, that `auditStockGroups`
+enforces the mirroring at registration, and that both groups were verified
+identical in 4.4.0 and 5.5.2. Comments in this file are load-bearing: they are
+the shipped reference doc.
+
+**No new user-facing reference.** The message carries its own instructions (§7),
+and the repairs are ours, not the consumer's.
+
+**CHANGELOG:** one entry under `## [Unreleased]` → `### Added`.
+
+---
+
+## 11. Constraints
+
+- **Zero dependencies.** `node:` built-ins only. Style Dictionary is passed in
+  as an argument and never imported.
+- **Pure functions are the tested surface.** `auditStockGroups` is pure;
+  `registerNativeTransforms` stays the only side-effecting export in this area.
+- **Non-gating.** Nothing here throws, and nothing changes an exit code.
+- **`sd-native.mjs` is a contended file.** It generates a CI-gated doc from its
+  whole body, so concurrent branches conflict guaranteed. PR
+  [#69](https://github.com/jrpease/throughline/pull/69) (#52) is open against it.
+  This work **branches on top of `fix/52-unitless-dimension`**, and its PR must
+  be **retargeted to `main` before #69 merges**. Merging a parent with
+  `--delete-branch` auto-closes a stacked child, and it cannot be reopened once
+  its head has been rebased — that cost PR #65 on 2026-08-24.
+
+---
+
+## 12. Known limits, to file rather than solve
+
+- **Ungrouped transforms are invisible** (§4.3). Only names Style Dictionary
+  places in a stock group are checked.
+- **A stock reorder is not reported** (§4.1). If a future Style Dictionary
+  reorders a group because order became semantically significant, this check is
+  silent.
+- **The check cannot verify that a declined transform is still the right thing
+  to decline.** `DECLINED_STOCK_TRANSFORMS` entries carry reasons for a human;
+  nothing tests that the reason still holds.

--- a/docs/superpowers/specs/2026-08-27-stock-transform-accounting-design.md
+++ b/docs/superpowers/specs/2026-08-27-stock-transform-accounting-design.md
@@ -106,19 +106,37 @@ Answering it needs no snapshot. For each platform, take its stock group from the
 live `transformGroups` and report every name that is **neither** in that
 platform's own `transforms` array **nor** a declared exclusion.
 
-This requires making the exclusions explicit. Today they are an *absence* from
-the `PLATFORMS` arrays, which is indistinguishable from an oversight — issue
-item 4. They become data:
+This requires two things to become data.
+
+**The stock group each platform mirrors** moves *into* `PLATFORMS`, not into a
+parallel constant beside it:
 
 ```js
-// Which Style Dictionary stock transform group each platform is built from.
-// Held as data so auditStockGroups() can find it; nativePlatform() still emits
-// an explicit transform list and never a transformGroup key.
-const STOCK_GROUP = {
-  'ios-swift': 'ios-swift',
-  'android-kotlin': 'compose',
+const PLATFORMS = {
+  'ios-swift': {
+    stockGroup: 'ios-swift',
+    transforms: [ /* unchanged */ ],
+    destination: 'Tokens.swift',
+    format: 'ios-swift/enum.swift',
+  },
+  'android-kotlin': {
+    stockGroup: 'compose',
+    transforms: [ /* unchanged */ ],
+    destination: 'Tokens.kt',
+    format: 'compose/object',
+  },
 };
+```
 
+`nativePlatform()` builds its return value field by field
+(`sd-native.mjs:435-453`) rather than spreading the preset, so `stockGroup` is
+never emitted into the Style Dictionary platform config. Nothing about the
+produced config changes.
+
+**The exclusions** become a declared list. Today they are an *absence* from the
+`PLATFORMS` arrays, which is indistinguishable from an oversight — issue item 4:
+
+```js
 // Stock transforms this config deliberately does NOT run. The reason is the
 // point: an entry here is a decision on the record, where an absence from
 // PLATFORMS is indistinguishable from an oversight.
@@ -130,7 +148,23 @@ const DECLINED_STOCK_TRANSFORMS = {
 };
 ```
 
-### 3.1 Why this beats the snapshot approach
+### 3.1 The declined list is flat across platforms, deliberately
+
+`DECLINED_STOCK_TRANSFORMS` is keyed by transform name alone, with no platform
+qualifier. A name declined for Compose is therefore also declined if it ever
+appears in the `ios-swift` stock group.
+
+That is safe today **only because every name in it is platform-prefixed**
+(`size/swift/…`, `size/compose/…`), so no cross-platform collision is
+expressible. That safety is a property of Style Dictionary's current naming
+conventions, not of this design. A future decline of an unprefixed name — a
+hypothetical shared `size/px` — would widen silently across both platforms.
+
+The flat map is chosen because a per-platform map would be ceremony for a
+collision that cannot currently occur. The moment an unprefixed name is
+declined, it must become per-platform. Recorded in §12.
+
+### 3.2 Why this beats the snapshot approach
 
 - **Nothing to keep fresh.** No version-stamped constant, so no re-blessing
   ritual and no stale-vs-drifted ambiguity.
@@ -139,34 +173,55 @@ const DECLINED_STOCK_TRANSFORMS = {
   declined *in writing*.
 - **It discharges issue item 4** — the exclusions stop being implicit.
 - **It fits the module's existing principle.** From
-  `2026-08-21-native-adapter-config-module-design.md:95-109`: *"Pure functions are
-  the tested surface… testable without Style Dictionary present."* The check
+  `2026-08-21-native-adapter-config-module-design.md:95-109`: *"Pure functions
+  are the tested surface… testable without Style Dictionary present."* The check
   takes a plain object and tests against literals.
 - **It catches renames too.** A renamed stock transform arrives as an
   unaccounted name.
 
-### 3.2 What runs does not change
+### 3.3 What runs does not change
 
-`PLATFORMS` stays the deliberate, reviewable literal. `nativePlatform()` returns
-the same arrays it returns today. This is a diagnostic, not a behaviour change.
+`PLATFORMS` keeps the same deliberate, reviewable transform arrays.
+`nativePlatform()` returns exactly what it returns today. This is a diagnostic,
+not a behaviour change.
+
 Deriving the list at runtime instead — the issue's first option — was rejected:
 it trades a silent *omission* for a silent *inclusion*, and every native defect
 this project has found (#50's three, #51, #52) was a size/unit transform doing
 the wrong thing to a value. Auto-admitting an unknown transform into the
 pipeline is the more dangerous half of that trade.
 
-### 3.3 The mapping enforces itself
+### 3.4 A platform that declares no stock group
 
-`auditStockGroups` iterates `PLATFORMS`, not `STOCK_GROUP`. A third platform
-added without a stock-group mapping produces a lookup miss, which is reported as
-a **group missing** finding. Forgetting the mapping is therefore loud, not
-silent.
+An earlier draft of this spec kept the mapping in a separate `STOCK_GROUP`
+constant and claimed "the mapping enforces itself" because the audit iterates
+`PLATFORMS` rather than `STOCK_GROUP`. That claim was unpinnable: both constants
+had the same two keys, so an implementation looping over
+`Object.entries(STOCK_GROUP)` — the more natural way to write it, since it
+yields platform and group together — would satisfy every test and silently void
+the guarantee.
+
+Folding `stockGroup` into `PLATFORMS` **deletes the invariant instead of
+asserting it.** There is no second constant to fall out of sync with, and no
+wrong thing to iterate.
+
+What remains is a preset that omits `stockGroup`. `auditStockGroups` reports
+that as **its own finding kind with its own message** (§7) — never as a
+group-missing finding, whose diagnosis (*Style Dictionary drifted; report your
+version*) would be wrong for this cause and would tell a consumer to chase a
+defect that is ours.
+
+**The surface that catches it before shipping is our CI, not a consumer's
+console.** Test 1 (§9) runs the audit against the real stock arrays and asserts
+an empty result; a platform added without a `stockGroup` yields a finding and
+that test fails. The `console.warn` is the backstop for a build we never ran,
+not the primary guard.
 
 ---
 
 ## 4. Deliberate non-rules
 
-Three things the check must **not** report. Each is pinned by a test (§8) so a
+Three things the check must **not** report. Each is pinned by a test (§9) so a
 later change cannot quietly widen the rule.
 
 **4.1 Order is never compared.** Our transform lists are hand-ordered for our own
@@ -182,7 +237,7 @@ makes Style Dictionary throw on an unknown transform (§1.3), so we add nothing.
 **4.3 Ungrouped transforms are out of scope.** Style Dictionary registered 62
 transforms in 5.5.2; only six are in `compose`. A transform registered but placed
 in no stock group is invisible to this check — correctly, because this module
-mirrors *groups*, not the registry. Filed as a known limit (§11).
+mirrors *groups*, not the registry. Filed as a known limit (§12).
 
 ---
 
@@ -201,7 +256,13 @@ The check **warns and never throws, and never changes an exit code.**
   advisory and the doc lint are both non-gating by design.
 
 Delivery: `console.warn('throughline: …')`, matching the existing convention at
-`scripts/install.mjs:58`. It fires once per build, at registration.
+`scripts/install.mjs:58`.
+
+It fires once per **registration** — typically once per process — **not once per
+build.** Registration and builds are not one-to-one: the module's own documented
+usage (`build-native-adapter-config.mjs:190-199`) calls `registerNativeTransforms`
+once and then constructs one `StyleDictionary` per mode. Nothing re-checks per
+mode, and nothing needs to: the stock groups cannot change between modes.
 
 ---
 
@@ -273,6 +334,16 @@ throughline: could not read Style Dictionary's stock transform groups
 its transform lists are still complete.
 ```
 
+**No stock group declared** — a `PLATFORMS` preset missing `stockGroup`. This is
+our defect, not a drift signal, so it says so rather than sending the reader
+after their Style Dictionary version:
+
+```
+throughline: PLATFORMS['ios-tvos'] declares no stockGroup, so its transform list
+cannot be checked against Style Dictionary's stock groups. This is a throughline
+packaging defect — please report it.
+```
+
 The singular form of the unaccounted message reads `has 1 transform this
 adapter neither runs nor declined:` — no `transform(s)` anywhere.
 
@@ -292,18 +363,26 @@ export function auditStockGroups(transformGroups) // → string[]
 
 Contract:
 
-- `transformGroups` is not a non-null object → `[unreadable message]`, length 1.
+- `transformGroups` fails `typeof transformGroups === 'object' && transformGroups !== null`
+  → `[unreadable message]`, length 1, and nothing further is evaluated.
+  **An array passes this check** — it is a non-null object — and therefore flows
+  into the per-platform loop, where each platform yields a group-missing
+  finding. That is the chosen reading; a stricter plain-object test is
+  deliberately not used, because the only realistic non-object inputs are
+  `undefined` and `null`, and rejecting arrays would be a rule with no case.
 - Otherwise, for each entry of `PLATFORMS` in declaration order:
-  - `transformGroups[STOCK_GROUP[platform]]` is not an array → group-missing
+  - the preset has no `stockGroup` → the no-stock-group message for that
+    platform.
+  - `transformGroups[preset.stockGroup]` is not an array → the group-missing
     message for that platform.
-  - Otherwise collect every name in that array that is neither in the
+  - otherwise, collect every name in that array that is neither in the
     platform's `transforms` nor a key of `DECLINED_STOCK_TRANSFORMS`. If the
     collection is non-empty, emit **one** unaccounted message listing all of
     them, comma-separated, in stock order.
 - No findings → `[]`.
 
-Each platform is evaluated independently: a finding for `compose` must not
-suppress evaluation of `ios-swift`.
+Each platform is evaluated independently: a finding for one must never suppress
+evaluation of the other.
 
 Call site, inside `registerNativeTransforms`:
 
@@ -329,36 +408,60 @@ case is cheap and needs no Style Dictionary installed.
    byte-identical in 4.4.0 and 5.5.2 — asserting the same array twice would be
    duplication, not coverage.
 
+   This test carries two loads beyond the obvious one. It is the CI net for a
+   platform added without a `stockGroup` (§3.4). And it discriminates against an
+   implementation that compares the *reverse* direction: `PLATFORMS` contains six
+   names absent from stock (`value/color-mix-to-hex8`, the three `unit-aware`
+   size transforms, and both string-literal transforms), so a check asking "is
+   everything we run in stock?" fails here immediately.
+
 **The rule**
 
-2. One unaccounted name → exactly one message, matching §7 verbatim.
-3. Two unaccounted names in one group → **one** message listing both, not two
-   messages.
+2. One unaccounted name → exactly one message, matching §7's **singular** form
+   verbatim.
+3. Two unaccounted names in one group → **one** message listing both,
+   comma-separated in stock order — not two messages.
 4. Both platforms unaccounted → two messages, one per platform.
-5. A declined name present in stock → `[]`. Proves the deny-list works.
+5. A declined name present in stock → `[]`. Proves the deny-list is consulted.
 
 **The non-rules of §4**
 
-6. A stock group reordered, same names → `[]`.
-7. A declined name removed from stock → `[]`.
+6. A stock group reordered, same names → `[]`. Discriminates against a check
+   that compares ordered arrays.
+7. A declined name removed from stock → `[]`. Discriminates against a
+   snapshot-comparing implementation, which would report the removal.
 
 **Degenerate inputs**
 
 8. Group absent from `transformGroups` → group-missing message.
-9. `undefined`, `null`, and a non-object (e.g. a string) → the unreadable
-   message, length 1, in each case.
+9. `undefined`, `null`, a string, and a number → the unreadable message,
+   length 1, in each case.
+10. An **array** → two group-missing messages, *not* the unreadable message.
+    Pins §8's chosen reading, which two different implementations would
+    otherwise both satisfy.
 
 **Through the side-effecting caller**
 
-10. `registerNativeTransforms` with a fake carrying correct `hooks` emits no
+11. `registerNativeTransforms` with a fake carrying correct `hooks` emits no
     warning (capture `console.warn`, restore in a `finally`).
-11. `registerNativeTransforms` with a fake lacking `hooks` emits exactly one
+12. `registerNativeTransforms` with a fake lacking `hooks` emits exactly one
     unreadable warning. This pins the §6 decision.
 
 **Not broken**
 
-12. The existing assertions at `sd-native.test.mjs:118-164` still pass
-    unchanged — `nativePlatform`'s emitted arrays are untouched (§3.2).
+13. The existing assertions at `sd-native.test.mjs:118-164` still pass
+    unchanged — `nativePlatform`'s emitted arrays are untouched (§3.3).
+
+### 9.1 What is deliberately not asserted
+
+The **no-stock-group** message (§7) cannot be exercised from outside the module:
+`PLATFORMS` is module-private and `auditStockGroups` takes no injectable platform
+map. Adding a test-only injection parameter to a diagnostic would be
+configurability nothing asked for.
+
+So test 1 guards the *behaviour* — a preset added without `stockGroup` makes it
+fail — while the message's exact wording ships unasserted. That is a real gap,
+accepted rather than papered over, and recorded in §12.
 
 ---
 
@@ -384,8 +487,24 @@ enforces the mirroring at registration, and that both groups were verified
 identical in 4.4.0 and 5.5.2. Comments in this file are load-bearing: they are
 the shipped reference doc.
 
-**No new user-facing reference.** The message carries its own instructions (§7),
-and the repairs are ours, not the consumer's.
+**`PROSE['platform']` in the generator must be updated too.** The prose that
+accompanies the platform code block in the shipped reference is
+`scripts/build-native-adapter-config.mjs:109-147` — a narrative section titled
+*"Assemble the platform from the stock list"* that opens with the very rule this
+change enforces. Regeneration alone would leave the code block gaining two
+constants and an exported function with no prose acknowledging the audit exists,
+against the generator's own principle that prose sits adjacent to the code it
+explains.
+
+It gains one paragraph stating: that the stock list is now accounted for rather
+than mirrored by hand, that every stock transform must be run or declined in
+writing, that the check warns and never throws, and that it fires in the
+consumer's build because that is the only place the installed Style Dictionary
+version is knowable. It must not restate the message text — that would be a
+second copy to drift.
+
+**No new user-facing reference beyond that.** The message carries its own
+instructions (§7), and the repairs are ours, not the consumer's.
 
 **CHANGELOG:** one entry under `## [Unreleased]` → `### Added`.
 
@@ -418,3 +537,8 @@ and the repairs are ours, not the consumer's.
 - **The check cannot verify that a declined transform is still the right thing
   to decline.** `DECLINED_STOCK_TRANSFORMS` entries carry reasons for a human;
   nothing tests that the reason still holds.
+- **`DECLINED_STOCK_TRANSFORMS` is flat across platforms** (§3.1). Safe only
+  while every declined name is platform-prefixed. Declining an unprefixed name
+  must convert the map to per-platform; nothing enforces that today.
+- **The no-stock-group message ships unasserted** (§9.1). Its behaviour is
+  guarded by test 1; its wording is not.

--- a/docs/superpowers/specs/2026-08-27-stock-transform-accounting-design.md
+++ b/docs/superpowers/specs/2026-08-27-stock-transform-accounting-design.md
@@ -193,7 +193,7 @@ this project has found (#50's three, #51, #52) was a size/unit transform doing
 the wrong thing to a value. Auto-admitting an unknown transform into the
 pipeline is the more dangerous half of that trade.
 
-### 3.4 A platform that declares no stock group
+### 3.4 A preset that cannot be checked
 
 An earlier draft of this spec kept the mapping in a separate `STOCK_GROUP`
 constant and claimed "the mapping enforces itself" because the audit iterates
@@ -211,9 +211,10 @@ That is a claim about the stock-group mapping specifically.
 `DECLINED_STOCK_TRANSFORMS` is a separate constant and can contradict
 `PLATFORMS` in one direction this check cannot see — §12.
 
-What remains is a preset that omits `stockGroup`. `auditStockGroups` reports
-that as **its own finding kind with its own message** (§7) — never as a
-group-missing finding, whose diagnosis (*Style Dictionary drifted; report your
+What remains is a preset that cannot be checked at all — one that omits
+`stockGroup`, or whose `transforms` is not an array. `auditStockGroups` reports
+either as **one finding kind with one message** (§7), the incomplete-preset
+message — never as a group-missing finding, whose diagnosis (*Style Dictionary drifted; report your
 version*) would be wrong for this cause and would tell a consumer to chase a
 defect that is ours.
 

--- a/docs/superpowers/specs/2026-08-27-stock-transform-accounting-design.md
+++ b/docs/superpowers/specs/2026-08-27-stock-transform-accounting-design.md
@@ -166,8 +166,10 @@ declined, it must become per-platform. Recorded in §12.
 
 ### 3.2 Why this beats the snapshot approach
 
-- **Nothing to keep fresh.** No version-stamped constant, so no re-blessing
-  ritual and no stale-vs-drifted ambiguity.
+- **Nothing to keep fresh in the production path.** The live check needs no
+  snapshot, so divergence is reported against what this config decided rather
+  than against what we last recorded, and the stale-vs-drifted ambiguity is
+  gone. One version-stamped literal does remain, in the test file — see §12.
 - **It states the actual rule.** "A hand-picked list silently drops whatever it
   forgets" becomes mechanically impossible: every stock name must be run or
   declined *in writing*.
@@ -204,6 +206,10 @@ the guarantee.
 Folding `stockGroup` into `PLATFORMS` **deletes the invariant instead of
 asserting it.** There is no second constant to fall out of sync with, and no
 wrong thing to iterate.
+
+That is a claim about the stock-group mapping specifically.
+`DECLINED_STOCK_TRANSFORMS` is a separate constant and can contradict
+`PLATFORMS` in one direction this check cannot see — §12.
 
 What remains is a preset that omits `stockGroup`. `auditStockGroups` reports
 that as **its own finding kind with its own message** (§7) — never as a
@@ -334,14 +340,14 @@ throughline: could not read Style Dictionary's stock transform groups
 its transform lists are still complete.
 ```
 
-**No stock group declared** — a `PLATFORMS` preset missing `stockGroup`. This is
-our defect, not a drift signal, so it says so rather than sending the reader
-after their Style Dictionary version:
+**Incomplete preset** — a `PLATFORMS` preset missing `stockGroup` or `transforms`.
+This is our defect, not a drift signal, so it says so rather than sending the
+reader after their Style Dictionary version:
 
 ```
-throughline: PLATFORMS['ios-tvos'] declares no stockGroup, so its transform list
-cannot be checked against Style Dictionary's stock groups. This is a throughline
-packaging defect — please report it.
+throughline: PLATFORMS['ios-tvos'] is incomplete — it needs both stockGroup and
+transforms — so its transform list cannot be checked against Style Dictionary's
+stock groups. This is a throughline packaging defect — please report it.
 ```
 
 The singular form of the unaccounted message reads `has 1 transform this
@@ -371,8 +377,9 @@ Contract:
   deliberately not used, because the only realistic non-object inputs are
   `undefined` and `null`, and rejecting arrays would be a rule with no case.
 - Otherwise, for each entry of `PLATFORMS` in declaration order:
-  - the preset has no `stockGroup` → the no-stock-group message for that
-    platform.
+  - the preset has no `stockGroup`, or its `transforms` is not an array → the
+    incomplete-preset message for that platform. This guard is what keeps the
+    function's no-throw promise.
   - `transformGroups[preset.stockGroup]` is not an array → the group-missing
     message for that platform.
   - otherwise, collect every name in that array that is neither in the
@@ -454,7 +461,7 @@ case is cheap and needs no Style Dictionary installed.
 
 ### 9.1 What is deliberately not asserted
 
-The **no-stock-group** message (§7) cannot be exercised from outside the module:
+The **incomplete-preset** message (§7) cannot be exercised from outside the module:
 `PLATFORMS` is module-private and `auditStockGroups` takes no injectable platform
 map. Adding a test-only injection parameter to a diagnostic would be
 configurability nothing asked for.
@@ -540,5 +547,16 @@ instructions (§7), and the repairs are ours, not the consumer's.
 - **`DECLINED_STOCK_TRANSFORMS` is flat across platforms** (§3.1). Safe only
   while every declined name is platform-prefixed. Declining an unprefixed name
   must convert the map to per-platform; nothing enforces that today.
-- **The no-stock-group message ships unasserted** (§9.1). Its behaviour is
+- **The incomplete-preset message ships unasserted** (§9.1). Its behaviour is
   guarded by test 1; its wording is not.
+- **A transform that is both run and declined is invisible.**
+  `auditStockGroups` reports a name only when it is in neither the platform's
+  `transforms` nor `DECLINED_STOCK_TRANSFORMS`; a name in *both* satisfies the
+  check twice and is never reported. The decline reasons ship in
+  `references/native-adapter-config.md`, so a contradiction there is published
+  documentation disagreeing with what runs.
+- **`REAL_STOCK` in the test file is a version-stamped snapshot** (§3.2). When a
+  stock group next changes, test 1 keeps passing against the stale literal while
+  real consumers get the warning, and someone must re-bless it. The liability is
+  strictly smaller than a snapshot in production code — a stale literal can only
+  fail to alarm, never false-alarm — but it is not nil.

--- a/references/native-adapter-config.md
+++ b/references/native-adapter-config.md
@@ -826,6 +826,17 @@ export function registerNativeTransforms(StyleDictionary) {
     filter: isQuotable,
     transform: (token) => `"${escapeCommon(stringValue(token)).replace(/\$/g, '\\$')}"`,
   });
+
+  // Last, so every registration side effect has completed before anything is
+  // printed. Fires once per REGISTRATION — typically once per process, not once
+  // per build: the documented usage registers once and then constructs one
+  // StyleDictionary per mode, and the stock groups cannot change between modes.
+  //
+  // The ?. chain is what turns a caller with no hooks into undefined, which
+  // auditStockGroups reports as unreadable rather than silently skipping.
+  for (const warning of auditStockGroups(StyleDictionary?.hooks?.transformGroups)) {
+    console.warn(warning);
+  }
 }
 ```
 

--- a/references/native-adapter-config.md
+++ b/references/native-adapter-config.md
@@ -449,6 +449,7 @@ what was meant.
 //              size/compose/em size/compose/remToSp size/compose/remToDp
 const PLATFORMS = {
   'ios-swift': {
+    stockGroup: 'ios-swift',
     transforms: [
       'attribute/cti',
       'name/camel',
@@ -463,6 +464,7 @@ const PLATFORMS = {
     format: 'ios-swift/enum.swift',
   },
   'android-kotlin': {
+    stockGroup: 'compose',
     transforms: [
       'attribute/cti',
       'name/camel',
@@ -476,6 +478,85 @@ const PLATFORMS = {
     format: 'compose/object',
   },
 };
+
+// Stock transforms this config deliberately does NOT run. The reason is the
+// point: an entry here is a decision on the record, where an absence from
+// PLATFORMS is indistinguishable from an oversight.
+//
+// Keyed by transform name alone, with no platform qualifier. That is safe only
+// because every name here is platform-prefixed, so no cross-platform collision
+// is expressible. Declining an unprefixed name — a hypothetical shared
+// "size/px" — would widen silently across both platforms and must convert this
+// to a per-platform map.
+const DECLINED_STOCK_TRANSFORMS = {
+  'size/swift/remToCGFloat': 'rem-assuming — replaced by size/unit-aware/swift',
+  'size/compose/remToDp': 'rem-assuming — replaced by size/unit-aware/compose-dp',
+  'size/compose/remToSp': 'rem-assuming — replaced by size/unit-aware/compose-sp',
+  'size/compose/em': 'em is not representable in native output — filtered out',
+};
+
+// Report every transform in a platform's live stock group that this config
+// neither runs nor explicitly declined. Pure: it takes Style Dictionary's
+// hooks.transformGroups and returns formatted warning strings, so the wording
+// is what the tests assert and the caller is a bare loop.
+//
+// Warns, never throws. The dangerous direction is an ADDITION we never learned
+// about, which is usually harmless and occasionally important — throwing would
+// break a build over a change the consumer cannot fix. The fatal direction, a
+// transform we run being removed, already makes Style Dictionary throw on an
+// unknown transform name.
+//
+// Order is never compared: our lists are hand-ordered for our own reasons and
+// do not inherit stock order. Removals are never reported: a declined name
+// disappearing is a non-event.
+export function auditStockGroups(transformGroups) {
+  if (typeof transformGroups !== 'object' || transformGroups === null) {
+    return [
+      "throughline: could not read Style Dictionary's stock transform groups " +
+        '(hooks.transformGroups is not an object), so this adapter cannot check ' +
+        'whether its transform lists are still complete.',
+    ];
+  }
+  const warnings = [];
+  for (const [platform, preset] of Object.entries(PLATFORMS)) {
+    const group = preset.stockGroup;
+    if (!group) {
+      warnings.push(
+        `throughline: PLATFORMS['${platform}'] declares no stockGroup, so its ` +
+          "transform list cannot be checked against Style Dictionary's stock " +
+          'groups. This is a throughline packaging defect — please report it.',
+      );
+      continue;
+    }
+    const stock = transformGroups[group];
+    if (!Array.isArray(stock)) {
+      warnings.push(
+        `throughline: Style Dictionary has no "${group}" transform group, which ` +
+          `PLATFORMS['${platform}'] mirrors. The stock group may have been ` +
+          'renamed or removed. Upgrade @radicool/throughline, or report your ' +
+          'Style Dictionary version.',
+      );
+      continue;
+    }
+    const unaccounted = stock.filter(
+      (name) =>
+        !preset.transforms.includes(name) &&
+        !Object.hasOwn(DECLINED_STOCK_TRANSFORMS, name),
+    );
+    if (unaccounted.length) {
+      const n = unaccounted.length;
+      warnings.push(
+        `throughline: Style Dictionary's "${group}" transform group has ${n} ` +
+          `transform${n === 1 ? '' : 's'} this adapter neither runs nor declined: ` +
+          `${unaccounted.join(', ')}. Native output may be incomplete. Upgrade ` +
+          '@radicool/throughline, or report your Style Dictionary version. ' +
+          `(Maintainer repair: add each to PLATFORMS['${platform}'].transforms, ` +
+          'or to DECLINED_STOCK_TRANSFORMS with a reason.)',
+      );
+    }
+  }
+  return warnings;
+}
 
 // % and em are container- or parent-relative, so there is no build-time native
 // magnitude. Filter on the AUTHORED value, not on $type — a "100%" token may be

--- a/references/native-adapter-config.md
+++ b/references/native-adapter-config.md
@@ -537,11 +537,12 @@ export function auditStockGroups(transformGroups) {
   const warnings = [];
   for (const [platform, preset] of Object.entries(PLATFORMS)) {
     const group = preset.stockGroup;
-    if (!group) {
+    if (!group || !Array.isArray(preset.transforms)) {
       warnings.push(
-        `throughline: PLATFORMS['${platform}'] declares no stockGroup, so its ` +
-          "transform list cannot be checked against Style Dictionary's stock " +
-          'groups. This is a throughline packaging defect — please report it.',
+        `throughline: PLATFORMS['${platform}'] is incomplete — it needs both ` +
+          'stockGroup and transforms — so its transform list cannot be checked ' +
+          "against Style Dictionary's stock groups. This is a throughline " +
+          'packaging defect — please report it.',
       );
       continue;
     }

--- a/references/native-adapter-config.md
+++ b/references/native-adapter-config.md
@@ -419,6 +419,17 @@ a `unitless-dimension` advisory, which does not gate — the emitted value is
 right under the ratio reading, and only the author can say whether a ratio is
 what was meant.
 
+**The stock list is accounted for, not transcribed.** `PLATFORMS` records the
+stock group each platform mirrors, and `auditStockGroups` checks at
+registration that every transform in that live group is either run here or
+declined in writing, with a reason. A stock transform this config has never
+decided about warns; it is never silently dropped. The check warns and never
+throws — a new stock transform is usually harmless, and the fatal direction, a
+transform we run being removed, already makes Style Dictionary throw on an
+unknown name. It runs in your build because that is the only place the
+installed Style Dictionary version is knowable: ThroughLine declares no
+dependency on it.
+
 ```js
 // Build each platform's transform list from Style Dictionary's STOCK group,
 // replacing only the rem-assuming size transforms and inserting the color-mix
@@ -442,11 +453,17 @@ what was meant.
 // transform claims a unitless value, so it emits bare on both platforms, and
 // tokens:validate-output reports it as a unitless-dimension advisory.
 //
-// Stock, from SD 4.4.0:
-//   ios-swift: attribute/cti name/camel color/UIColorSwift
-//              content/swift/literal asset/swift/literal size/swift/remToCGFloat
-//   compose:   attribute/cti name/camel color/composeColor
-//              size/compose/em size/compose/remToSp size/compose/remToDp
+// The lists below mirror Style Dictionary's stock groups, and nothing derives
+// them at runtime — what runs stays deliberate and reviewable. But nothing is
+// transcribed either: auditStockGroups checks at registration that every name
+// in the live stock group is either run here or declined in writing, so a
+// stock transform this config has never made a decision about is loud rather
+// than silently dropped.
+//
+// Both groups were verified byte-identical in SD 4.4.0 and 5.5.2. The `ios`
+// group was not — it renamed size/remToPt to size/remToFloat between them, and
+// 5.x added seven transforms overall. The drift this guards against is real;
+// it has simply not landed on the two groups we build from.
 const PLATFORMS = {
   'ios-swift': {
     stockGroup: 'ios-swift',

--- a/scripts/build-native-adapter-config.mjs
+++ b/scripts/build-native-adapter-config.mjs
@@ -144,7 +144,18 @@ byte-for-byte what a correctly typed \`number\` already produced, so correcting
 the source's \`$type\` changes no output. \`tokens:validate-output\` reports it as
 a \`unitless-dimension\` advisory, which does not gate — the emitted value is
 right under the ratio reading, and only the author can say whether a ratio is
-what was meant.`],
+what was meant.
+
+**The stock list is accounted for, not transcribed.** \`PLATFORMS\` records the
+stock group each platform mirrors, and \`auditStockGroups\` checks at
+registration that every transform in that live group is either run here or
+declined in writing, with a reason. A stock transform this config has never
+decided about warns; it is never silently dropped. The check warns and never
+throws — a new stock transform is usually harmless, and the fatal direction, a
+transform we run being removed, already makes Style Dictionary throw on an
+unknown name. It runs in your build because that is the only place the
+installed Style Dictionary version is knowable: ThroughLine declares no
+dependency on it.`],
   ['sources', `## 5. Guard the per-mode source list
 
 Style Dictionary deduplicates by dot-path, so one build over both a light and a

--- a/scripts/lib/sd-native.mjs
+++ b/scripts/lib/sd-native.mjs
@@ -333,11 +333,17 @@ export function preprocess(dict) {
 // transform claims a unitless value, so it emits bare on both platforms, and
 // tokens:validate-output reports it as a unitless-dimension advisory.
 //
-// Stock, from SD 4.4.0:
-//   ios-swift: attribute/cti name/camel color/UIColorSwift
-//              content/swift/literal asset/swift/literal size/swift/remToCGFloat
-//   compose:   attribute/cti name/camel color/composeColor
-//              size/compose/em size/compose/remToSp size/compose/remToDp
+// The lists below mirror Style Dictionary's stock groups, and nothing derives
+// them at runtime — what runs stays deliberate and reviewable. But nothing is
+// transcribed either: auditStockGroups checks at registration that every name
+// in the live stock group is either run here or declined in writing, so a
+// stock transform this config has never made a decision about is loud rather
+// than silently dropped.
+//
+// Both groups were verified byte-identical in SD 4.4.0 and 5.5.2. The `ios`
+// group was not — it renamed size/remToPt to size/remToFloat between them, and
+// 5.x added seven transforms overall. The drift this guards against is real;
+// it has simply not landed on the two groups we build from.
 const PLATFORMS = {
   'ios-swift': {
     stockGroup: 'ios-swift',

--- a/scripts/lib/sd-native.mjs
+++ b/scripts/lib/sd-native.mjs
@@ -340,6 +340,7 @@ export function preprocess(dict) {
 //              size/compose/em size/compose/remToSp size/compose/remToDp
 const PLATFORMS = {
   'ios-swift': {
+    stockGroup: 'ios-swift',
     transforms: [
       'attribute/cti',
       'name/camel',
@@ -354,6 +355,7 @@ const PLATFORMS = {
     format: 'ios-swift/enum.swift',
   },
   'android-kotlin': {
+    stockGroup: 'compose',
     transforms: [
       'attribute/cti',
       'name/camel',
@@ -367,6 +369,85 @@ const PLATFORMS = {
     format: 'compose/object',
   },
 };
+
+// Stock transforms this config deliberately does NOT run. The reason is the
+// point: an entry here is a decision on the record, where an absence from
+// PLATFORMS is indistinguishable from an oversight.
+//
+// Keyed by transform name alone, with no platform qualifier. That is safe only
+// because every name here is platform-prefixed, so no cross-platform collision
+// is expressible. Declining an unprefixed name — a hypothetical shared
+// "size/px" — would widen silently across both platforms and must convert this
+// to a per-platform map.
+const DECLINED_STOCK_TRANSFORMS = {
+  'size/swift/remToCGFloat': 'rem-assuming — replaced by size/unit-aware/swift',
+  'size/compose/remToDp': 'rem-assuming — replaced by size/unit-aware/compose-dp',
+  'size/compose/remToSp': 'rem-assuming — replaced by size/unit-aware/compose-sp',
+  'size/compose/em': 'em is not representable in native output — filtered out',
+};
+
+// Report every transform in a platform's live stock group that this config
+// neither runs nor explicitly declined. Pure: it takes Style Dictionary's
+// hooks.transformGroups and returns formatted warning strings, so the wording
+// is what the tests assert and the caller is a bare loop.
+//
+// Warns, never throws. The dangerous direction is an ADDITION we never learned
+// about, which is usually harmless and occasionally important — throwing would
+// break a build over a change the consumer cannot fix. The fatal direction, a
+// transform we run being removed, already makes Style Dictionary throw on an
+// unknown transform name.
+//
+// Order is never compared: our lists are hand-ordered for our own reasons and
+// do not inherit stock order. Removals are never reported: a declined name
+// disappearing is a non-event.
+export function auditStockGroups(transformGroups) {
+  if (typeof transformGroups !== 'object' || transformGroups === null) {
+    return [
+      "throughline: could not read Style Dictionary's stock transform groups " +
+        '(hooks.transformGroups is not an object), so this adapter cannot check ' +
+        'whether its transform lists are still complete.',
+    ];
+  }
+  const warnings = [];
+  for (const [platform, preset] of Object.entries(PLATFORMS)) {
+    const group = preset.stockGroup;
+    if (!group) {
+      warnings.push(
+        `throughline: PLATFORMS['${platform}'] declares no stockGroup, so its ` +
+          "transform list cannot be checked against Style Dictionary's stock " +
+          'groups. This is a throughline packaging defect — please report it.',
+      );
+      continue;
+    }
+    const stock = transformGroups[group];
+    if (!Array.isArray(stock)) {
+      warnings.push(
+        `throughline: Style Dictionary has no "${group}" transform group, which ` +
+          `PLATFORMS['${platform}'] mirrors. The stock group may have been ` +
+          'renamed or removed. Upgrade @radicool/throughline, or report your ' +
+          'Style Dictionary version.',
+      );
+      continue;
+    }
+    const unaccounted = stock.filter(
+      (name) =>
+        !preset.transforms.includes(name) &&
+        !Object.hasOwn(DECLINED_STOCK_TRANSFORMS, name),
+    );
+    if (unaccounted.length) {
+      const n = unaccounted.length;
+      warnings.push(
+        `throughline: Style Dictionary's "${group}" transform group has ${n} ` +
+          `transform${n === 1 ? '' : 's'} this adapter neither runs nor declined: ` +
+          `${unaccounted.join(', ')}. Native output may be incomplete. Upgrade ` +
+          '@radicool/throughline, or report your Style Dictionary version. ' +
+          `(Maintainer repair: add each to PLATFORMS['${platform}'].transforms, ` +
+          'or to DECLINED_STOCK_TRANSFORMS with a reason.)',
+      );
+    }
+  }
+  return warnings;
+}
 
 // % and em are container- or parent-relative, so there is no build-time native
 // magnitude. Filter on the AUTHORED value, not on $type — a "100%" token may be

--- a/scripts/lib/sd-native.mjs
+++ b/scripts/lib/sd-native.mjs
@@ -704,5 +704,16 @@ export function registerNativeTransforms(StyleDictionary) {
     filter: isQuotable,
     transform: (token) => `"${escapeCommon(stringValue(token)).replace(/\$/g, '\\$')}"`,
   });
+
+  // Last, so every registration side effect has completed before anything is
+  // printed. Fires once per REGISTRATION — typically once per process, not once
+  // per build: the documented usage registers once and then constructs one
+  // StyleDictionary per mode, and the stock groups cannot change between modes.
+  //
+  // The ?. chain is what turns a caller with no hooks into undefined, which
+  // auditStockGroups reports as unreadable rather than silently skipping.
+  for (const warning of auditStockGroups(StyleDictionary?.hooks?.transformGroups)) {
+    console.warn(warning);
+  }
 }
 // @doc-section-end register

--- a/scripts/lib/sd-native.mjs
+++ b/scripts/lib/sd-native.mjs
@@ -417,11 +417,12 @@ export function auditStockGroups(transformGroups) {
   const warnings = [];
   for (const [platform, preset] of Object.entries(PLATFORMS)) {
     const group = preset.stockGroup;
-    if (!group) {
+    if (!group || !Array.isArray(preset.transforms)) {
       warnings.push(
-        `throughline: PLATFORMS['${platform}'] declares no stockGroup, so its ` +
-          "transform list cannot be checked against Style Dictionary's stock " +
-          'groups. This is a throughline packaging defect — please report it.',
+        `throughline: PLATFORMS['${platform}'] is incomplete — it needs both ` +
+          'stockGroup and transforms — so its transform list cannot be checked ' +
+          "against Style Dictionary's stock groups. This is a throughline " +
+          'packaging defect — please report it.',
       );
       continue;
     }

--- a/scripts/lib/sd-native.test.mjs
+++ b/scripts/lib/sd-native.test.mjs
@@ -254,10 +254,12 @@ test('nativeSources names the file when its JSON does not parse', () => {
 test('registerNativeTransforms registers the preprocessor and six transforms', () => {
   const preprocessors = [];
   const transforms = [];
-  registerNativeTransforms({
-    registerPreprocessor: (p) => preprocessors.push(p),
-    registerTransform: (t) => transforms.push(t),
-  });
+  registerNativeTransforms(
+    fakeStyleDictionary({
+      onPreprocessor: (p) => preprocessors.push(p),
+      onTransform: (t) => transforms.push(t),
+    }),
+  );
 
   assert.deepEqual(preprocessors.map((p) => p.name), ['dtcg/resolve-dual-node']);
   assert.deepEqual(transforms.map((t) => t.name).sort(), [
@@ -272,19 +274,16 @@ test('registerNativeTransforms registers the preprocessor and six transforms', (
 });
 
 test('the registered swift transform converts a px dimension 1:1', () => {
-  const transforms = [];
-  registerNativeTransforms({ registerPreprocessor: () => {}, registerTransform: (t) => transforms.push(t) });
-  const swift = transforms.find((t) => t.name === 'size/unit-aware/swift');
+  const swift = collectTransforms().get('size/unit-aware/swift');
   const token = { $type: 'dimension', $value: '14px', original: { $value: '14px' } };
   assert.equal(swift.filter(token), true);
   assert.equal(swift.transform(token), 'CGFloat(14.00)');
 });
 
 test('the registered compose transforms still split sp from dp by the legacy $type gate', () => {
-  const transforms = [];
-  registerNativeTransforms({ registerPreprocessor: () => {}, registerTransform: (t) => transforms.push(t) });
-  const dp = transforms.find((t) => t.name === 'size/unit-aware/compose-dp');
-  const sp = transforms.find((t) => t.name === 'size/unit-aware/compose-sp');
+  const registered = collectTransforms();
+  const dp = registered.get('size/unit-aware/compose-dp');
+  const sp = registered.get('size/unit-aware/compose-sp');
 
   const dimension = { $type: 'dimension', $value: '16px', original: { $value: '16px' } };
   const fontSize = { $type: 'fontSize', $value: '14px', original: { $value: '14px' } };
@@ -299,29 +298,32 @@ test('the registered compose transforms still split sp from dp by the legacy $ty
 });
 
 test('the registered swift transform also handles fontSize, matching stock', () => {
-  const transforms = [];
-  registerNativeTransforms({ registerPreprocessor: () => {}, registerTransform: (t) => transforms.push(t) });
-  const swift = transforms.find((t) => t.name === 'size/unit-aware/swift');
+  const swift = collectTransforms().get('size/unit-aware/swift');
   assert.equal(swift.filter({ $type: 'fontSize', $value: '14px', original: { $value: '14px' } }), true);
 });
 
 test('the registered size transforms skip a value with no native magnitude', () => {
-  const transforms = [];
-  registerNativeTransforms({ registerPreprocessor: () => {}, registerTransform: (t) => transforms.push(t) });
-  const swift = transforms.find((t) => t.name === 'size/unit-aware/swift');
+  const swift = collectTransforms().get('size/unit-aware/swift');
   assert.equal(swift.filter({ $type: 'dimension', $value: '100%', original: { $value: '100%' } }), false);
 });
 
-// Collect the transforms registerNativeTransforms registers, without needing
-// a real Style Dictionary. Mirrors the fake used elsewhere in this file.
+// One fake Style Dictionary for every registerNativeTransforms call in this
+// file. It carries hooks.transformGroups because registration now audits them,
+// and a fake without hooks warns by design.
+function fakeStyleDictionary({ onPreprocessor = () => {}, onTransform = () => {} } = {}) {
+  return {
+    hooks: { transformGroups: REAL_STOCK },
+    registerPreprocessor: onPreprocessor,
+    registerTransform: onTransform,
+  };
+}
+
+// Collect the transforms registerNativeTransforms registers, keyed by name.
 function collectTransforms() {
   const registered = new Map();
-  registerNativeTransforms({
-    registerPreprocessor() {},
-    registerTransform(t) {
-      registered.set(t.name, t);
-    },
-  });
+  registerNativeTransforms(
+    fakeStyleDictionary({ onTransform: (t) => registered.set(t.name, t) }),
+  );
   return registered;
 }
 
@@ -1274,4 +1276,30 @@ test('auditStockGroups reports unreadable transformGroups', () => {
 
 test('auditStockGroups treats an array as a readable object with no groups', () => {
   assert.deepEqual(auditStockGroups([]), [NO_IOS_GROUP, NO_COMPOSE_GROUP]);
+});
+
+// Swap console.warn for the duration of fn and return everything it emitted.
+// Restored in a finally so a throwing fn cannot leak the stub into later tests.
+function captureWarnings(fn) {
+  const original = console.warn;
+  const seen = [];
+  console.warn = (...args) => seen.push(args.join(' '));
+  try {
+    fn();
+  } finally {
+    console.warn = original;
+  }
+  return seen;
+}
+
+test('registerNativeTransforms is silent when the stock groups are accounted for', () => {
+  const seen = captureWarnings(() => registerNativeTransforms(fakeStyleDictionary()));
+  assert.deepEqual(seen, []);
+});
+
+test('registerNativeTransforms warns when it cannot read the stock transform groups', () => {
+  const seen = captureWarnings(() =>
+    registerNativeTransforms({ registerPreprocessor() {}, registerTransform() {} }),
+  );
+  assert.deepEqual(seen, [UNREADABLE]);
 });

--- a/scripts/lib/sd-native.test.mjs
+++ b/scripts/lib/sd-native.test.mjs
@@ -13,6 +13,7 @@ import {
   registerNativeTransforms,
   hasNativeForm,
   EXT_NS,
+  auditStockGroups,
 } from './sd-native.mjs';
 
 test('magnitude treats px as 1:1', () => {
@@ -1155,4 +1156,122 @@ test('a unitless zero is a ratio, not a zero measurement', () => {
   // "0px" is a measurement and is unaffected.
   const zeroPx = { $type: 'dimension', $value: '0px', original: { $value: '0px' } };
   assert.equal(t.get('size/unit-aware/compose-dp').filter(zeroPx), true);
+});
+
+// Style Dictionary's stock transform groups, read from real installs of 4.4.0
+// and 5.5.2 via StyleDictionary.hooks.transformGroups. Both groups are
+// byte-identical across those versions, so one literal covers both; asserting
+// the same array twice would be duplication, not coverage.
+const REAL_STOCK = {
+  'ios-swift': [
+    'attribute/cti',
+    'name/camel',
+    'color/UIColorSwift',
+    'content/swift/literal',
+    'asset/swift/literal',
+    'size/swift/remToCGFloat',
+  ],
+  compose: [
+    'attribute/cti',
+    'name/camel',
+    'color/composeColor',
+    'size/compose/em',
+    'size/compose/remToSp',
+    'size/compose/remToDp',
+  ],
+};
+
+const UNREADABLE =
+  "throughline: could not read Style Dictionary's stock transform groups " +
+  '(hooks.transformGroups is not an object), so this adapter cannot check ' +
+  'whether its transform lists are still complete.';
+
+const NO_COMPOSE_GROUP =
+  'throughline: Style Dictionary has no "compose" transform group, which ' +
+  "PLATFORMS['android-kotlin'] mirrors. The stock group may have been renamed " +
+  'or removed. Upgrade @radicool/throughline, or report your Style Dictionary ' +
+  'version.';
+
+const NO_IOS_GROUP =
+  'throughline: Style Dictionary has no "ios-swift" transform group, which ' +
+  "PLATFORMS['ios-swift'] mirrors. The stock group may have been renamed " +
+  'or removed. Upgrade @radicool/throughline, or report your Style Dictionary ' +
+  'version.';
+
+test('auditStockGroups is silent on the real stock groups', () => {
+  assert.deepEqual(auditStockGroups(REAL_STOCK), []);
+});
+
+test('auditStockGroups reports one stock transform that is neither run nor declined', () => {
+  const groups = { ...REAL_STOCK, compose: [...REAL_STOCK.compose, 'size/compose/foo'] };
+  assert.deepEqual(auditStockGroups(groups), [
+    'throughline: Style Dictionary\'s "compose" transform group has 1 transform ' +
+      'this adapter neither runs nor declined: size/compose/foo. Native output ' +
+      'may be incomplete. Upgrade @radicool/throughline, or report your Style ' +
+      'Dictionary version. (Maintainer repair: add each to ' +
+      "PLATFORMS['android-kotlin'].transforms, or to DECLINED_STOCK_TRANSFORMS " +
+      'with a reason.)',
+  ]);
+});
+
+test('auditStockGroups reports two unaccounted names in ONE message, in stock order', () => {
+  const groups = {
+    ...REAL_STOCK,
+    compose: [...REAL_STOCK.compose, 'size/compose/foo', 'size/compose/bar'],
+  };
+  assert.deepEqual(auditStockGroups(groups), [
+    'throughline: Style Dictionary\'s "compose" transform group has 2 transforms ' +
+      'this adapter neither runs nor declined: size/compose/foo, size/compose/bar. ' +
+      'Native output may be incomplete. Upgrade @radicool/throughline, or report ' +
+      'your Style Dictionary version. (Maintainer repair: add each to ' +
+      "PLATFORMS['android-kotlin'].transforms, or to DECLINED_STOCK_TRANSFORMS " +
+      'with a reason.)',
+  ]);
+});
+
+test('auditStockGroups reports each platform independently', () => {
+  const groups = {
+    'ios-swift': [...REAL_STOCK['ios-swift'], 'size/swift/newThing'],
+    compose: [...REAL_STOCK.compose, 'size/compose/foo'],
+  };
+  const out = auditStockGroups(groups);
+  assert.equal(out.length, 2);
+  assert.ok(out[0].includes('"ios-swift" transform group has 1 transform'));
+  assert.ok(out[0].includes('size/swift/newThing'));
+  assert.ok(out[1].includes('"compose" transform group has 1 transform'));
+  assert.ok(out[1].includes('size/compose/foo'));
+});
+
+test('auditStockGroups is silent on a group holding only declined transforms', () => {
+  const groups = { ...REAL_STOCK, compose: ['size/compose/em', 'size/compose/remToDp'] };
+  assert.deepEqual(auditStockGroups(groups), []);
+});
+
+test('auditStockGroups ignores stock ORDER', () => {
+  const groups = { ...REAL_STOCK, compose: [...REAL_STOCK.compose].reverse() };
+  assert.deepEqual(auditStockGroups(groups), []);
+});
+
+test('auditStockGroups ignores a REMOVED declined transform', () => {
+  const groups = {
+    ...REAL_STOCK,
+    compose: REAL_STOCK.compose.filter((n) => n !== 'size/compose/em'),
+  };
+  assert.deepEqual(auditStockGroups(groups), []);
+});
+
+test('auditStockGroups reports a stock group that is absent entirely', () => {
+  assert.deepEqual(auditStockGroups({ 'ios-swift': REAL_STOCK['ios-swift'] }), [
+    NO_COMPOSE_GROUP,
+  ]);
+});
+
+test('auditStockGroups reports unreadable transformGroups', () => {
+  for (const bad of [undefined, null, 'nope', 42]) {
+    assert.deepEqual(auditStockGroups(bad), [UNREADABLE], `input: ${String(bad)}`);
+  }
+});
+
+test('auditStockGroups treats an array as a readable object with no groups', () => {
+  assert.deepEqual(auditStockGroups([]), [NO_IOS_GROUP, NO_COMPOSE_GROUP]);
 });


### PR DESCRIPTION
Closes #54.

**Stacked on [#69](https://github.com/jrpease/throughline/pull/69)** (`fix/52-unitless-dimension`), because `scripts/lib/sd-native.mjs` generates a CI-gated doc from its whole body and concurrent branches conflict guaranteed. **This PR must be retargeted to `main` before #69 merges** — merging a parent with `--delete-branch` auto-closes a stacked child, and it cannot be reopened once its head has been rebased. That cost PR #65 on 2026-08-24.

## The problem

`sd-native.mjs` states its own design rule: *"Build each platform's transform list from Style Dictionary's STOCK group… A hand-picked list silently drops whatever it forgets."* That rule is how #50 found three real defects. But nothing enforced it — `PLATFORMS` was a hand-written literal, and the stock lists it claimed to mirror existed only as a prose comment stamped `SD 4.4.0`. The four rem-assuming transforms it deliberately declines existed only as an *absence* from an array, indistinguishable from an oversight.

## Both directions of drift are real, measured

Read from real installs via `StyleDictionary.hooks.transformGroups`:

| group | 4.4.0 | 5.5.2 | drift |
|---|---|---|---|
| `ios-swift` | 6 names | 6 names | **none — byte-identical** |
| `compose` | 6 names | 6 names | **none — byte-identical** |
| `ios` | …`size/remToPt` | …`size/remToFloat` | **renamed** |
| transforms registered | 55 | 62 | **+7 added** |

Style Dictionary demonstrably renames names inside a stock group and adds transforms. It just hasn't landed on the two groups we consume.

## The approach

The issue proposed snapshotting the stock lists and asserting live-vs-snapshot. This inverts the comparison instead, and asks the question the design rule actually poses: **is there a stock transform this config neither runs nor explicitly declined?**

That needs no snapshot — so there is nothing to keep fresh, no re-blessing ritual, and no way to confuse "our snapshot is stale" with "Style Dictionary drifted." It also makes the exclusions explicit, which the issue asked for separately.

- `stockGroup` moves *into* each `PLATFORMS` preset rather than a parallel constant, so there is no second map to fall out of sync with.
- `DECLINED_STOCK_TRANSFORMS` records each declined name **with its reason**.
- `auditStockGroups` is pure, takes a plain object, and returns formatted strings.
- `registerNativeTransforms` — which already holds the `StyleDictionary` class — calls it and `console.warn`s.

**It warns and never throws, and never changes an exit code.** A new stock transform is usually harmless; the fatal direction (a transform we run being removed) already makes Style Dictionary throw on an unknown name. The check runs in *your* build because ThroughLine declares no dependency on Style Dictionary — that is the only place the installed version is knowable.

## Nothing that runs changes

`nativePlatform()` returns exactly what it returned before. Verified against real 4.4.0 and 5.5.2: identical transform lists, and `stockGroup` does not leak into the emitted platform config.

## Verification

- **387 tests, 0 failures.** All six CI gates green.
- Against **real** Style Dictionary 4.4.0 and 5.5.2: `auditStockGroups` returns `[]` and registration emits zero warnings.
- **Positive controls** on the real 5.5.2 class: adding a transform to the live `compose` group produces exactly one unaccounted warning; deleting the group produces exactly one group-missing warning.
- The final review ran an adversarial pass trying to build an implementation that passes all twelve new tests while voiding the guarantee — reversing the comparison, dropping the deny-list, iterating the wrong object, and swapping the two `stockGroup` values each die on at least one test.

## Known limits, recorded in the spec rather than solved

Ungrouped transforms are invisible; a stock reorder is not reported; a name that is both run *and* declined is invisible; `REAL_STOCK` in the test file remains a version-stamped literal that will need re-blessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018etbNQyHfuuGWwmd88T8Zm
