### PR TITLE
docs: scope the #55 e2e procedure to the harness that ran it (#73)

### DIFF
--- a/docs/superpowers/notes/2026-08-24-hoist-dual-nodes-e2e.md
+++ b/docs/superpowers/notes/2026-08-24-hoist-dual-nodes-e2e.md
@@ -38,6 +38,48 @@ and was live at the time this task started:
   `android-kotlin`, light/dark, mobile viewport axis,
   `packageName: 'com.zygarden.tokens'` for Kotlin. Unmodified.
 
+## Do not copy this procedure forward (added 2026-08-27, issue #73)
+
+The steps below were correct **for the harness as it existed when this run
+executed**, and stopped being correct about three hours later. Anyone
+reaching for them as a template will get a verification that cannot fail.
+
+The harness has two symlink surfaces. `<harness>/scripts/lib` is a
+directory-level symlink; `<harness>/lib/` is three per-file symlinks
+(`dtcg.mjs`, `native-literal.mjs`, `sd-native.mjs`). Which one matters
+depends on which `build.mjs` is present, and `build.mjs` was rewritten on
+2026-08-24 at 13:46 — the same minute `<harness>/lib/` was created. The
+rewritten script imports `./lib/sd-native.mjs` and never reads
+`scripts/lib`.
+
+| Run | Built at | Import surface | Swapping `scripts/lib` |
+|-----|----------|----------------|------------------------|
+| This one (`#55`) | 10:22 | `scripts/lib` — `lib/` did not exist yet | works |
+| `#60` | 17:59 | `./lib/` | no-op |
+| `#52` and later | — | `./lib/` | no-op |
+
+**This run's verdict stands.** `<harness>/lib/` was created at 13:46, three
+hours and 24 minutes after `out-55/` was built, so a 10:22 build importing
+`./lib/sd-native.mjs` would have failed with `ERR_MODULE_NOT_FOUND`. Both
+builds recorded `EXIT:0`, so the import resolved against the only surface
+that existed — the one the swap retargeted. The empty diff is a true
+negative.
+
+`#60`'s verdict also stands, on separate evidence: alongside its zygarden
+build it ran synthetic fixtures that reach the defect, and those *did* move
+across the swap (`20px` → `20.00.dp`, `1.5` → `1.50.dp`). A no-op swap
+could not have produced that.
+
+**The durable lesson.** For both runs the defect is unreachable in
+zygarden's source, so an empty diff was the predicted result under a sound
+procedure *and* under a broken one. The two hypotheses were observationally
+identical, and no amount of re-running the same comparison could separate
+them — only a baseline assertion can. Before trusting a diff, prove the
+baseline is what you think it is: check that the "before" build actually
+exhibits the pre-fix behaviour. `#52`'s run did this and caught the stale
+procedure before it produced a false result; see
+`2026-08-26-unitless-dimension-e2e.md`.
+
 ## Procedure
 
 1. `scripts/lib` symlinked to this branch's live tree

--- a/docs/superpowers/notes/2026-08-27-stacked-native-prs-handoff.md
+++ b/docs/superpowers/notes/2026-08-27-stacked-native-prs-handoff.md
@@ -1,31 +1,40 @@
-# Two stacked native PRs — handoff
+# Native stack landed, and the e2e evidence audit — handoff
 
 **Date:** 2026-08-27
 **Supersedes:** `2026-08-24-native-backlog-handoff.md`
 
-## Read this first — there is an ordering constraint with a known cost
+## The stacked landing — done, and the trap that is not in the old instructions
 
-Two PRs are open and **stacked**:
+Both PRs landed on 2026-08-27. `main` is at `a8123fe`.
 
-| PR | issue | branch | base |
-|---|---|---|---|
-| [#69](https://github.com/jrpease/throughline/pull/69) | #52 unitless ratios | `fix/52-unitless-dimension` | `main` |
-| [#74](https://github.com/jrpease/throughline/pull/74) | #54 stock transform accounting | `feat/54-stock-transform-accounting` | **`fix/52-unitless-dimension`** |
+| PR | issue | squash commit |
+|---|---|---|
+| [#69](https://github.com/jrpease/throughline/pull/69) | #52 unitless ratios | `509845a` |
+| [#74](https://github.com/jrpease/throughline/pull/74) | #54 stock transform accounting | `a8123fe` |
 
-**#74 must be retargeted to `main` BEFORE #69 merges:**
+The retarget-before-merge ordering worked as written — `gh pr edit 74 --base main`,
+then `gh pr merge 69` **without** `--delete-branch`. #74 stayed open. That part of
+the constraint is settled; it exists because merging a parent with
+`--delete-branch` auto-closes the stacked child, which cannot be reopened once its
+head has been rebased. That cost PR #65 on 2026-08-24.
+
+**What the instructions did not say, and nearly cost a bad merge:** the moment you
+retarget the child while the parent is still open, GitHub reports it
+`MERGEABLE / CLEAN` — with **26 commits**, its own 10 plus the parent's 16.
+Nothing in that status reveals the parent is riding along, and merging there
+would have squashed both PRs into one commit under the child's title. After the
+parent squash-merges, the child does *not* shrink on its own, because the squash
+orphaned its copies of the parent's commits. Rebase explicitly:
 
 ```
-gh pr edit 74 --base main
-gh pr merge 69            # WITHOUT --delete-branch
-git push origin --delete fix/52-unitless-dimension   # by hand, after
+git rebase --onto origin/main <parent-tip> <child-branch>
+git push --force-with-lease
 ```
 
-Merging the parent with `--delete-branch` auto-closes the stacked child, and
-once the child's head has been rebased it **cannot be reopened** — GitHub
-refuses even after the base branch is restored. That cost PR #65 on 2026-08-24
-and its content had to be reopened as #66.
+#74 went 26 → 10 commits and 8 files this way, no conflicts. **Verify the commit
+count after retargeting, not just the mergeable flag.**
 
-Both are stacked rather than parallel because `scripts/lib/sd-native.mjs`
+Both were stacked rather than parallel because `scripts/lib/sd-native.mjs`
 generates `references/native-adapter-config.md` from its whole body, so two
 branches off `main` that both touch it conflict guaranteed.
 
@@ -66,18 +75,27 @@ repo, which declares zero dependencies deliberately.
 
 ## What is unfinished
 
-**Nothing has been released since 0.15.0.** Eight items now sit unreleased:
-#34, #50, #53, #55, #51, #60, #52, #54. A version cut was deferred once already
-on 2026-08-26.
+**Nothing has been released since 0.15.0.** Ten CHANGELOG entries across eight
+issues now sit unreleased: #34, #50, #53, #55, #51, #60, #52, #54. A version cut
+has been deferred twice — 2026-08-26 and again 2026-08-27.
+
+**PR [#76](https://github.com/jrpease/throughline/pull/76) is open** — a
+documentation-only change scoping the #55 e2e procedure to the harness that ran
+it. One commit, green, `MERGEABLE/CLEAN` against `main`.
 
 ## Open questions for the next session
 
-- **#73 — was #55's and #60's e2e evidence vacuous?** Filed 2026-08-26. The
-  #52 cycle found that the documented symlink swap targets `scripts/lib`, while
-  `build.mjs` imports a *different* top-level `lib/` of per-file symlinks —
-  so following the note literally builds "main" from HEAD's code and produces a
-  false byte-identical pass. Whether the earlier runs hit that is unverified.
-  Worth answering before leaning on that harness again.
+- **#73 — was #55's and #60's e2e evidence vacuous?** **Answered and closed
+  2026-08-27: no.** Both runs were sound, neither for the reason the issue
+  assumed. #55 ran at 10:22, before the top-level `lib/` directory existed
+  (born 13:46), so a build importing `./lib/` would have thrown
+  `ERR_MODULE_NOT_FOUND`; both builds recorded `EXIT:0`, so the swap hit the
+  only surface present. #60 ran synthetic fixtures reaching the defect, and
+  those moved across the swap (`20px` → `20.00.dp`) — which a no-op cannot do.
+  What was stale was the *procedure text*, frozen after the harness was
+  restructured and inherited four days later. `2026-08-24-hoist-dual-nodes-e2e.md`
+  now carries a warning ahead of its steps (PR #76), and the general practice is
+  [#77](https://github.com/jrpease/throughline/issues/77).
 - **Which backlog slot is next.** #36 (validator silently drops a token to a key
   collision) is the last of the "instruments" items. The consumption-layer epic
   (#39–#44) has been parked pending a clean native base, which it now has. The


### PR DESCRIPTION
Answers and closes the question in #73. No code changes — one annotation block in an existing e2e note.

## The question

#73 alleged that #55's and #60's e2e evidence was vacuous: their procedure swaps `<harness>/scripts/lib`, but `build.mjs` imports `./lib/sd-native.mjs` and never reads `scripts/lib`. If that held, the "before" build was silently the "after" build, and the empty diff both notes record is exactly what a broken comparison produces.

## The answer: both runs were sound

**#55 — structural impossibility.** `out-55/` was built 2026-08-24 at 10:22; the top-level `lib/` directory was *born* at 13:46, 3h24m later. A 10:22 build importing `./lib/sd-native.mjs` would have thrown `ERR_MODULE_NOT_FOUND`. Both builds recorded `EXIT:0`, so the import resolved against the only surface that existed — the one the swap retargeted.

**#60 — a positive control already in the harness.** `out-60-*` ran at 17:59:43, when `build.mjs` did import `./lib/`. But at 17:59:58 and 18:03 the same session built synthetic fixtures that reach the defect, and those moved across the swap: `20px` → `20.00.dp`, `1.5` → `1.50.dp`. A no-op cannot produce that. The zygarden pair is byte-identical, as predicted — it was never the load-bearing evidence.

## What was actually wrong

The prose, not the runs. The #55 note's procedure was correct when executed and became a no-op at 13:46, when `build.mjs` was rewritten and `lib/` created in the same minute. The note was last edited at 15:23 — after the restructure — freezing steps that no longer worked, which #52's plan inherited four days later and which nearly produced a false PASS there.

Confirmed by replaying the disputed swap against a commit pair whose output provably differs (#52's fix), on a replica harness so the original survives as evidence:

| Same commit pair, same harness | Result |
|---|---|
| `scripts/lib` swap (the inherited text) | empty diff; "pre-fix" build still emitted `= 2` |
| `lib/*` swap (what `build.mjs` reads) | 5 changed lines per file — exactly #52 §7's prediction |

## What this changes

A 42-line block placed immediately before `## Procedure`, so a reader reaching for the steps hits the warning first: a per-run table of which import surface was live, why both verdicts stand, and the lesson.

Neither note's verdict is amended — both were right. What is amended is the implication that their steps are reusable.

## The durable lesson

For both runs the defect is unreachable in zygarden's source, so an empty diff was the predicted result under a sound procedure **and** under a broken one. Observationally identical; no amount of careful re-running separates them. A check whose passing result is "nothing happened" carries no evidence that the check ran. What settles it is a control that should produce a *presence*.

## Verification

387/387 tests, all six CI gates green. The change is documentation only and touches no generated output.

Refs #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018etbNQyHfuuGWwmd88T8Zm