### PR TITLE
feat: em letter spacing reaches Compose as a real TextUnit (#64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,28 @@ Read this before upgrading; the full technical detail for each is below.
   and `compose` groups are byte-identical.
 
 ### Fixed
+- **An `em` letter spacing now reaches Compose instead of being dropped.**
+  All 13 `typography.textStyle.*.letterSpacing` tokens on a real source resolve
+  to `em`, and `nativeFilter` removed them from both platforms — they were the
+  bulk of the 19 source tokens `tokens:validate-output` reported as having no
+  emitted symbol. Compose has a real `.em` `TextUnit`, so unlike `%` this is a
+  filter gap rather than a value with no native form. The classifier's unit gate
+  now admits `em` alongside `px` and `rem`, so the role is stamped;
+  `size/unit-aware/compose-em` emits it; and `nativeFilter` keeps it only where
+  the platform is Compose *and* the token carries the text role, so an `em`
+  *spacing* still drops. Emitted parenthesised — `(-0.03).em` — because
+  `-0.03.em` parses as `-(0.03.em)`, which `kotlinc` 2.4.10 rejects with
+  "unresolved reference 'unaryMinus'"; the parenthesised form compiles either
+  way, and a tight letter spacing is negative, so this is the common case rather
+  than an edge one. **iOS is excluded deliberately, not pending:** letter spacing
+  there is an `NSAttributedString` kern in points, which needs the font size a
+  token does not carry, so no constant Swift could emit would be right at every
+  font size. Measured: Kotlin goes from 195 to 208 declarations and compiles to
+  bytecode; Swift output is byte-identical. The four
+  `typography.letterSpacing.{tight,normal,wide,widest}` primitives still do not
+  emit — their leaf names state no role, the same documented limit as a bare
+  scale primitive — leaving Android with 6 unmatched source tokens, of which a
+  `linear-gradient()` and a `100%` have no native form at all.
 - **The native literal grammar no longer vouches for output that does not
   compile.** `invalid-literal` accepted `.5` and `0100`, so
   `tokens:validate-output` exited 0 on values neither platform can build. The

--- a/references/native-adapter-config.md
+++ b/references/native-adapter-config.md
@@ -309,7 +309,11 @@ export const EXT_NS = 'com.radicool.throughline';
 // no longer the only thing standing between a ratio and 1.50.sp. It stays
 // because the stamp is also the override's carrier, and stamping a ratio as
 // text would still be a claim the source never made.
-const ABSOLUTE_UNIT = /^-?(?:\d+(?:\.\d+)?|\.\d+)(?:px|rem)$/;
+// em joins px and rem since #64: Compose's TextUnit has a real .em, so an
+// em-valued letterSpacing is a text-role dimension like any other. It is still
+// a unit — the gate's job is to exclude the UNITLESS value, whose role the
+// source never stated.
+const TEXT_ROLE_UNIT = /^-?(?:\d+(?:\.\d+)?|\.\d+)(?:px|rem|em)$/;
 
 // Runs AFTER resolveInPlace and BEFORE hoistDualNodes. Both halves matter.
 //
@@ -330,7 +334,7 @@ function classifyTextUnits(node) {
       TEXT_UNIT_NAMES.has(key) &&
       '$value' in val &&
       val.$type === 'dimension' &&
-      ABSOLUTE_UNIT.test(String(val.$value).trim())
+      TEXT_ROLE_UNIT.test(String(val.$value).trim())
     ) {
       val.$extensions ??= {};
       val.$extensions[EXT_NS] ??= {};
@@ -400,11 +404,15 @@ What remains:
   only to a human — no nominal or structural signal marks it — so it is not
   stamped. The semantic tokens that reference it are, and those are what a
   consumer should reach for.
-- **An `em`-valued `letterSpacing` is dropped from native output entirely**
-  rather than emitted as Compose's `.em` TextUnit. A filter gap, not a
-  `dp`/`sp` gap.
+- **An `em` letter spacing reaches Compose but not Swift.** `size/unit-aware/compose-em`
+  emits it as a real `.em` TextUnit, parenthesised — `(-0.03).em` — because
+  `-0.03.em` parses as `-(0.03.em)` and needs an `unaryMinus` operator, while
+  the parenthesised form compiles regardless. iOS is excluded deliberately, not
+  pending: letter spacing there is an `NSAttributedString` kern in points,
+  which needs the font size the token does not carry, so no constant Swift
+  could emit would be right at every font size.
 
-Both are Android-only. `size/unit-aware/swift` filters
+The first is Android-only. `size/unit-aware/swift` filters
 `dimension || fontSize` and emits `CGFloat`, which carries no unit to be wrong
 about; iOS handles Dynamic Type at the use site via `UIFontMetrics`.
 `tokens:validate-output` passes in both cases: it checks magnitude, not unit.
@@ -489,6 +497,7 @@ const PLATFORMS = {
       'color/composeColor',
       'size/unit-aware/compose-dp',
       'size/unit-aware/compose-sp',
+      'size/unit-aware/compose-em',
       'value/kotlin-string-literal',
     ],
     destination: 'Tokens.kt',
@@ -509,7 +518,7 @@ const DECLINED_STOCK_TRANSFORMS = {
   'size/swift/remToCGFloat': 'rem-assuming — replaced by size/unit-aware/swift',
   'size/compose/remToDp': 'rem-assuming — replaced by size/unit-aware/compose-dp',
   'size/compose/remToSp': 'rem-assuming — replaced by size/unit-aware/compose-sp',
-  'size/compose/em': 'em is not representable in native output — filtered out',
+  'size/compose/em': 'rem-assuming — replaced by size/unit-aware/compose-em',
 };
 
 // Report every transform in a platform's live stock group that this config
@@ -581,8 +590,24 @@ export function auditStockGroups(transformGroups) {
 // typed string rather than dimension.
 const WEB_ONLY_UNIT = /^-?[\d.]+(%|em)$/;
 
-export function nativeFilter(token) {
-  return !WEB_ONLY_UNIT.test(String(token.original?.$value ?? token.$value).trim());
+// The em magnitude, which magnitude() deliberately does not return: em has no
+// build-time px equivalent, so it is not a native LENGTH. It is a TextUnit.
+const EM_VALUE = /^(-?(?:\d+(?:\.\d+)?|\.\d+))em$/;
+
+export function nativeFilter(token, platform) {
+  const v = String(token.original?.$value ?? token.$value).trim();
+  if (!WEB_ONLY_UNIT.test(v)) return true;
+  // One exception, and it is narrow. Compose has a real .em TextUnit, so an
+  // em letterSpacing DOES have a native form there — unlike %, which has none
+  // anywhere. It survives only where all three hold: the platform is Compose,
+  // the value is em, and the token carries the text role. An em SPACING has no
+  // TextUnit meaning and still drops.
+  //
+  // iOS is deliberately excluded rather than pending. Letter spacing there is
+  // an NSAttributedString kern in points, which needs the font size the token
+  // does not carry, so there is no value Swift could emit that would not be
+  // wrong at some font size.
+  return platform === 'android-kotlin' && EM_VALUE.test(v) && isTextUnit(token);
 }
 
 // A CSS function has no native form. Quoting it would produce a string that
@@ -655,7 +680,7 @@ export function nativePlatform({ platform, buildPath, className = 'Tokens', pack
         destination: preset.destination,
         format: preset.format,
         options: fileOptions,
-        filter: (token) => nativeFilter(token) && hasNativeForm(token, platform),
+        filter: (token) => nativeFilter(token, platform) && hasNativeForm(token, platform),
       },
     ],
   };
@@ -746,6 +771,12 @@ const RATIO = /^-?(?:\d+(?:\.\d+)?|\.\d+)$/;
 const isRatio = (token) => RATIO.test(String(token.original?.$value ?? token.$value).trim());
 // The role preprocess stamped. $type cannot carry it — see classifyTextUnits.
 const isTextUnit = (token) => token.$extensions?.[EXT_NS]?.nativeUnit === 'text';
+const emMagnitude = (token) => {
+  const m = String(token.original?.$value ?? token.$value)
+    .trim()
+    .match(EM_VALUE);
+  return m ? Number(m[1]) : null;
+};
 
 // Quote string-valued tokens no stock transform covers.
 //
@@ -823,6 +854,23 @@ export function registerNativeTransforms(StyleDictionary) {
     transitive: true,
     filter: (token) => (isTextUnit(token) || isFontSize(token)) && hasMagnitude(token) && !isRatio(token),
     transform: (token) => `${authored(token).toFixed(2)}.sp`,
+  });
+
+  // em is a THIRD text unit, not a variant of sp. Compose's .em is relative to
+  // the font size at the use site, which is what an em letterSpacing means, so
+  // it needs neither a magnitude nor a conversion. dp and sp both decline these
+  // already — magnitude() returns null for em — so nothing contends.
+  //
+  // The parentheses are load-bearing. `-0.03.em` parses as `-(0.03.em)`, which
+  // kotlinc 2.4.10 rejects with "unresolved reference 'unaryMinus'" unless
+  // TextUnit defines that operator. `(-0.03).em` compiles either way, and
+  // negatives are the common case: a tight letterSpacing is negative.
+  StyleDictionary.registerTransform({
+    name: 'size/unit-aware/compose-em',
+    type: 'value',
+    transitive: true,
+    filter: (token) => (isTextUnit(token) || isFontSize(token)) && emMagnitude(token) !== null,
+    transform: (token) => `(${emMagnitude(token).toFixed(2)}).em`,
   });
 
   // Two transforms rather than one platform-sniffing transform, because the

--- a/scripts/build-native-adapter-config.mjs
+++ b/scripts/build-native-adapter-config.mjs
@@ -127,11 +127,15 @@ What remains:
   only to a human — no nominal or structural signal marks it — so it is not
   stamped. The semantic tokens that reference it are, and those are what a
   consumer should reach for.
-- **An \`em\`-valued \`letterSpacing\` is dropped from native output entirely**
-  rather than emitted as Compose's \`.em\` TextUnit. A filter gap, not a
-  \`dp\`/\`sp\` gap.
+- **An \`em\` letter spacing reaches Compose but not Swift.** \`size/unit-aware/compose-em\`
+  emits it as a real \`.em\` TextUnit, parenthesised — \`(-0.03).em\` — because
+  \`-0.03.em\` parses as \`-(0.03.em)\` and needs an \`unaryMinus\` operator, while
+  the parenthesised form compiles regardless. iOS is excluded deliberately, not
+  pending: letter spacing there is an \`NSAttributedString\` kern in points,
+  which needs the font size the token does not carry, so no constant Swift
+  could emit would be right at every font size.
 
-Both are Android-only. \`size/unit-aware/swift\` filters
+The first is Android-only. \`size/unit-aware/swift\` filters
 \`dimension || fontSize\` and emits \`CGFloat\`, which carries no unit to be wrong
 about; iOS handles Dynamic Type at the use site via \`UIFontMetrics\`.
 \`tokens:validate-output\` passes in both cases: it checks magnitude, not unit.

--- a/scripts/lib/native-literal.mjs
+++ b/scripts/lib/native-literal.mjs
@@ -121,6 +121,37 @@ export function parseLiteral(value, grammar = {}) {
     if (i >= s.length) return false;
     if (s[i] === '"') return string();
 
+    // A parenthesised NUMBER, optionally with a unit. Compose letter spacing
+    // needs `(-0.03).em`, because `-0.03.em` parses as `-(0.03.em)` and
+    // kotlinc rejects it with "unresolved reference 'unaryMinus'" unless
+    // TextUnit defines that operator. The parenthesised form compiles either
+    // way, so it is what the transform emits.
+    //
+    // Deliberately not expression support: only a single number may sit inside
+    // the parens. Accepting `(1 + 2)` would make this gate vouch for
+    // arithmetic it cannot evaluate, which is the failure class the module
+    // exists to prevent.
+    if (s[i] === '(') {
+      const save = i;
+      i += 1;
+      ws();
+      const inner = s.slice(i).match(numberRe);
+      if (!inner) {
+        i = save;
+        return false;
+      }
+      i += inner[0].length;
+      ws();
+      if (s[i] !== ')') {
+        i = save;
+        return false;
+      }
+      i += 1;
+      if (take(units.map((u) => `.${u}`))) return true;
+      take(suffixes);
+      return true;
+    }
+
     const rest = s.slice(i);
     const bool = rest.match(/^(?:true|false)(?![A-Za-z0-9_])/);
     if (bool) {

--- a/scripts/lib/native-literal.test.mjs
+++ b/scripts/lib/native-literal.test.mjs
@@ -130,3 +130,26 @@ test('#70 does not narrow what both platforms already accepted', () => {
   assert.ok(isValidLiteral('0xffffffff', KOTLIN), 'Color() argument');
   assert.ok(isValidLiteral('16.00.dp', KOTLIN), 'unit suffix still parses');
 });
+
+// #64. Compose letter spacing emits `(-0.03).em`: `-0.03.em` parses as
+// `-(0.03.em)`, which kotlinc 2.4.10 rejects with "unresolved reference
+// 'unaryMinus'". The parenthesised form compiles whether or not TextUnit
+// defines that operator, so the grammar has to accept it.
+test('accepts a parenthesised number with a unit, as Compose em needs', () => {
+  assert.ok(isValidLiteral('(-0.03).em', KOTLIN));
+  assert.ok(isValidLiteral('(0.05).em', KOTLIN));
+  assert.ok(isValidLiteral('(0).em', KOTLIN));
+  assert.ok(isValidLiteral('(-0.03)', KOTLIN), 'parens without a unit');
+  assert.ok(isValidLiteral('(-0.03)', SWIFT), 'Swift parenthesises too');
+});
+
+// Parens wrap a NUMBER, not an expression. Widening to real expressions would
+// make the gate vouch for arithmetic it cannot evaluate.
+test('parenthesised support does not become expression support', () => {
+  assert.equal(isValidLiteral('(1 + 2).em', KOTLIN), false);
+  assert.equal(isValidLiteral('(foo).em', KOTLIN), false);
+  assert.equal(isValidLiteral('()', KOTLIN), false);
+  assert.equal(isValidLiteral('(-0.03', KOTLIN), false, 'unclosed');
+  assert.equal(isValidLiteral('(.5).em', KOTLIN), true, 'Kotlin allows .5');
+  assert.equal(isValidLiteral('(.5)', SWIFT), false, 'Swift still rejects .5');
+});

--- a/scripts/lib/sd-native.mjs
+++ b/scripts/lib/sd-native.mjs
@@ -240,7 +240,11 @@ export const EXT_NS = 'com.radicool.throughline';
 // no longer the only thing standing between a ratio and 1.50.sp. It stays
 // because the stamp is also the override's carrier, and stamping a ratio as
 // text would still be a claim the source never made.
-const ABSOLUTE_UNIT = /^-?(?:\d+(?:\.\d+)?|\.\d+)(?:px|rem)$/;
+// em joins px and rem since #64: Compose's TextUnit has a real .em, so an
+// em-valued letterSpacing is a text-role dimension like any other. It is still
+// a unit — the gate's job is to exclude the UNITLESS value, whose role the
+// source never stated.
+const TEXT_ROLE_UNIT = /^-?(?:\d+(?:\.\d+)?|\.\d+)(?:px|rem|em)$/;
 
 // Runs AFTER resolveInPlace and BEFORE hoistDualNodes. Both halves matter.
 //
@@ -261,7 +265,7 @@ function classifyTextUnits(node) {
       TEXT_UNIT_NAMES.has(key) &&
       '$value' in val &&
       val.$type === 'dimension' &&
-      ABSOLUTE_UNIT.test(String(val.$value).trim())
+      TEXT_ROLE_UNIT.test(String(val.$value).trim())
     ) {
       val.$extensions ??= {};
       val.$extensions[EXT_NS] ??= {};
@@ -369,6 +373,7 @@ const PLATFORMS = {
       'color/composeColor',
       'size/unit-aware/compose-dp',
       'size/unit-aware/compose-sp',
+      'size/unit-aware/compose-em',
       'value/kotlin-string-literal',
     ],
     destination: 'Tokens.kt',
@@ -389,7 +394,7 @@ const DECLINED_STOCK_TRANSFORMS = {
   'size/swift/remToCGFloat': 'rem-assuming — replaced by size/unit-aware/swift',
   'size/compose/remToDp': 'rem-assuming — replaced by size/unit-aware/compose-dp',
   'size/compose/remToSp': 'rem-assuming — replaced by size/unit-aware/compose-sp',
-  'size/compose/em': 'em is not representable in native output — filtered out',
+  'size/compose/em': 'rem-assuming — replaced by size/unit-aware/compose-em',
 };
 
 // Report every transform in a platform's live stock group that this config
@@ -461,8 +466,24 @@ export function auditStockGroups(transformGroups) {
 // typed string rather than dimension.
 const WEB_ONLY_UNIT = /^-?[\d.]+(%|em)$/;
 
-export function nativeFilter(token) {
-  return !WEB_ONLY_UNIT.test(String(token.original?.$value ?? token.$value).trim());
+// The em magnitude, which magnitude() deliberately does not return: em has no
+// build-time px equivalent, so it is not a native LENGTH. It is a TextUnit.
+const EM_VALUE = /^(-?(?:\d+(?:\.\d+)?|\.\d+))em$/;
+
+export function nativeFilter(token, platform) {
+  const v = String(token.original?.$value ?? token.$value).trim();
+  if (!WEB_ONLY_UNIT.test(v)) return true;
+  // One exception, and it is narrow. Compose has a real .em TextUnit, so an
+  // em letterSpacing DOES have a native form there — unlike %, which has none
+  // anywhere. It survives only where all three hold: the platform is Compose,
+  // the value is em, and the token carries the text role. An em SPACING has no
+  // TextUnit meaning and still drops.
+  //
+  // iOS is deliberately excluded rather than pending. Letter spacing there is
+  // an NSAttributedString kern in points, which needs the font size the token
+  // does not carry, so there is no value Swift could emit that would not be
+  // wrong at some font size.
+  return platform === 'android-kotlin' && EM_VALUE.test(v) && isTextUnit(token);
 }
 
 // A CSS function has no native form. Quoting it would produce a string that
@@ -535,7 +556,7 @@ export function nativePlatform({ platform, buildPath, className = 'Tokens', pack
         destination: preset.destination,
         format: preset.format,
         options: fileOptions,
-        filter: (token) => nativeFilter(token) && hasNativeForm(token, platform),
+        filter: (token) => nativeFilter(token, platform) && hasNativeForm(token, platform),
       },
     ],
   };
@@ -613,6 +634,12 @@ const RATIO = /^-?(?:\d+(?:\.\d+)?|\.\d+)$/;
 const isRatio = (token) => RATIO.test(String(token.original?.$value ?? token.$value).trim());
 // The role preprocess stamped. $type cannot carry it — see classifyTextUnits.
 const isTextUnit = (token) => token.$extensions?.[EXT_NS]?.nativeUnit === 'text';
+const emMagnitude = (token) => {
+  const m = String(token.original?.$value ?? token.$value)
+    .trim()
+    .match(EM_VALUE);
+  return m ? Number(m[1]) : null;
+};
 
 // Quote string-valued tokens no stock transform covers.
 //
@@ -690,6 +717,23 @@ export function registerNativeTransforms(StyleDictionary) {
     transitive: true,
     filter: (token) => (isTextUnit(token) || isFontSize(token)) && hasMagnitude(token) && !isRatio(token),
     transform: (token) => `${authored(token).toFixed(2)}.sp`,
+  });
+
+  // em is a THIRD text unit, not a variant of sp. Compose's .em is relative to
+  // the font size at the use site, which is what an em letterSpacing means, so
+  // it needs neither a magnitude nor a conversion. dp and sp both decline these
+  // already — magnitude() returns null for em — so nothing contends.
+  //
+  // The parentheses are load-bearing. `-0.03.em` parses as `-(0.03.em)`, which
+  // kotlinc 2.4.10 rejects with "unresolved reference 'unaryMinus'" unless
+  // TextUnit defines that operator. `(-0.03).em` compiles either way, and
+  // negatives are the common case: a tight letterSpacing is negative.
+  StyleDictionary.registerTransform({
+    name: 'size/unit-aware/compose-em',
+    type: 'value',
+    transitive: true,
+    filter: (token) => (isTextUnit(token) || isFontSize(token)) && emMagnitude(token) !== null,
+    transform: (token) => `(${emMagnitude(token).toFixed(2)}).em`,
   });
 
   // Two transforms rather than one platform-sniffing transform, because the

--- a/scripts/lib/sd-native.test.mjs
+++ b/scripts/lib/sd-native.test.mjs
@@ -251,7 +251,7 @@ test('nativeSources names the file when its JSON does not parse', () => {
   });
 });
 
-test('registerNativeTransforms registers the preprocessor and six transforms', () => {
+test('registerNativeTransforms registers the preprocessor and seven transforms', () => {
   const preprocessors = [];
   const transforms = [];
   registerNativeTransforms(
@@ -264,6 +264,7 @@ test('registerNativeTransforms registers the preprocessor and six transforms', (
   assert.deepEqual(preprocessors.map((p) => p.name), ['dtcg/resolve-dual-node']);
   assert.deepEqual(transforms.map((t) => t.name).sort(), [
     'size/unit-aware/compose-dp',
+    'size/unit-aware/compose-em',
     'size/unit-aware/compose-sp',
     'size/unit-aware/swift',
     'value/color-mix-to-hex8',
@@ -935,14 +936,16 @@ test('preprocess does not stamp a unitless ratio named lineHeight', () => {
   assert.equal(roleOf(out.t.lineHeight), undefined);
 });
 
-test('preprocess does not stamp an em or percentage value', () => {
+// #64 split these two apart. em stamps now — Compose has a real .em TextUnit,
+// so the role is meaningful there. % does not, and has no native form anywhere.
+test('preprocess stamps an em value but never a percentage', () => {
   const out = preprocess({
     t: {
       letterSpacing: { $value: '-0.03em', $type: 'dimension' },
       lineHeight: { $value: '150%', $type: 'dimension' },
     },
   });
-  assert.equal(roleOf(out.t.letterSpacing), undefined);
+  assert.equal(roleOf(out.t.letterSpacing), 'text');
   assert.equal(roleOf(out.t.lineHeight), undefined);
 });
 
@@ -1302,4 +1305,99 @@ test('registerNativeTransforms warns when it cannot read the stock transform gro
     registerNativeTransforms({ registerPreprocessor() {}, registerTransform() {} }),
   );
   assert.deepEqual(seen, [UNREADABLE]);
+});
+
+// #64. An em-valued letterSpacing has a real Compose form — TextUnit's .em —
+// so unlike %, it is not "no native form". iOS is different: letter spacing
+// there is an NSAttributedString kern in points, which needs the font size a
+// token does not carry, so Swift keeps dropping these. The asymmetry is the
+// decision, not an oversight.
+const emSpacing = () => ({
+  $type: 'dimension',
+  $value: '-0.03em',
+  original: { $value: '-0.03em' },
+  $extensions: { [EXT_NS]: { nativeUnit: 'text' } },
+});
+
+// The role comes from the LEAF name, so this reaches the 13
+// typography.textStyle.*.letterSpacing tokens — which is where a consumer
+// should reach anyway. It does not reach the four
+// typography.letterSpacing.{tight,normal,wide,widest} primitives, whose leaf
+// names are tight/normal/wide/widest and which therefore state no role. That
+// is the same documented limit as a bare scale primitive (#63), not a new one.
+test('classifyTextUnits stamps an em letterSpacing, not only px and rem', () => {
+  const out = preprocess({
+    typography: {
+      letterSpacing: { tight: { $type: 'dimension', $value: '-0.03em' } },
+      textStyle: {
+        h1: { letterSpacing: { $type: 'dimension', $value: '{typography.letterSpacing.tight}' } },
+        h2: { letterSpacing: { $type: 'dimension', $value: '0.05em' } },
+      },
+    },
+  });
+  assert.equal(roleOf(out.typography.textStyle.h1.letterSpacing), 'text', 'resolved alias');
+  assert.equal(roleOf(out.typography.textStyle.h2.letterSpacing), 'text', 'authored directly');
+  assert.equal(roleOf(out.typography.letterSpacing.tight), undefined, 'primitive states no role');
+});
+
+test('nativeFilter keeps a text-role em on Compose and drops it on Swift', () => {
+  assert.equal(nativeFilter(emSpacing(), 'android-kotlin'), true);
+  assert.equal(nativeFilter(emSpacing(), 'ios-swift'), false);
+});
+
+test('nativeFilter still drops an em that carries no text role', () => {
+  const spacing = { $type: 'dimension', $value: '0.5em', original: { $value: '0.5em' } };
+  assert.equal(nativeFilter(spacing, 'android-kotlin'), false, 'em spacing has no TextUnit form');
+  assert.equal(nativeFilter(spacing, 'ios-swift'), false);
+});
+
+test('nativeFilter drops % on every platform, and defaults to dropping em', () => {
+  const pct = { $type: 'dimension', $value: '100%', original: { $value: '100%' } };
+  assert.equal(nativeFilter(pct, 'android-kotlin'), false);
+  assert.equal(nativeFilter(pct, 'ios-swift'), false);
+  assert.equal(nativeFilter(emSpacing()), false, 'no platform named — drop, as before');
+});
+
+// kotlinc 2.4.10: `-0.03.em` parses as `-(0.03.em)` and fails with
+// "unresolved reference 'unaryMinus'". `(-0.03).em` compiles whether or not
+// TextUnit defines that operator, so the parens are load-bearing.
+test('the compose em transform emits a parenthesised TextUnit', () => {
+  const t = collectTransforms().get('size/unit-aware/compose-em');
+  assert.ok(t, 'transform must be registered');
+  assert.equal(t.filter(emSpacing()), true);
+  assert.equal(t.transform(emSpacing()), '(-0.03).em');
+
+  const wide = { ...emSpacing(), $value: '0.05em', original: { $value: '0.05em' } };
+  assert.equal(t.transform(wide), '(0.05).em');
+});
+
+test('the em transform declines everything the dp and sp transforms claim', () => {
+  const t = collectTransforms().get('size/unit-aware/compose-em');
+  const px = { $type: 'dimension', $value: '16px', original: { $value: '16px' } };
+  const textPx = { ...px, $extensions: { [EXT_NS]: { nativeUnit: 'text' } } };
+  const ratio = { $type: 'dimension', $value: '1.5', original: { $value: '1.5' } };
+  assert.equal(t.filter(px), false);
+  assert.equal(t.filter(textPx), false);
+  assert.equal(t.filter(ratio), false);
+});
+
+test('dp and sp still decline an em value, so nothing contends for it', () => {
+  const registered = collectTransforms();
+  assert.equal(registered.get('size/unit-aware/compose-dp').filter(emSpacing()), false);
+  assert.equal(registered.get('size/unit-aware/compose-sp').filter(emSpacing()), false);
+  assert.equal(registered.get('size/unit-aware/swift').filter(emSpacing()), false);
+});
+
+test('the Compose preset runs the em transform', () => {
+  const p = nativePlatform({
+    platform: 'android-kotlin',
+    buildPath: 'o/',
+    packageName: 'com.example',
+  });
+  assert.ok(p.transforms.includes('size/unit-aware/compose-em'));
+});
+
+test('the emitted em value is a valid Kotlin literal by our own grammar', () => {
+  const v = collectTransforms().get('size/unit-aware/compose-em').transform(emSpacing());
+  assert.equal(hasNativeForm({ $value: v }, 'android-kotlin'), true);
 });


### PR DESCRIPTION
**Stacked on #78.** Base is `fix/70-native-literal-grammar`, not `main`, because both touch `CHANGELOG.md` and this one needs #70's grammar work. **Retarget this to `main` before merging #78**, and merge #78 *without* `--delete-branch` — deleting the base auto-closes a stacked PR unreopenably, which cost PR #65 on 2026-08-24.

## What this closes

All 13 `typography.textStyle.*.letterSpacing` tokens on zygarden's source resolve to `em`, and `nativeFilter` dropped them from **both** platforms. They were the bulk of the 19 source tokens `tokens:validate-output` reported as having no emitted symbol. Compose has a real `.em` `TextUnit`, so this was a filter gap — not a value with no native form, the way `%` is.

## Four coupled changes

The issue predicted these could not be split, and it was right:

1. `ABSOLUTE_UNIT` → `TEXT_ROLE_UNIT`, admitting `em`, so `classifyTextUnits` stamps the role. Without the stamp the new transform has nothing to filter on. The gate's job was never "absolute" — it is to exclude the *unitless* value, whose role the source never stated.
2. `nativeFilter` takes the platform. `%` still drops everywhere; `em` survives only where **all three** hold — platform is Compose, value is `em`, token carries the text role. An `em` *spacing* has no TextUnit meaning and still drops.
3. `size/unit-aware/compose-em` emits it. `dp` and `sp` already decline `em` (`magnitude()` returns `null`), so nothing contends.
4. The stock `size/compose/em` decline reason read *"em is not representable in native output"*. Now false, so it says what replaced it.

## The parens are load-bearing

It emits `(-0.03).em`. Measured, not assumed:

```
-0.03.em     kotlinc 2.4.10 → error: unresolved reference 'unaryMinus'
(-0.03).em   compiles
```

`-0.03.em` parses as `-(0.03.em)`. Whether real Compose's `TextUnit` defines `unaryMinus` I could not verify — the docs fetch didn't reach the class and Maven is blocked from this sandbox — and the parenthesised form compiles either way, so it doesn't matter. **A tight letter spacing is negative, so this is the common case, not an edge one.**

That costs the literal grammar parenthesised-`NUMBER` support. Deliberately a *number*, not an expression: accepting `(1 + 2)` would have the gate vouch for arithmetic it cannot evaluate.

## iOS is excluded deliberately, not pending

Letter spacing on iOS is an `NSAttributedString` kern in **points**, which needs the font size a token does not carry. No constant Swift could emit is right at every font size. Emitting the bare ratio would compile as a `CGFloat` and be silently wrong at 1/33rd the intended size if used directly — the exact failure class this module exists to prevent.

## Measured against zygarden's real source

| | before | after |
|---|---|---|
| Kotlin declarations | 195 | **208**, compiles to bytecode (`kotlinc`) |
| Swift declarations | 195 | 195, **byte-identical**, `swiftc -parse` clean |
| unmatched source tokens, Android | 19 | **6** |
| unmatched source tokens, iOS | 19 | 19 (by decision) |

Purely additive: 13 Kotlin lines added, none removed. Not a breaking change, so it sits under Fixed rather than the new Breaking section.

**The remaining 6 on Android:** the four `typography.letterSpacing.{tight,normal,wide,widest}` primitives, whose leaf names state no role — the same documented limit as a bare scale primitive — plus a `linear-gradient()` and a `100%`, which have no native form at all. So every remaining Android gap is either a stated limit or genuinely unrepresentable.

## Verification

403 tests (11 new), all six gates green. `references/native-adapter-config.md` regenerated, and the **generator's own prose** corrected too — it still described `em` as dropped, twenty lines from the code that now emits it.

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018etbNQyHfuuGWwmd88T8Zm