### PR TITLE
e2e runs compile their output, and four notes stop saying they cannot (#81)

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -24,7 +24,13 @@ node --test                  # all tests
 node ci/validate-plugin.mjs  # guard plugin manifests
 node ci/validate-skills.mjs  # guard skill/command/manifest-doc structure
 node ci/compile-native-output.mjs <dir>  # compile generated Tokens.kt/.swift (not a CI gate)
+node ci/compile-native-output.mjs <dir> --allow-missing  # tolerate one absent toolchain
 ```
+
+`--allow-missing` downgrades a compiler that is not on `PATH` from a failure to
+a skip. It does not excuse a run in which *nothing* compiled: with neither
+toolchain present the run still exits 1, because a green run that verified
+nothing is the vacuous pass this module exists to prevent.
 
 ## Compile verification is not a CI gate
 
@@ -47,6 +53,7 @@ zygarden source, which is stronger evidence than that fixture would be.
 
 Reopen this deliberately if the tradeoff changes. Do not let it drift.
 
-Unlike the validators above, this module is **not** run by `node --test` against
-a real compiler: the test suite injects a fake environment, so the suite stays
-green on a runner with neither toolchain installed.
+This module's logic tests *do* run under `node --test`, like the validators above — but
+never against a real compiler. The suite injects a fake environment, so it stays
+green on a runner with neither toolchain installed. Only the CLI invocations
+above reach `kotlinc` and `swiftc`.

--- a/ci/README.md
+++ b/ci/README.md
@@ -23,4 +23,30 @@ own structure. Zero dependencies; stdlib only.
 node --test                  # all tests
 node ci/validate-plugin.mjs  # guard plugin manifests
 node ci/validate-skills.mjs  # guard skill/command/manifest-doc structure
+node ci/compile-native-output.mjs <dir>  # compile generated Tokens.kt/.swift (not a CI gate)
 ```
+
+## Compile verification is not a CI gate
+
+`ci/compile-native-output.mjs` compiles generated native token output —
+`kotlinc` typechecks `Tokens.kt` to bytecode against `ci/stubs/*.kt`; `swiftc
+-parse` checks `Tokens.swift` syntax only, because it imports `UIKit` and
+`-typecheck` must resolve imports where `-parse` need not.
+
+It runs at e2e time, deliberately, and `.github/workflows/` does not call it.
+
+Producing `Tokens.kt` at all requires Style Dictionary, because `PLATFORMS` in
+`scripts/lib/sd-native.mjs` targets SD's stock formatters — this repo owns the
+transforms and the config, not the formatter. The repo also declares zero
+dependencies and has no lockfile, and `ubuntu-latest` carries neither toolchain.
+Gating would mean adding a dependency graph, a lockfile, a committed token
+fixture, a JDK, and a Swift toolchain — in order to prove that output compiles
+*under one pinned Style Dictionary version*, while the version a consumer
+actually runs stays invisible to us either way. The e2e harness builds real
+zygarden source, which is stronger evidence than that fixture would be.
+
+Reopen this deliberately if the tradeoff changes. Do not let it drift.
+
+Unlike the validators above, this module is **not** run by `node --test` against
+a real compiler: the test suite injects a fake environment, so the suite stays
+green on a runner with neither toolchain installed.

--- a/ci/compile-native-output.mjs
+++ b/ci/compile-native-output.mjs
@@ -6,7 +6,7 @@
 // Runs at e2e time, NOT in CI — see ci/README.md for that decision (#81).
 // Pure functions + CLI.
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readdirSync } from 'node:fs';
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { tmpdir } from 'node:os';
@@ -18,7 +18,7 @@ export const PLATFORMS = [
     id: 'kotlin',
     file: 'Tokens.kt',
     compiler: 'kotlinc',
-    strength: 'typechecked to bytecode',
+    strength: 'typechecked to bytecode (against ci/stubs, not real Compose)',
   },
   {
     id: 'swift',
@@ -51,7 +51,7 @@ export function compileNativeOutput(dir, { allowMissing = false, env } = {}) {
       results.push({
         id: platform.id,
         status: 'fail',
-        detail: 'kotlinc exited 0 but produced no Tokens.class',
+        detail: `kotlinc exited 0 but produced no ${run.className ?? 'Tokens'}.class`,
       });
     } else {
       results.push({ id: platform.id, status: 'pass', detail: platform.strength });
@@ -67,10 +67,19 @@ export function compileNativeOutput(dir, { allowMissing = false, env } = {}) {
 
 const LABEL = { pass: 'PASS', fail: 'FAIL', absent: '----', skipped: 'SKIP' };
 
-export function formatCompileReport({ results }) {
+export function formatCompileReport({ results, compiled }) {
   const lines = ['compile-native-output — do the emitted native tokens build?', ''];
   for (const r of results) {
     lines.push(`  [${LABEL[r.status]}] ${r.id}: ${r.detail}`);
+  }
+  // Without this, a run in which nothing compiled prints only SKIP/---- lines
+  // and exits 1 — a transcript that reads as benign unless you also kept $?.
+  if (compiled === 0) {
+    lines.push(
+      '',
+      '  NOTHING COMPILED. Not one emitted file was successfully compiled, so',
+      '  this run verified nothing — reason enough on its own for exit 1.',
+    );
   }
   lines.push(
     '',
@@ -93,6 +102,16 @@ function findFile(dir, name) {
   return false;
 }
 
+// The emitted object is named by nativePlatform's `className` option, which is
+// public and defaults to 'Tokens', while the destination stays Tokens.kt — so
+// the class to look for must come from the source, not from the file name.
+// Deliberately narrow: "any *.class exists" would always be true, because the
+// stubs compile, and would destroy the exited-0-but-emitted-nothing guard.
+export function expectedKotlinClassName(source) {
+  const match = source.match(/^\s*(?:(?:public|internal|private)\s+)?object\s+([A-Za-z_]\w*)/m);
+  return match ? match[1] : null;
+}
+
 export function realEnv() {
   return {
     fileExists: (path) => existsSync(path),
@@ -107,16 +126,31 @@ export function realEnv() {
     runKotlin(source) {
       const outDir = mkdtempSync(join(tmpdir(), 'tl-kotlinc-'));
       const stubs = [join(STUB_DIR, 'compose-unit.kt'), join(STUB_DIR, 'compose-graphics.kt')];
+      const className = expectedKotlinClassName(readFileSync(source, 'utf8'));
       try {
-        // execFileSync throws on a non-zero exit and carries stderr on the
-        // error. No shell, no pipe — a pipeline would report the wrong status.
-        execFileSync('kotlinc', [...stubs, source, '-d', outDir], {
-          stdio: ['ignore', 'pipe', 'pipe'],
-        });
-      } catch (err) {
-        return { code: err.status ?? 1, stderr: String(err.stderr ?? err.message).trim(), classProduced: false };
+        try {
+          // execFileSync throws on a non-zero exit and carries stderr on the
+          // error. No shell, no pipe — a pipeline would report the wrong status.
+          execFileSync('kotlinc', [...stubs, source, '-d', outDir], {
+            stdio: ['ignore', 'pipe', 'pipe'],
+          });
+        } catch (err) {
+          return {
+            code: err.status ?? 1,
+            stderr: String(err.stderr ?? err.message).trim(),
+            classProduced: false,
+            className,
+          };
+        }
+        return {
+          code: 0,
+          stderr: '',
+          classProduced: className !== null && findFile(outDir, `${className}.class`),
+          className,
+        };
+      } finally {
+        rmSync(outDir, { recursive: true, force: true });
       }
-      return { code: 0, stderr: '', classProduced: findFile(outDir, 'Tokens.class') };
     },
     runSwift(source) {
       try {

--- a/ci/compile-native-output.mjs
+++ b/ci/compile-native-output.mjs
@@ -59,7 +59,10 @@ export function compileNativeOutput(dir, { allowMissing = false, env } = {}) {
   }
   const compiled = results.filter((r) => r.status === 'pass').length;
   const failed = results.filter((r) => r.status === 'fail').length;
-  return { results, exitCode: failed > 0 ? 1 : 0, compiled, failed };
+  // A run that compiled nothing fails, whatever --allow-missing said. The flag
+  // tolerates one absent toolchain; it does not excuse the absence of both,
+  // which would be a green run that verified nothing.
+  return { results, exitCode: failed > 0 || compiled === 0 ? 1 : 0, compiled, failed };
 }
 
 const LABEL = { pass: 'PASS', fail: 'FAIL', absent: '----', skipped: 'SKIP' };

--- a/ci/compile-native-output.mjs
+++ b/ci/compile-native-output.mjs
@@ -1,0 +1,144 @@
+// Compiles generated native token output to prove it is buildable, not merely
+// well-formed. Kotlin typechecks to bytecode against ci/stubs/*.kt; Swift is
+// parsed only, because Tokens.swift imports UIKit and -typecheck must resolve
+// imports where -parse need not.
+//
+// Runs at e2e time, NOT in CI — see ci/README.md for that decision (#81).
+// Pure functions + CLI.
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readdirSync } from 'node:fs';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { tmpdir } from 'node:os';
+
+export const STUB_DIR = resolve(dirname(fileURLToPath(import.meta.url)), 'stubs');
+
+export const PLATFORMS = [
+  {
+    id: 'kotlin',
+    file: 'Tokens.kt',
+    compiler: 'kotlinc',
+    strength: 'typechecked to bytecode',
+  },
+  {
+    id: 'swift',
+    file: 'Tokens.swift',
+    compiler: 'swiftc',
+    strength: 'parsed only (UIKit unavailable; -typecheck impossible)',
+  },
+];
+
+export function compileNativeOutput(dir, { allowMissing = false, env } = {}) {
+  const results = [];
+  for (const platform of PLATFORMS) {
+    const source = join(dir, platform.file);
+    if (!env.fileExists(source)) {
+      results.push({ id: platform.id, status: 'absent', detail: `${platform.file} not present` });
+      continue;
+    }
+    if (!env.commandExists(platform.compiler)) {
+      results.push({
+        id: platform.id,
+        status: allowMissing ? 'skipped' : 'fail',
+        detail: `${platform.compiler} not found on PATH`,
+      });
+      continue;
+    }
+    const run = platform.id === 'kotlin' ? env.runKotlin(source) : env.runSwift(source);
+    if (run.code !== 0) {
+      results.push({ id: platform.id, status: 'fail', detail: run.stderr });
+    } else if (platform.id === 'kotlin' && !run.classProduced) {
+      results.push({
+        id: platform.id,
+        status: 'fail',
+        detail: 'kotlinc exited 0 but produced no Tokens.class',
+      });
+    } else {
+      results.push({ id: platform.id, status: 'pass', detail: platform.strength });
+    }
+  }
+  const compiled = results.filter((r) => r.status === 'pass').length;
+  const failed = results.filter((r) => r.status === 'fail').length;
+  return { results, exitCode: failed > 0 ? 1 : 0, compiled, failed };
+}
+
+const LABEL = { pass: 'PASS', fail: 'FAIL', absent: '----', skipped: 'SKIP' };
+
+export function formatCompileReport({ results }) {
+  const lines = ['compile-native-output — do the emitted native tokens build?', ''];
+  for (const r of results) {
+    lines.push(`  [${LABEL[r.status]}] ${r.id}: ${r.detail}`);
+  }
+  lines.push(
+    '',
+    '  Kotlin is typechecked to bytecode; Swift is parsed only. swiftc -typecheck',
+    '  cannot run here: Tokens.swift imports UIKit, which is unavailable on the',
+    '  macOS command line. Swift syntax is asserted; Swift types are not.',
+  );
+  return lines;
+}
+
+function findFile(dir, name) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (findFile(full, name)) return true;
+    } else if (entry.name === name) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function realEnv() {
+  return {
+    fileExists: (path) => existsSync(path),
+    commandExists(cmd) {
+      try {
+        execFileSync('which', [cmd], { stdio: 'ignore' });
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    runKotlin(source) {
+      const outDir = mkdtempSync(join(tmpdir(), 'tl-kotlinc-'));
+      const stubs = [join(STUB_DIR, 'compose-unit.kt'), join(STUB_DIR, 'compose-graphics.kt')];
+      try {
+        // execFileSync throws on a non-zero exit and carries stderr on the
+        // error. No shell, no pipe — a pipeline would report the wrong status.
+        execFileSync('kotlinc', [...stubs, source, '-d', outDir], {
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
+      } catch (err) {
+        return { code: err.status ?? 1, stderr: String(err.stderr ?? err.message).trim(), classProduced: false };
+      }
+      return { code: 0, stderr: '', classProduced: findFile(outDir, 'Tokens.class') };
+    },
+    runSwift(source) {
+      try {
+        execFileSync('swiftc', ['-parse', source], { stdio: ['ignore', 'pipe', 'pipe'] });
+      } catch (err) {
+        return { code: err.status ?? 1, stderr: String(err.stderr ?? err.message).trim() };
+      }
+      return { code: 0, stderr: '' };
+    },
+  };
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const allowMissing = args.includes('--allow-missing');
+  const dir = args.find((a) => !a.startsWith('--'));
+  if (!dir) {
+    console.error('usage: node ci/compile-native-output.mjs <dir> [--allow-missing]');
+    process.exit(2);
+  }
+  const outcome = compileNativeOutput(dir, { allowMissing, env: realEnv() });
+  for (const line of formatCompileReport(outcome)) console.log(line);
+  process.exit(outcome.exitCode);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/ci/compile-native-output.test.mjs
+++ b/ci/compile-native-output.test.mjs
@@ -1,0 +1,84 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  compileNativeOutput,
+  formatCompileReport,
+  PLATFORMS,
+  STUB_DIR,
+} from './compile-native-output.mjs';
+
+// A fake environment. Defaults to "both files present, both compilers present,
+// both compile clean"; each test overrides only what it is about.
+function fakeEnv({
+  present = ['Tokens.kt', 'Tokens.swift'],
+  commands = ['kotlinc', 'swiftc'],
+  kotlin = { code: 0, stderr: '', classProduced: true },
+  swift = { code: 0, stderr: '' },
+} = {}) {
+  return {
+    fileExists: (p) => present.some((f) => p.endsWith(f)),
+    commandExists: (c) => commands.includes(c),
+    runKotlin: () => kotlin,
+    runSwift: () => swift,
+  };
+}
+
+function byId(results, id) {
+  return results.find((r) => r.id === id);
+}
+
+test('both platforms compiling clean is a pass', () => {
+  const out = compileNativeOutput('/out', { env: fakeEnv() });
+  assert.equal(out.exitCode, 0);
+  assert.equal(byId(out.results, 'kotlin').status, 'pass');
+  assert.equal(byId(out.results, 'swift').status, 'pass');
+  assert.equal(out.compiled, 2);
+});
+
+test('an absent Tokens.swift is reported absent, not as a pass', () => {
+  const out = compileNativeOutput('/out', { env: fakeEnv({ present: ['Tokens.kt'] }) });
+  assert.equal(byId(out.results, 'swift').status, 'absent');
+  assert.equal(out.exitCode, 0, 'kotlin still compiled, so the run passes');
+  assert.equal(out.compiled, 1);
+});
+
+test('kotlinc exiting 0 without producing Tokens.class is a failure', () => {
+  const env = fakeEnv({ kotlin: { code: 0, stderr: '', classProduced: false } });
+  const out = compileNativeOutput('/out', { env });
+  assert.equal(byId(out.results, 'kotlin').status, 'fail');
+  assert.match(byId(out.results, 'kotlin').detail, /no Tokens\.class/);
+  assert.equal(out.exitCode, 1);
+});
+
+test('a compiler failure surfaces the compiler stderr verbatim', () => {
+  const stderr = "Broken.kt:4:28: error: unresolved reference 'unaryMinus' for operator '-'.";
+  const env = fakeEnv({ kotlin: { code: 1, stderr, classProduced: false } });
+  const out = compileNativeOutput('/out', { env });
+  assert.equal(byId(out.results, 'kotlin').status, 'fail');
+  assert.equal(byId(out.results, 'kotlin').detail, stderr);
+});
+
+test('one platform failing does not suppress the other platform verdict', () => {
+  const env = fakeEnv({ kotlin: { code: 1, stderr: 'boom', classProduced: false } });
+  const out = compileNativeOutput('/out', { env });
+  assert.equal(out.exitCode, 1);
+  assert.equal(byId(out.results, 'kotlin').status, 'fail');
+  assert.equal(byId(out.results, 'swift').status, 'pass');
+});
+
+test('the report states the Kotlin/Swift asymmetry on every run', () => {
+  const out = compileNativeOutput('/out', { env: fakeEnv() });
+  const text = formatCompileReport(out).join('\n');
+  assert.match(text, /typechecked to bytecode/);
+  assert.match(text, /parsed only/);
+  assert.match(text, /UIKit/);
+});
+
+test('stub paths resolve relative to the module, not the working directory', () => {
+  assert.ok(STUB_DIR.startsWith('/'), 'STUB_DIR must be absolute');
+  assert.match(STUB_DIR, /ci\/stubs$/);
+});
+
+test('PLATFORMS names the two files the emitter writes', () => {
+  assert.deepEqual(PLATFORMS.map((p) => p.file), ['Tokens.kt', 'Tokens.swift']);
+});

--- a/ci/compile-native-output.test.mjs
+++ b/ci/compile-native-output.test.mjs
@@ -2,6 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   compileNativeOutput,
+  expectedKotlinClassName,
   formatCompileReport,
   PLATFORMS,
   STUB_DIR,
@@ -72,6 +73,35 @@ test('the report states the Kotlin/Swift asymmetry on every run', () => {
   assert.match(text, /typechecked to bytecode/);
   assert.match(text, /parsed only/);
   assert.match(text, /UIKit/);
+});
+
+test('a report in which nothing compiled says so, in the report itself', () => {
+  const out = compileNativeOutput('/out', { allowMissing: true, env: fakeEnv({ commands: [] }) });
+  const text = formatCompileReport(out).join('\n');
+  assert.match(text, /NOTHING COMPILED/);
+  assert.match(text, /verified nothing — reason enough on its own for exit 1/);
+});
+
+test('a passing report does not claim nothing was compiled', () => {
+  const text = formatCompileReport(compileNativeOutput('/out', { env: fakeEnv() })).join('\n');
+  assert.doesNotMatch(text, /NOTHING COMPILED/);
+});
+
+test('the printed Kotlin verdict discloses that the stubs are not real Compose', () => {
+  const out = compileNativeOutput('/out', { env: fakeEnv() });
+  assert.match(formatCompileReport(out).join('\n'), /not real Compose/);
+});
+
+test('the expected Kotlin class name comes from the default object declaration', () => {
+  assert.equal(expectedKotlinClassName('package p\n\nobject Tokens {\n  val x = 1.dp\n}\n'), 'Tokens');
+});
+
+test('a non-default className is read from the source, not assumed to be Tokens', () => {
+  assert.equal(expectedKotlinClassName('package p\n\nobject Brand {\n  val x = 1.dp\n}\n'), 'Brand');
+});
+
+test('source with no object declaration yields no expected class name', () => {
+  assert.equal(expectedKotlinClassName('package p\n\nval x = 1.dp\n'), null);
 });
 
 test('stub paths resolve relative to the module, not the working directory', () => {

--- a/ci/compile-native-output.test.mjs
+++ b/ci/compile-native-output.test.mjs
@@ -82,3 +82,35 @@ test('stub paths resolve relative to the module, not the working directory', () 
 test('PLATFORMS names the two files the emitter writes', () => {
   assert.deepEqual(PLATFORMS.map((p) => p.file), ['Tokens.kt', 'Tokens.swift']);
 });
+
+test('a missing compiler fails the run by default', () => {
+  const out = compileNativeOutput('/out', { env: fakeEnv({ commands: ['swiftc'] }) });
+  assert.equal(byId(out.results, 'kotlin').status, 'fail');
+  assert.match(byId(out.results, 'kotlin').detail, /kotlinc not found/);
+  assert.equal(out.exitCode, 1);
+});
+
+test('--allow-missing downgrades one absent toolchain to a skip', () => {
+  const out = compileNativeOutput('/out', {
+    allowMissing: true,
+    env: fakeEnv({ commands: ['swiftc'] }),
+  });
+  assert.equal(byId(out.results, 'kotlin').status, 'skipped');
+  assert.equal(byId(out.results, 'swift').status, 'pass');
+  assert.equal(out.exitCode, 0, 'swift really compiled, so the run is meaningful');
+});
+
+test('--allow-missing does not excuse a run in which nothing compiled', () => {
+  const out = compileNativeOutput('/out', {
+    allowMissing: true,
+    env: fakeEnv({ commands: [] }),
+  });
+  assert.equal(out.compiled, 0);
+  assert.equal(out.exitCode, 1, 'a green run that verified nothing is the vacuous pass');
+});
+
+test('a directory holding neither output file fails rather than passing empty', () => {
+  const out = compileNativeOutput('/out', { env: fakeEnv({ present: [] }) });
+  assert.equal(out.compiled, 0);
+  assert.equal(out.exitCode, 1);
+});

--- a/ci/stubs/compose-graphics.kt
+++ b/ci/stubs/compose-graphics.kt
@@ -1,0 +1,7 @@
+// Minimal stand-in for androidx.compose.ui.graphics. Separate file because a
+// Kotlin source file carries exactly one package declaration.
+// Long, not Int: 0xffffffff is 4294967295, past Int.MAX_VALUE, so Kotlin types
+// the literal Long. Used by ci/compile-native-output.mjs (#81).
+package androidx.compose.ui.graphics
+
+class Color(val value: Long)

--- a/ci/stubs/compose-unit.kt
+++ b/ci/stubs/compose-unit.kt
@@ -1,0 +1,12 @@
+// Minimal stand-in for androidx.compose.ui.unit, so kotlinc can typecheck
+// generated Tokens.kt without Compose on the classpath. Not Compose: real Dp is
+// a value class. Asserts only that the expression resolves and typechecks.
+// Used by ci/compile-native-output.mjs (#81).
+package androidx.compose.ui.unit
+
+class Dp(val value: Double)
+class TextUnit(val value: Double)
+
+val Double.dp: Dp get() = Dp(this)
+val Double.sp: TextUnit get() = TextUnit(this)
+val Double.em: TextUnit get() = TextUnit(this)

--- a/docs/superpowers/notes/2026-08-21-native-config-e2e-results.md
+++ b/docs/superpowers/notes/2026-08-21-native-config-e2e-results.md
@@ -279,8 +279,13 @@ $ grep -n '\.sp\b' out/light/android/Tokens.kt | head -3
    by name only and are checked by no rule** — and nothing checks that any of
    it compiles. Any public claim built on this run must say that, not "196
    correct symbols".
-4. **Nothing was compiled.** No `swiftc` or `kotlinc` ran; correctness here is
-   value fidelity as measured by `tokens:validate-output` only.
+4. **Nothing was compiled in this run.** No `swiftc` or `kotlinc` ran;
+   correctness here is value fidelity as measured by `tokens:validate-output`
+   only. `swiftc` was nonetheless available at `/usr/bin/swiftc` via the Xcode
+   command line tools when this run happened, and went unused — the Swift
+   half of this limitation was self-imposed. `kotlinc` was not available: it
+   was installed on 2026-08-27, after this run. Later runs compile both, via
+   `ci/compile-native-output.mjs` (#81).
 5. **The desktop viewport axis was not built.** Only the mobile axis was.
 6. **Unitless ratios emit as `dp` on Android.** `leading.*` is authored
    unitless (`"1.5"`, typed `dimension`) and emits `val leadingNormal = 1.50.dp`

--- a/docs/superpowers/notes/2026-08-23-native-literal-validity-e2e.md
+++ b/docs/superpowers/notes/2026-08-23-native-literal-validity-e2e.md
@@ -226,12 +226,17 @@ literal syntax, not numeric magnitude.
 
 ## What this run does NOT establish
 
-1. **Nothing was compiled.** No `swiftc` or `kotlinc` ran. "Valid literal"
-   here means `parseLiteral`/`isValidLiteral` (Task 1's grammar) accepts the
-   emitted text as a syntactically well-formed Swift or Kotlin literal — not
-   that the surrounding declaration, type, or file compiles. A type mismatch
-   or a reference to an undefined symbol elsewhere in the file would still
-   pass every check made here.
+1. **Nothing was compiled in this run.** No `swiftc` or `kotlinc` ran. "Valid
+   literal" here means `parseLiteral`/`isValidLiteral` (Task 1's grammar)
+   accepts the emitted text as a syntactically well-formed Swift or Kotlin
+   literal — not that the surrounding declaration, type, or file compiles. A
+   type mismatch or a reference to an undefined symbol elsewhere in the file
+   would still pass every check made here. `swiftc` was nonetheless available
+   at `/usr/bin/swiftc` via the Xcode command line tools when this run
+   happened, and went unused — the Swift half of this limitation was
+   self-imposed. `kotlinc` was not available: it was installed on 2026-08-27,
+   after this run. Later runs compile both, via `ci/compile-native-output.mjs`
+   (#81).
 2. **Colour values are still matched by name only and checked by no rule.**
    As in the 2026-08-21 native-config run, `matched` counts name resolution
    in `tokens:validate-output`, not value agreement. `invalid-literal` checks

--- a/docs/superpowers/notes/2026-08-24-hoist-dual-nodes-e2e.md
+++ b/docs/superpowers/notes/2026-08-24-hoist-dual-nodes-e2e.md
@@ -169,9 +169,14 @@ this source, and matches identically between HEAD and `main`.
   collides, so this e2e run does **not** validate either fix — synthetic unit
   fixtures do (see Tasks 1 and 2's test suites). Proving *nothing moved* is
   this run's entire job, and is the only thing it claims to have proven.
-- **Nothing was compiled.** No `swiftc` or `kotlinc` ran. `decls`/`broken` are
-  `grep`-based counts, not a compiler's verdict, and `diff -r` establishes
-  byte-identity, not correctness of what those bytes mean.
+- **Nothing was compiled in this run.** No `swiftc` or `kotlinc` ran.
+  `decls`/`broken` are `grep`-based counts, not a compiler's verdict, and
+  `diff -r` establishes byte-identity, not correctness of what those bytes
+  mean. `swiftc` was nonetheless available at `/usr/bin/swiftc` via the Xcode
+  command line tools when this run happened, and went unused — the Swift
+  half of this limitation was self-imposed. `kotlinc` was not available: it
+  was installed on 2026-08-27, after this run. Later runs compile both, via
+  `ci/compile-native-output.mjs` (#81).
 - **The two widenings recorded in the spec (`#52` and `#51`) are unreachable
   in this source for the same reason.** `#52` (untyped unitless literal child
   under a `dimension` dual node emitting `dp`) and `#51` (untyped `fontSize`

--- a/docs/superpowers/notes/2026-08-26-unitless-dimension-e2e.md
+++ b/docs/superpowers/notes/2026-08-26-unitless-dimension-e2e.md
@@ -229,10 +229,15 @@ Every clause of the prediction held. Nothing was adjusted to fit.
 
 ## What this run does NOT establish
 
-- **Nothing was compiled.** No `swiftc` or `kotlinc` ran; the declaration and
-  `.sp`/`.dp` counts are `grep`-based, and the advisory/diff checks are
-  textual, not a compiler's verdict on whether the bare `Int`/`Double`
-  literals actually satisfy whatever consumes them downstream.
+- **Nothing was compiled in this run.** No `swiftc` or `kotlinc` ran; the
+  declaration and `.sp`/`.dp` counts are `grep`-based, and the advisory/diff
+  checks are textual, not a compiler's verdict on whether the bare
+  `Int`/`Double` literals actually satisfy whatever consumes them downstream.
+  `swiftc` was nonetheless available at `/usr/bin/swiftc` via the Xcode
+  command line tools when this run happened, and went unused — the Swift
+  half of this limitation was self-imposed. `kotlinc` was not available: it
+  was installed on 2026-08-27, after this run. Later runs compile both, via
+  `ci/compile-native-output.mjs` (#81).
 - **The harness's `scripts/lib` symlink is unused by this build path.** It
   was left pointed at the live repo throughout (as found), but `build.mjs`
   never reads it — see the correction above. Anyone reusing this harness for

--- a/docs/superpowers/notes/2026-08-28-compile-verification-e2e.md
+++ b/docs/superpowers/notes/2026-08-28-compile-verification-e2e.md
@@ -114,26 +114,60 @@ compile-native-output — do the emitted native tokens build?
 exit=0
 ```
 
+### Step 6 — a Swift control, which must also fail
+
+Steps 4-5 exercise Kotlin only. Recorded later the same day, during the
+post-review fix pass, so the runner prints the then-new "NOTHING COMPILED" line.
+
+```
+$ mkdir -p /tmp/tl-swift-control
+$ echo 'public enum A { public static let x = CGFloat(.5) }' > /tmp/tl-swift-control/Tokens.swift
+$ node ci/compile-native-output.mjs /tmp/tl-swift-control --allow-missing; echo "exit=$?"
+compile-native-output — do the emitted native tokens build?
+
+  [----] kotlin: Tokens.kt not present
+  [FAIL] swift: /tmp/tl-swift-control/Tokens.swift:1:47: error: '.5' is not a valid floating point literal; it must be written '0.5'
+1 | public enum A { public static let x = CGFloat(.5) }
+  |                                               `- error: '.5' is not a valid floating point literal; it must be written '0.5'
+2 |
+
+  NOTHING COMPILED. Not one emitted file was successfully compiled, so
+  this run verified nothing — reason enough on its own for exit 1.
+
+  Kotlin is typechecked to bytecode; Swift is parsed only. swiftc -typecheck
+  cannot run here: Tokens.swift imports UIKit, which is unavailable on the
+  macOS command line. Swift syntax is asserted; Swift types are not.
+exit=1
+```
+
 ## Prediction vs. actual
 
 | Prediction | Actual |
 |---|---|
-| `Tokens.kt` compiles, exit 0, `Tokens.class` produced | [x] |
-| `Tokens.swift` parses, exit 0 | [x] |
-| 208 Kotlin declarations / 195 Swift | [x] |
-| `-0.03.em` FAILS with `unresolved reference 'unaryMinus'` | [x] |
-| `(-0.03).em` passes | [x] |
+| `Tokens.kt` compiles, exit 0, `Tokens.class` produced | `[PASS] kotlin`, exit 0 (Step 3) |
+| `Tokens.swift` parses, exit 0 | `[PASS] swift`, exit 0 (Step 3) |
+| 208 Kotlin declarations / 195 Swift | 208 `val` / 195 `public static let` (Step 2) |
+| `-0.03.em` FAILS with `unresolved reference 'unaryMinus'` | `[FAIL] kotlin: ... unresolved reference 'unaryMinus'`, exit 1 (Step 4) |
+| `(-0.03).em` passes | `[PASS] kotlin`, exit 0 (Step 5) |
 
 ## What this run does NOT establish
 
 - **Swift is parsed, never typechecked.** `Tokens.swift` imports `UIKit`, which
   is unavailable on the macOS command line, so `swiftc -typecheck` cannot run. A
   Swift type error — a wrong `UIColor` initialiser arity, an `Int` where
-  `CGFloat` is required — passes this check. Only syntax is asserted.
+  `CGFloat` is required — passes this check. It is not only type errors: two
+  `public static let` declarations with the *same* name pass (the camel-join
+  collision class), and so does a `Tokens.swift` with no `import UIKit` at all.
+  One file carrying both was run through the checker and exited 0. Only syntax
+  is asserted.
 - **The Kotlin stubs are not Compose.** They are six declarations with matching
   names and shapes (`Dp`, `TextUnit`, `.dp`, `.sp`, `.em`, `Color`). Real `Dp`
   is a value class and real `Color` wraps a `ULong`; nothing beyond "this
   expression resolves and typechecks" is covered.
+- **An emitter that dropped every token still passes.** `object Tokens {}`
+  compiles and produces `Tokens.class`, so the class guard catches an empty
+  *output directory*, not an empty *object*. Declaration counts (Step 2) are
+  what stand between this check and a silently emptied build.
 - **Neither compiler validates semantics.** `2.dp` where `2.sp` was meant
   compiles. This closes the gap between "well-formed literal" and "compiles",
   which is narrower than "correct" — `tokens:validate-output` and the e2e diff

--- a/docs/superpowers/notes/2026-08-28-compile-verification-e2e.md
+++ b/docs/superpowers/notes/2026-08-28-compile-verification-e2e.md
@@ -1,0 +1,142 @@
+# Compile verification (#81) — baseline and control against zygarden
+
+**Date:** 2026-08-28
+**Gate for:** Task 6 of the #81 plan — the committed runner
+(`ci/compile-native-output.mjs`) compiles real emitted output, and demonstrably
+fails on output that does not compile.
+**Verdict:** PASS — the runner both passed against real zygarden output and
+failed against deliberately broken output, quoting the exact historical
+`unaryMinus` defect.
+
+## Why this run exists
+
+Four e2e notes claimed nothing could be compiled. Both compilers are in fact
+available (`swiftc` throughout; `kotlinc` since 2026-08-27), so the ceiling on
+what an e2e run asserts was lower than it needed to be. This run establishes the
+new ceiling and, more importantly, that the check can fail.
+
+## Harness
+
+Reused at
+`/private/tmp/claude-501/-Users-jordansstudio-Dev-throughline/395cf4ed-9e55-4c18-a73d-e9980db4545c/scratchpad/e2e`
+(a prior session's harness, still alive) — not rebuilt.
+
+- **Style Dictionary:** 4.4.0, installed in the harness directory.
+- **Source:** the 15 zygarden JSON files, light + mobile axes (the build drops
+  any filename containing `desktop` or `dark`).
+- **Module under test:** reached via
+  `<harness>/lib/{dtcg,native-literal,sd-native}.mjs` symlinked into this
+  checkout's `scripts/lib/`. Not `scripts/lib`, which `build.mjs` never reads —
+  the no-op #73 was filed over.
+- **Branch:** `feat/81-compile-verification` at `4dd004f`.
+
+## Procedure
+
+### Step 1 — build zygarden
+
+```
+$ H=/private/tmp/claude-501/-Users-jordansstudio-Dev-throughline/395cf4ed-9e55-4c18-a73d-e9980db4545c/scratchpad/e2e
+$ cd "$H" && node build.mjs ../tokens out-81-baseline
+swift
+✔︎ out-81-baseline/Tokens.swift
+
+kt
+✔︎ out-81-baseline/Tokens.kt
+---exit=0---
+$ ls out-81-baseline
+Tokens.kt
+Tokens.swift
+```
+
+### Step 2 — declaration counts
+
+```
+$ grep -c '^  val ' "$H/out-81-baseline/Tokens.kt"
+208
+$ grep -c 'public static let' "$H/out-81-baseline/Tokens.swift"
+195
+```
+
+### Step 3 — baseline compile
+
+```
+$ cd /Users/jordansstudio/Dev/throughline
+$ node ci/compile-native-output.mjs "$H/out-81-baseline"; echo "exit=$?"
+compile-native-output — do the emitted native tokens build?
+
+  [PASS] kotlin: typechecked to bytecode
+  [PASS] swift: parsed only (UIKit unavailable; -typecheck impossible)
+
+  Kotlin is typechecked to bytecode; Swift is parsed only. swiftc -typecheck
+  cannot run here: Tokens.swift imports UIKit, which is unavailable on the
+  macOS command line. Swift syntax is asserted; Swift types are not.
+exit=0
+```
+
+### Step 4 — the control, which must fail
+
+```
+$ mkdir -p /tmp/tl-control
+$ cat > /tmp/tl-control/Tokens.kt <<'EOF'
+package com.zygarden.tokens
+import androidx.compose.ui.unit.*
+object Tokens {
+  val letterSpacingTight = -0.03.em
+}
+EOF
+$ node ci/compile-native-output.mjs /tmp/tl-control --allow-missing; echo "exit=$?"
+compile-native-output — do the emitted native tokens build?
+
+  [FAIL] kotlin: /tmp/tl-control/Tokens.kt:4:28: error: unresolved reference 'unaryMinus' for operator '-'.
+  val letterSpacingTight = -0.03.em
+                           ^
+  [----] swift: Tokens.swift not present
+
+  Kotlin is typechecked to bytecode; Swift is parsed only. swiftc -typecheck
+  cannot run here: Tokens.swift imports UIKit, which is unavailable on the
+  macOS command line. Swift syntax is asserted; Swift types are not.
+exit=1
+```
+
+### Step 5 — the control's fixed form
+
+```
+$ sed -i '' 's/-0\.03\.em/(-0.03).em/' /tmp/tl-control/Tokens.kt
+$ node ci/compile-native-output.mjs /tmp/tl-control --allow-missing; echo "exit=$?"
+compile-native-output — do the emitted native tokens build?
+
+  [PASS] kotlin: typechecked to bytecode
+  [----] swift: Tokens.swift not present
+
+  Kotlin is typechecked to bytecode; Swift is parsed only. swiftc -typecheck
+  cannot run here: Tokens.swift imports UIKit, which is unavailable on the
+  macOS command line. Swift syntax is asserted; Swift types are not.
+exit=0
+```
+
+## Prediction vs. actual
+
+| Prediction | Actual |
+|---|---|
+| `Tokens.kt` compiles, exit 0, `Tokens.class` produced | [x] |
+| `Tokens.swift` parses, exit 0 | [x] |
+| 208 Kotlin declarations / 195 Swift | [x] |
+| `-0.03.em` FAILS with `unresolved reference 'unaryMinus'` | [x] |
+| `(-0.03).em` passes | [x] |
+
+## What this run does NOT establish
+
+- **Swift is parsed, never typechecked.** `Tokens.swift` imports `UIKit`, which
+  is unavailable on the macOS command line, so `swiftc -typecheck` cannot run. A
+  Swift type error — a wrong `UIColor` initialiser arity, an `Int` where
+  `CGFloat` is required — passes this check. Only syntax is asserted.
+- **The Kotlin stubs are not Compose.** They are six declarations with matching
+  names and shapes (`Dp`, `TextUnit`, `.dp`, `.sp`, `.em`, `Color`). Real `Dp`
+  is a value class and real `Color` wraps a `ULong`; nothing beyond "this
+  expression resolves and typechecks" is covered.
+- **Neither compiler validates semantics.** `2.dp` where `2.sp` was meant
+  compiles. This closes the gap between "well-formed literal" and "compiles",
+  which is narrower than "correct" — `tokens:validate-output` and the e2e diff
+  remain the checks for whether the right thing was emitted.
+- **The harness is scratch and unowned.** It can vanish; only the runner and
+  stubs are repo assets. Spec §8.1 is what makes it rebuildable.

--- a/docs/superpowers/notes/2026-08-28-compile-verification-e2e.md
+++ b/docs/superpowers/notes/2026-08-28-compile-verification-e2e.md
@@ -57,6 +57,12 @@ $ grep -c 'public static let' "$H/out-81-baseline/Tokens.swift"
 195
 ```
 
+> **The Kotlin `[PASS]` lines in Steps 3 and 5 predate a later wording change.**
+> The post-review fix pass amended the Kotlin verdict string to `typechecked to
+> bytecode (against ci/stubs, not real Compose)`, so the runner no longer prints
+> the shorter form these two transcripts show. Verdicts, exit codes and
+> declaration counts are unaffected — only the disclosure text changed.
+
 ### Step 3 — baseline compile
 
 ```

--- a/docs/superpowers/plans/2026-08-28-compile-verification.md
+++ b/docs/superpowers/plans/2026-08-28-compile-verification.md
@@ -1,0 +1,878 @@
+# Compile Verification for Native Token Output — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give e2e runs a committed, runnable compile check for native token
+output, and correct four notes that claim compiling was impossible.
+
+**Architecture:** A single stdlib-only Node module in `ci/` — pure decision
+function plus a thin CLI, matching the existing `ci/` idiom — that shells out to
+`kotlinc` and `swiftc` against two committed Kotlin stub files. Kotlin
+typechecks to bytecode; Swift parses only. Nothing ships to consumers and
+nothing runs in GitHub Actions.
+
+**Tech Stack:** Node 20+ stdlib only (`node:test`, `node:child_process`,
+`node:fs`, `node:path`, `node:url`, `node:os`). Kotlin 2.4.10 `kotlinc`, Apple
+Swift 6.3.2 `swiftc`. No npm dependencies, no lockfile.
+
+**Spec:** `docs/superpowers/specs/2026-08-28-compile-verification-design.md`
+
+## Global Constraints
+
+- **Zero dependencies.** Do not add a `dependencies`, `devDependencies`,
+  lockfile, or `node_modules` to this repo. Style Dictionary stays confined to
+  the scratch e2e harness. (Spec §2.3)
+- **`ci/` never ships.** `package.json`'s `files` omits `ci/` and must continue
+  to. Nothing in this plan may be added to `files`. (Spec §3)
+- **Nothing is added to `.github/workflows/`.** Compile verification is
+  explicitly not a CI gate. (Spec §7)
+- **The test suite never invokes a real compiler.** CI is `ubuntu-latest` with
+  Node 24 and neither toolchain; `node --test` must stay green there.
+  (Spec §5)
+- **Run tests as bare `node --test` from the repo root**, never `node --test
+  ci/`, which errors on Node ≥21. (Spec §5, `ci/README.md`)
+- **Exit status is read from the process directly, never through a pipe.** A
+  pipeline reports its last command, which produced a false `exit=0` during
+  design. (Spec §4)
+- **Stub paths resolve relative to the runner module** via `import.meta.url`,
+  never the working directory — the intended caller is a scratchpad harness.
+  (Spec §4)
+- **Verified toolchain facts:** `kotlinc` 2.4.10 at `/opt/homebrew/bin/kotlinc`
+  (installed 2026-08-27 22:59); `swiftc` 6.3.2 at `/usr/bin/swiftc`.
+
+---
+
+## File Structure
+
+| path | responsibility |
+|---|---|
+| `ci/stubs/compose-unit.kt` | *(new)* `androidx.compose.ui.unit` — `Dp`, `TextUnit`, `.dp`, `.sp`, `.em` |
+| `ci/stubs/compose-graphics.kt` | *(new)* `androidx.compose.ui.graphics` — `Color` |
+| `ci/compile-native-output.mjs` | *(new)* pure decision function + report formatter + CLI |
+| `ci/compile-native-output.test.mjs` | *(new)* decision-logic tests with an injected fake environment |
+| `ci/README.md` | *(modify)* runner entry + the not-a-CI-gate decision |
+| `docs/superpowers/notes/2026-08-21-native-config-e2e-results.md` | *(modify)* scope the stale claim |
+| `docs/superpowers/notes/2026-08-23-native-literal-validity-e2e.md` | *(modify)* scope the stale claim |
+| `docs/superpowers/notes/2026-08-24-hoist-dual-nodes-e2e.md` | *(modify)* scope the stale claim |
+| `docs/superpowers/notes/2026-08-26-unitless-dimension-e2e.md` | *(modify)* scope the stale claim |
+| `docs/superpowers/notes/2026-08-28-compile-verification-e2e.md` | *(new)* baseline run + control |
+
+Two stub files rather than one because a Kotlin source file carries exactly one
+`package` declaration (spec §2.1).
+
+---
+
+## Task 1: The Kotlin stub pair
+
+**Files:**
+- Create: `ci/stubs/compose-unit.kt`
+- Create: `ci/stubs/compose-graphics.kt`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: two stub paths consumed by Task 2's `runKotlin` —
+  `ci/stubs/compose-unit.kt` and `ci/stubs/compose-graphics.kt`. Filenames are
+  load-bearing; Task 2 hardcodes them.
+
+- [ ] **Step 1: Create the unit stub**
+
+Create `ci/stubs/compose-unit.kt`:
+
+```kotlin
+// Minimal stand-in for androidx.compose.ui.unit, so kotlinc can typecheck
+// generated Tokens.kt without Compose on the classpath. Not Compose: real Dp is
+// a value class. Asserts only that the expression resolves and typechecks.
+// Used by ci/compile-native-output.mjs (#81).
+package androidx.compose.ui.unit
+
+class Dp(val value: Double)
+class TextUnit(val value: Double)
+
+val Double.dp: Dp get() = Dp(this)
+val Double.sp: TextUnit get() = TextUnit(this)
+val Double.em: TextUnit get() = TextUnit(this)
+```
+
+- [ ] **Step 2: Create the graphics stub**
+
+Create `ci/stubs/compose-graphics.kt`:
+
+```kotlin
+// Minimal stand-in for androidx.compose.ui.graphics. Separate file because a
+// Kotlin source file carries exactly one package declaration.
+// Long, not Int: 0xffffffff is 4294967295, past Int.MAX_VALUE, so Kotlin types
+// the literal Long. Used by ci/compile-native-output.mjs (#81).
+package androidx.compose.ui.graphics
+
+class Color(val value: Long)
+```
+
+- [ ] **Step 3: Verify the stubs compile on their own**
+
+Run:
+```bash
+kotlinc ci/stubs/compose-unit.kt ci/stubs/compose-graphics.kt -d /tmp/tl-stub-check
+echo "exit=$?"
+```
+Expected: `exit=0`, no diagnostics.
+
+- [ ] **Step 4: Verify they compile real generated output**
+
+This is the check that matters — the stub set in issue #81 fails here. Use any
+real `Tokens.kt`; the surviving harness has one at
+`/private/tmp/claude-501/-Users-jordansstudio-Dev-throughline/395cf4ed-9e55-4c18-a73d-e9980db4545c/scratchpad/e2e/out-52-head/Tokens.kt`.
+If that path is gone, rebuild per spec §8.1 first.
+
+```bash
+KT=/private/tmp/claude-501/-Users-jordansstudio-Dev-throughline/395cf4ed-9e55-4c18-a73d-e9980db4545c/scratchpad/e2e/out-52-head/Tokens.kt
+kotlinc ci/stubs/compose-unit.kt ci/stubs/compose-graphics.kt "$KT" -d /tmp/tl-real-check
+echo "exit=$?"
+find /tmp/tl-real-check -name 'Tokens.class'
+```
+Expected: `exit=0` and a `Tokens.class` path printed. If `unresolved reference
+'Color'` appears, the graphics stub is missing or misnamed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ci/stubs/compose-unit.kt ci/stubs/compose-graphics.kt
+git commit -m "feat: Compose stubs so kotlinc can typecheck generated Tokens.kt (#81)"
+```
+
+---
+
+## Task 2: The runner — detection, invocation, verdicts, report
+
+**Files:**
+- Create: `ci/compile-native-output.mjs`
+- Test: `ci/compile-native-output.test.mjs`
+
+**Interfaces:**
+- Consumes: `ci/stubs/compose-unit.kt`, `ci/stubs/compose-graphics.kt` (Task 1).
+- Produces, all named exports of `ci/compile-native-output.mjs`:
+  - `PLATFORMS` — array of `{ id, file, compiler, strength }`, ids `'kotlin'` and `'swift'`.
+  - `STUB_DIR` — absolute path string to `ci/stubs`.
+  - `compileNativeOutput(dir, { allowMissing = false, env })` → `{ results, exitCode, compiled, failed }` where `results` is an array of `{ id, status, detail }` and `status` is one of `'pass' | 'fail' | 'absent' | 'skipped'`.
+  - `formatCompileReport({ results })` → array of strings.
+  - `realEnv()` → an `env` object with `fileExists(path)`, `commandExists(cmd)`, `runKotlin(sourcePath)`, `runSwift(sourcePath)`.
+  - The `env` contract: `runKotlin` returns `{ code, stderr, classProduced }`; `runSwift` returns `{ code, stderr }`.
+  - Task 3 extends `compileNativeOutput`'s `allowMissing` behaviour; it adds no new exports.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `ci/compile-native-output.test.mjs`:
+
+```js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  compileNativeOutput,
+  formatCompileReport,
+  PLATFORMS,
+  STUB_DIR,
+} from './compile-native-output.mjs';
+
+// A fake environment. Defaults to "both files present, both compilers present,
+// both compile clean"; each test overrides only what it is about.
+function fakeEnv({
+  present = ['Tokens.kt', 'Tokens.swift'],
+  commands = ['kotlinc', 'swiftc'],
+  kotlin = { code: 0, stderr: '', classProduced: true },
+  swift = { code: 0, stderr: '' },
+} = {}) {
+  return {
+    fileExists: (p) => present.some((f) => p.endsWith(f)),
+    commandExists: (c) => commands.includes(c),
+    runKotlin: () => kotlin,
+    runSwift: () => swift,
+  };
+}
+
+function byId(results, id) {
+  return results.find((r) => r.id === id);
+}
+
+test('both platforms compiling clean is a pass', () => {
+  const out = compileNativeOutput('/out', { env: fakeEnv() });
+  assert.equal(out.exitCode, 0);
+  assert.equal(byId(out.results, 'kotlin').status, 'pass');
+  assert.equal(byId(out.results, 'swift').status, 'pass');
+  assert.equal(out.compiled, 2);
+});
+
+test('an absent Tokens.swift is reported absent, not as a pass', () => {
+  const out = compileNativeOutput('/out', { env: fakeEnv({ present: ['Tokens.kt'] }) });
+  assert.equal(byId(out.results, 'swift').status, 'absent');
+  assert.equal(out.exitCode, 0, 'kotlin still compiled, so the run passes');
+  assert.equal(out.compiled, 1);
+});
+
+test('kotlinc exiting 0 without producing Tokens.class is a failure', () => {
+  const env = fakeEnv({ kotlin: { code: 0, stderr: '', classProduced: false } });
+  const out = compileNativeOutput('/out', { env });
+  assert.equal(byId(out.results, 'kotlin').status, 'fail');
+  assert.match(byId(out.results, 'kotlin').detail, /no Tokens\.class/);
+  assert.equal(out.exitCode, 1);
+});
+
+test('a compiler failure surfaces the compiler stderr verbatim', () => {
+  const stderr = "Broken.kt:4:28: error: unresolved reference 'unaryMinus' for operator '-'.";
+  const env = fakeEnv({ kotlin: { code: 1, stderr, classProduced: false } });
+  const out = compileNativeOutput('/out', { env });
+  assert.equal(byId(out.results, 'kotlin').status, 'fail');
+  assert.equal(byId(out.results, 'kotlin').detail, stderr);
+});
+
+test('one platform failing does not suppress the other platform verdict', () => {
+  const env = fakeEnv({ kotlin: { code: 1, stderr: 'boom', classProduced: false } });
+  const out = compileNativeOutput('/out', { env });
+  assert.equal(out.exitCode, 1);
+  assert.equal(byId(out.results, 'kotlin').status, 'fail');
+  assert.equal(byId(out.results, 'swift').status, 'pass');
+});
+
+test('the report states the Kotlin/Swift asymmetry on every run', () => {
+  const out = compileNativeOutput('/out', { env: fakeEnv() });
+  const text = formatCompileReport(out).join('\n');
+  assert.match(text, /typechecked to bytecode/);
+  assert.match(text, /parsed only/);
+  assert.match(text, /UIKit/);
+});
+
+test('stub paths resolve relative to the module, not the working directory', () => {
+  assert.ok(STUB_DIR.startsWith('/'), 'STUB_DIR must be absolute');
+  assert.match(STUB_DIR, /ci\/stubs$/);
+});
+
+test('PLATFORMS names the two files the emitter writes', () => {
+  assert.deepEqual(PLATFORMS.map((p) => p.file), ['Tokens.kt', 'Tokens.swift']);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `node --test ci/compile-native-output.test.mjs`
+Expected: FAIL — `Cannot find module ... compile-native-output.mjs`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `ci/compile-native-output.mjs`:
+
+```js
+// Compiles generated native token output to prove it is buildable, not merely
+// well-formed. Kotlin typechecks to bytecode against ci/stubs/*.kt; Swift is
+// parsed only, because Tokens.swift imports UIKit and -typecheck must resolve
+// imports where -parse need not.
+//
+// Runs at e2e time, NOT in CI — see ci/README.md for that decision (#81).
+// Pure functions + CLI.
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readdirSync } from 'node:fs';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { tmpdir } from 'node:os';
+
+export const STUB_DIR = resolve(dirname(fileURLToPath(import.meta.url)), 'stubs');
+
+export const PLATFORMS = [
+  {
+    id: 'kotlin',
+    file: 'Tokens.kt',
+    compiler: 'kotlinc',
+    strength: 'typechecked to bytecode',
+  },
+  {
+    id: 'swift',
+    file: 'Tokens.swift',
+    compiler: 'swiftc',
+    strength: 'parsed only (UIKit unavailable; -typecheck impossible)',
+  },
+];
+
+export function compileNativeOutput(dir, { allowMissing = false, env } = {}) {
+  const results = [];
+  for (const platform of PLATFORMS) {
+    const source = join(dir, platform.file);
+    if (!env.fileExists(source)) {
+      results.push({ id: platform.id, status: 'absent', detail: `${platform.file} not present` });
+      continue;
+    }
+    if (!env.commandExists(platform.compiler)) {
+      results.push({
+        id: platform.id,
+        status: allowMissing ? 'skipped' : 'fail',
+        detail: `${platform.compiler} not found on PATH`,
+      });
+      continue;
+    }
+    const run = platform.id === 'kotlin' ? env.runKotlin(source) : env.runSwift(source);
+    if (run.code !== 0) {
+      results.push({ id: platform.id, status: 'fail', detail: run.stderr });
+    } else if (platform.id === 'kotlin' && !run.classProduced) {
+      results.push({
+        id: platform.id,
+        status: 'fail',
+        detail: 'kotlinc exited 0 but produced no Tokens.class',
+      });
+    } else {
+      results.push({ id: platform.id, status: 'pass', detail: platform.strength });
+    }
+  }
+  const compiled = results.filter((r) => r.status === 'pass').length;
+  const failed = results.filter((r) => r.status === 'fail').length;
+  return { results, exitCode: failed > 0 ? 1 : 0, compiled, failed };
+}
+
+const LABEL = { pass: 'PASS', fail: 'FAIL', absent: '----', skipped: 'SKIP' };
+
+export function formatCompileReport({ results }) {
+  const lines = ['compile-native-output — do the emitted native tokens build?', ''];
+  for (const r of results) {
+    lines.push(`  [${LABEL[r.status]}] ${r.id}: ${r.detail}`);
+  }
+  lines.push(
+    '',
+    '  Kotlin is typechecked to bytecode; Swift is parsed only. swiftc -typecheck',
+    '  cannot run here: Tokens.swift imports UIKit, which is unavailable on the',
+    '  macOS command line. Swift syntax is asserted; Swift types are not.',
+  );
+  return lines;
+}
+
+function findFile(dir, name) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (findFile(full, name)) return true;
+    } else if (entry.name === name) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function realEnv() {
+  return {
+    fileExists: (path) => existsSync(path),
+    commandExists(cmd) {
+      try {
+        execFileSync('which', [cmd], { stdio: 'ignore' });
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    runKotlin(source) {
+      const outDir = mkdtempSync(join(tmpdir(), 'tl-kotlinc-'));
+      const stubs = [join(STUB_DIR, 'compose-unit.kt'), join(STUB_DIR, 'compose-graphics.kt')];
+      try {
+        // execFileSync throws on a non-zero exit and carries stderr on the
+        // error. No shell, no pipe — a pipeline would report the wrong status.
+        execFileSync('kotlinc', [...stubs, source, '-d', outDir], {
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
+      } catch (err) {
+        return { code: err.status ?? 1, stderr: String(err.stderr ?? err.message).trim(), classProduced: false };
+      }
+      return { code: 0, stderr: '', classProduced: findFile(outDir, 'Tokens.class') };
+    },
+    runSwift(source) {
+      try {
+        execFileSync('swiftc', ['-parse', source], { stdio: ['ignore', 'pipe', 'pipe'] });
+      } catch (err) {
+        return { code: err.status ?? 1, stderr: String(err.stderr ?? err.message).trim() };
+      }
+      return { code: 0, stderr: '' };
+    },
+  };
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const allowMissing = args.includes('--allow-missing');
+  const dir = args.find((a) => !a.startsWith('--'));
+  if (!dir) {
+    console.error('usage: node ci/compile-native-output.mjs <dir> [--allow-missing]');
+    process.exit(2);
+  }
+  const outcome = compileNativeOutput(dir, { allowMissing, env: realEnv() });
+  for (const line of formatCompileReport(outcome)) console.log(line);
+  process.exit(outcome.exitCode);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test ci/compile-native-output.test.mjs`
+Expected: PASS, 8 tests.
+
+- [ ] **Step 5: Run the whole suite**
+
+Run: `node --test`
+Expected: PASS. The pre-existing count is 403; expect 411.
+
+- [ ] **Step 6: Smoke-test the CLI against real output**
+
+```bash
+node ci/compile-native-output.mjs /private/tmp/claude-501/-Users-jordansstudio-Dev-throughline/395cf4ed-9e55-4c18-a73d-e9980db4545c/scratchpad/e2e/out-52-head
+echo "exit=$?"
+```
+Expected: both `[PASS]`, the asymmetry paragraph, `exit=0`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ci/compile-native-output.mjs ci/compile-native-output.test.mjs
+git commit -m "feat: compile-verify generated native token output (#81)"
+```
+
+---
+
+## Task 3: The missing-compiler policy
+
+**Files:**
+- Modify: `ci/compile-native-output.mjs` (the `compileNativeOutput` return)
+- Test: `ci/compile-native-output.test.mjs` (append)
+
+**Interfaces:**
+- Consumes: `compileNativeOutput` from Task 2.
+- Produces: no new exports. `compileNativeOutput`'s `exitCode` gains one rule —
+  a run in which no platform actually compiled exits non-zero even when every
+  platform was skipped.
+
+Task 2 deliberately ships the incomplete rule (`exitCode: failed > 0 ? 1 : 0`),
+so this task's first test fails against real code rather than against a missing
+module.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `ci/compile-native-output.test.mjs`:
+
+```js
+test('a missing compiler fails the run by default', () => {
+  const out = compileNativeOutput('/out', { env: fakeEnv({ commands: ['swiftc'] }) });
+  assert.equal(byId(out.results, 'kotlin').status, 'fail');
+  assert.match(byId(out.results, 'kotlin').detail, /kotlinc not found/);
+  assert.equal(out.exitCode, 1);
+});
+
+test('--allow-missing downgrades one absent toolchain to a skip', () => {
+  const out = compileNativeOutput('/out', {
+    allowMissing: true,
+    env: fakeEnv({ commands: ['swiftc'] }),
+  });
+  assert.equal(byId(out.results, 'kotlin').status, 'skipped');
+  assert.equal(byId(out.results, 'swift').status, 'pass');
+  assert.equal(out.exitCode, 0, 'swift really compiled, so the run is meaningful');
+});
+
+test('--allow-missing does not excuse a run in which nothing compiled', () => {
+  const out = compileNativeOutput('/out', {
+    allowMissing: true,
+    env: fakeEnv({ commands: [] }),
+  });
+  assert.equal(out.compiled, 0);
+  assert.equal(out.exitCode, 1, 'a green run that verified nothing is the vacuous pass');
+});
+
+test('a directory holding neither output file fails rather than passing empty', () => {
+  const out = compileNativeOutput('/out', { env: fakeEnv({ present: [] }) });
+  assert.equal(out.compiled, 0);
+  assert.equal(out.exitCode, 1);
+});
+```
+
+- [ ] **Step 2: Run tests to verify the new ones fail**
+
+Run: `node --test ci/compile-native-output.test.mjs`
+Expected: the first two PASS (Task 2's code already handles them); the last two
+FAIL, both reporting `exitCode` was `0` where `1` was expected.
+
+- [ ] **Step 3: Change the exit rule**
+
+In `ci/compile-native-output.mjs`, replace this line:
+
+```js
+  return { results, exitCode: failed > 0 ? 1 : 0, compiled, failed };
+```
+
+with:
+
+```js
+  // A run that compiled nothing fails, whatever --allow-missing said. The flag
+  // tolerates one absent toolchain; it does not excuse the absence of both,
+  // which would be a green run that verified nothing.
+  return { results, exitCode: failed > 0 || compiled === 0 ? 1 : 0, compiled, failed };
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test ci/compile-native-output.test.mjs`
+Expected: PASS, 12 tests.
+
+- [ ] **Step 5: Run the whole suite**
+
+Run: `node --test`
+Expected: PASS, 415 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ci/compile-native-output.mjs ci/compile-native-output.test.mjs
+git commit -m "feat: a run that compiled nothing fails, --allow-missing notwithstanding (#81)"
+```
+
+---
+
+## Task 4: Document the runner and record the not-a-CI-gate decision
+
+**Files:**
+- Modify: `ci/README.md`
+
+**Interfaces:**
+- Consumes: the CLI from Tasks 2–3.
+- Produces: nothing code-level.
+
+- [ ] **Step 1: Add the runner to the "Run locally" block**
+
+In `ci/README.md`, find:
+
+```bash
+node --test                  # all tests
+node ci/validate-plugin.mjs  # guard plugin manifests
+node ci/validate-skills.mjs  # guard skill/command/manifest-doc structure
+```
+
+Add a fourth line:
+
+```bash
+node ci/compile-native-output.mjs <dir>  # compile generated Tokens.kt/.swift (not a CI gate)
+```
+
+- [ ] **Step 2: Append the decision section**
+
+Add at the end of `ci/README.md`:
+
+```markdown
+## Compile verification is not a CI gate
+
+`ci/compile-native-output.mjs` compiles generated native token output —
+`kotlinc` typechecks `Tokens.kt` to bytecode against `ci/stubs/*.kt`; `swiftc
+-parse` checks `Tokens.swift` syntax only, because it imports `UIKit` and
+`-typecheck` must resolve imports where `-parse` need not.
+
+It runs at e2e time, deliberately, and `.github/workflows/` does not call it.
+
+Producing `Tokens.kt` at all requires Style Dictionary, because `PLATFORMS` in
+`scripts/lib/sd-native.mjs` targets SD's stock formatters — this repo owns the
+transforms and the config, not the formatter. The repo also declares zero
+dependencies and has no lockfile, and `ubuntu-latest` carries neither toolchain.
+Gating would mean adding a dependency graph, a lockfile, a committed token
+fixture, a JDK, and a Swift toolchain — in order to prove that output compiles
+*under one pinned Style Dictionary version*, while the version a consumer
+actually runs stays invisible to us either way. The e2e harness builds real
+zygarden source, which is stronger evidence than that fixture would be.
+
+Reopen this deliberately if the tradeoff changes. Do not let it drift.
+
+Unlike the validators above, this module is **not** run by `node --test` against
+a real compiler: the test suite injects a fake environment, so the suite stays
+green on a runner with neither toolchain installed.
+```
+
+- [ ] **Step 3: Verify the structural gates still pass**
+
+Run: `node ci/validate-skills.mjs && node ci/validate-plugin.mjs && node --test`
+Expected: all PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ci/README.md
+git commit -m "docs: record why compile verification is not a CI gate (#81)"
+```
+
+---
+
+## Task 5: Scope the stale claim in the four e2e notes
+
+**Files:**
+- Modify: `docs/superpowers/notes/2026-08-21-native-config-e2e-results.md`
+- Modify: `docs/superpowers/notes/2026-08-23-native-literal-validity-e2e.md`
+- Modify: `docs/superpowers/notes/2026-08-24-hoist-dual-nodes-e2e.md`
+- Modify: `docs/superpowers/notes/2026-08-26-unitless-dimension-e2e.md`
+
+**Interfaces:**
+- Consumes: `ci/compile-native-output.mjs` exists (Tasks 2–3), so the notes can
+  cite it.
+- Produces: nothing code-level.
+
+**The one thing to get right.** `swiftc` and `kotlinc` must NOT be scoped
+identically. `kotlinc` was installed 2026-08-27 22:59; these notes are dated
+08-21 through 08-26, so it existed on the machine for none of them. A correction
+saying "both compilers were available" replaces a false implication with a false
+statement — the exact defect this work exists to prevent. See spec §6.
+
+**Do not touch any verdict.** The runs genuinely did not compile anything; that
+part of each record is accurate and stays.
+
+- [ ] **Step 1: Locate the claim in each file**
+
+Run: `grep -n "Nothing was compiled" docs/superpowers/notes/*.md`
+Expected: exactly four hits, one per file.
+
+- [ ] **Step 2: Replace the paragraph in each of the four files**
+
+Each occurrence sits in a "What this run does NOT establish" list and reads
+approximately:
+
+> - **Nothing was compiled.** No `swiftc` or `kotlinc` ran; the declaration and
+>   `.sp`/`.dp` counts are `grep`-based, not a compiler's verdict.
+
+Wording varies slightly between files. Preserve each file's surrounding list
+formatting and its own trailing clause; replace only the claim itself with:
+
+```markdown
+- **Nothing was compiled in this run.** No `swiftc` or `kotlinc` ran; the
+  declaration and `.sp`/`.dp` counts are `grep`-based, not a compiler's verdict.
+  `swiftc` was nonetheless available at `/usr/bin/swiftc` via the Xcode command
+  line tools when this run happened, and went unused — the Swift half of this
+  limitation was self-imposed. `kotlinc` was not available: it was installed on
+  2026-08-27, after this run. Later runs compile both, via
+  `ci/compile-native-output.mjs` (#81).
+```
+
+- [ ] **Step 3: Verify no note claims both compilers were available**
+
+Run:
+```bash
+grep -rn "oth compilers were" docs/superpowers/notes/ || echo "clean"
+```
+Expected: `clean`. Any hit is the §6 defect and must be fixed before committing.
+
+- [ ] **Step 4: Verify all four were updated and no verdict moved**
+
+Run:
+```bash
+grep -c "Nothing was compiled in this run" docs/superpowers/notes/*.md | grep -v ":0"
+git diff --stat
+```
+Expected: four files each with one hit; the diff touches only those four files.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/superpowers/notes/2026-08-21-native-config-e2e-results.md \
+        docs/superpowers/notes/2026-08-23-native-literal-validity-e2e.md \
+        docs/superpowers/notes/2026-08-24-hoist-dual-nodes-e2e.md \
+        docs/superpowers/notes/2026-08-26-unitless-dimension-e2e.md
+git commit -m "docs: the compile limitation was historical, and asymmetric (#81)"
+```
+
+---
+
+## Task 6: Baseline run against zygarden, with the control
+
+**Files:**
+- Create: `docs/superpowers/notes/2026-08-28-compile-verification-e2e.md`
+
+**Interfaces:**
+- Consumes: the CLI from Tasks 2–3, the stubs from Task 1.
+- Produces: the note. Nothing code-level.
+
+**The control matters more than the baseline.** A run whose only observed result
+is a pass cannot distinguish a working check from one that cannot fail — #73's
+durable lesson. Both halves must be recorded.
+
+- [ ] **Step 1: Locate or rebuild the harness**
+
+```bash
+H=/private/tmp/claude-501/-Users-jordansstudio-Dev-throughline/395cf4ed-9e55-4c18-a73d-e9980db4545c/scratchpad/e2e
+ls "$H/build.mjs" "$H/lib" && ls "$H/../tokens"/*.json | wc -l
+```
+Expected: `build.mjs` and `lib/` present, 15 token files.
+
+If it is gone, rebuild it from **spec §8.1**, which records Style Dictionary
+4.4.0, the token source at
+`/Users/jordansstudio/Dev/zygarden-frontend/libs/shared/util-tokens/src/tokens`,
+the `desktop`/`dark` filename filter, `packageName: 'com.zygarden.tokens'`, and
+`build.mjs` in full. Symlink `<harness>/lib/{dtcg,native-literal,sd-native}.mjs`
+into this checkout's `scripts/lib/` — **not** `scripts/lib`, which `build.mjs`
+never reads.
+
+- [ ] **Step 2: Build zygarden at this branch**
+
+```bash
+cd "$H" && node build.mjs ../tokens out-81-baseline && ls out-81-baseline
+```
+Expected: `Tokens.kt` and `Tokens.swift`.
+
+- [ ] **Step 3: Record the declaration counts**
+
+```bash
+grep -c '^  val ' "$H/out-81-baseline/Tokens.kt"
+grep -c 'public static let' "$H/out-81-baseline/Tokens.swift"
+```
+Expected: 208 Kotlin, 195 Swift (spec §8). A different count is a finding —
+record it rather than adjusting the prediction.
+
+- [ ] **Step 4: Run the baseline compile**
+
+```bash
+cd /Users/jordansstudio/Dev/throughline
+node ci/compile-native-output.mjs "$H/out-81-baseline"; echo "exit=$?"
+```
+Expected: `[PASS] kotlin`, `[PASS] swift`, `exit=0`. Capture the full output.
+
+- [ ] **Step 5: Run the control — it must FAIL**
+
+```bash
+mkdir -p /tmp/tl-control
+cat > /tmp/tl-control/Tokens.kt <<'EOF'
+package com.zygarden.tokens
+import androidx.compose.ui.unit.*
+object Tokens {
+  val letterSpacingTight = -0.03.em
+}
+EOF
+node ci/compile-native-output.mjs /tmp/tl-control --allow-missing; echo "exit=$?"
+```
+Expected: `[FAIL] kotlin` quoting `unresolved reference 'unaryMinus' for
+operator '-'`, and `exit=1`. **If this passes, the check is broken** — stop and
+investigate rather than recording the baseline as evidence.
+
+- [ ] **Step 6: Confirm the control's fixed form compiles**
+
+```bash
+sed -i '' 's/-0\.03\.em/(-0.03).em/' /tmp/tl-control/Tokens.kt
+node ci/compile-native-output.mjs /tmp/tl-control --allow-missing; echo "exit=$?"
+```
+Expected: `[PASS] kotlin`, `exit=0`. This is the #64 defect and its fix.
+
+- [ ] **Step 7: Write the note**
+
+Create `docs/superpowers/notes/2026-08-28-compile-verification-e2e.md`. Fill the
+bracketed slots from the transcripts captured in Steps 2-6 — paste them verbatim,
+do not summarise. Everything outside brackets is final text:
+
+````markdown
+# Compile verification (#81) — baseline and control against zygarden
+
+**Date:** 2026-08-28
+**Gate for:** Task 6 of the #81 plan — the committed runner
+(`ci/compile-native-output.mjs`) compiles real emitted output, and demonstrably
+fails on output that does not compile.
+**Verdict:** [PASS | FAIL] — [one sentence naming what held]
+
+## Why this run exists
+
+Four e2e notes claimed nothing could be compiled. Both compilers are in fact
+available (`swiftc` throughout; `kotlinc` since 2026-08-27), so the ceiling on
+what an e2e run asserts was lower than it needed to be. This run establishes the
+new ceiling and, more importantly, that the check can fail.
+
+## Harness
+
+[reused at <path>, or rebuilt per spec §8.1 — say which]
+
+- **Style Dictionary:** 4.4.0, installed in the harness directory.
+- **Source:** the 15 zygarden JSON files, light + mobile axes (the build drops
+  any filename containing `desktop` or `dark`).
+- **Module under test:** reached via
+  `<harness>/lib/{dtcg,native-literal,sd-native}.mjs` symlinked into this
+  checkout's `scripts/lib/`. Not `scripts/lib`, which `build.mjs` never reads —
+  the no-op #73 was filed over.
+- **Branch:** `feat/81-compile-verification` at [sha].
+
+## Procedure
+
+### Step 1 — build zygarden
+
+[transcript from plan Step 2]
+
+### Step 2 — declaration counts
+
+[transcript from plan Step 3]
+
+### Step 3 — baseline compile
+
+[transcript from plan Step 4]
+
+### Step 4 — the control, which must fail
+
+[transcript from plan Step 5]
+
+### Step 5 — the control's fixed form
+
+[transcript from plan Step 6]
+
+## Prediction vs. actual
+
+| Prediction | Actual |
+|---|---|
+| `Tokens.kt` compiles, exit 0, `Tokens.class` produced | [ ] |
+| `Tokens.swift` parses, exit 0 | [ ] |
+| 208 Kotlin declarations / 195 Swift | [ ] |
+| `-0.03.em` FAILS with `unresolved reference 'unaryMinus'` | [ ] |
+| `(-0.03).em` passes | [ ] |
+
+## What this run does NOT establish
+
+- **Swift is parsed, never typechecked.** `Tokens.swift` imports `UIKit`, which
+  is unavailable on the macOS command line, so `swiftc -typecheck` cannot run. A
+  Swift type error — a wrong `UIColor` initialiser arity, an `Int` where
+  `CGFloat` is required — passes this check. Only syntax is asserted.
+- **The Kotlin stubs are not Compose.** They are six declarations with matching
+  names and shapes (`Dp`, `TextUnit`, `.dp`, `.sp`, `.em`, `Color`). Real `Dp`
+  is a value class and real `Color` wraps a `ULong`; nothing beyond "this
+  expression resolves and typechecks" is covered.
+- **Neither compiler validates semantics.** `2.dp` where `2.sp` was meant
+  compiles. This closes the gap between "well-formed literal" and "compiles",
+  which is narrower than "correct" — `tokens:validate-output` and the e2e diff
+  remain the checks for whether the right thing was emitted.
+- **The harness is scratch and unowned.** It can vanish; only the runner and
+  stubs are repo assets. Spec §8.1 is what makes it rebuildable.
+````
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add docs/superpowers/notes/2026-08-28-compile-verification-e2e.md
+git commit -m "docs: e2e proof that zygarden's native output compiles, with a failing control (#81)"
+```
+
+---
+
+## Final verification
+
+- [ ] **All six CI gates pass**
+
+```bash
+node --test
+node ci/validate-plugin.mjs
+node ci/validate-skills.mjs
+node scripts/adapters/generate.mjs --check
+node scripts/build-doc-card-builder.mjs --check
+node scripts/build-native-adapter-config.mjs --check
+```
+Expected: all pass. `node --test` at 415.
+
+- [ ] **The constraints held**
+
+```bash
+git diff main --stat -- package.json .github/
+grep -n '"files"' -A 8 package.json
+ls package-lock.json node_modules 2>/dev/null || echo "no deps introduced"
+```
+Expected: no change to `package.json` or `.github/`; `files` still omits `ci/`;
+no lockfile, no `node_modules`.
+
+- [ ] **Open the PR**
+
+```bash
+gh pr create --base main --title "e2e runs compile their output, and four notes stop saying they cannot (#81)" --body "Closes #81"
+```

--- a/docs/superpowers/specs/2026-08-28-compile-verification-design.md
+++ b/docs/superpowers/specs/2026-08-28-compile-verification-design.md
@@ -139,6 +139,34 @@ committed token fixture, before any toolchain question arises.
 | 5 | `ci/README.md` — runner entry + the §7 decision | edit |
 | 6 | `docs/superpowers/notes/2026-08-28-compile-verification-e2e.md` | new note |
 
+### 3.1 The stub source, as measured
+
+Recorded here rather than left to re-derivation, because a spec arguing for
+measured artifacts over reconstructable prose should not make its own stubs
+reconstructable prose. This exact pair compiled zygarden's real output to
+bytecode during design.
+
+`ci/stubs/compose-unit.kt`:
+
+```kotlin
+package androidx.compose.ui.unit
+class Dp(val value: Double)
+class TextUnit(val value: Double)
+val Double.dp: Dp get() = Dp(this)
+val Double.sp: TextUnit get() = TextUnit(this)
+val Double.em: TextUnit get() = TextUnit(this)
+```
+
+`ci/stubs/compose-graphics.kt`:
+
+```kotlin
+package androidx.compose.ui.graphics
+class Color(val value: Long)
+```
+
+`Long`, not `Int` or `ULong`: `0xffffffff` is 4294967295, past `Int.MAX_VALUE`,
+so Kotlin types the literal `Long` and the constructor must accept one.
+
 `ci/` is the correct home: its README already states these are "**Not** copied
 into user repos — unlike `scripts/`, these guard *this plugin's* own structure",
 and `package.json`'s `files` omits `ci/` entirely. Nothing here reaches the
@@ -151,9 +179,11 @@ published tarball.
 Takes a directory holding `Tokens.kt` and/or `Tokens.swift`. For each file
 present:
 
-- **Kotlin** — `kotlinc ci/stubs/compose-unit.kt ci/stubs/compose-graphics.kt
-  <dir>/Tokens.kt -d <tmp>`. Passes only if the exit status is 0 **and** a
-  `Tokens.class` exists under `<tmp>`.
+- **Kotlin** — `kotlinc <stubs> <dir>/Tokens.kt -d <tmp>`. Passes only if the
+  exit status is 0 **and** a `Tokens.class` exists under `<tmp>`. **The stub
+  paths resolve relative to the runner module, not the working directory** —
+  via `import.meta.url` — because the intended caller is an e2e harness in a
+  scratchpad, where a cwd-relative `ci/stubs/...` resolves to nothing.
 - **Swift** — `swiftc -parse <dir>/Tokens.swift`. Passes on exit status 0.
 
 Rules:
@@ -167,6 +197,11 @@ Rules:
   was written about. `--allow-missing` downgrades it to a reported skip that does
   not affect the exit status — for a machine that genuinely has only one
   toolchain. It must be passed deliberately; it is never the default.
+- **A run in which nothing actually compiled fails, `--allow-missing`
+  notwithstanding.** At least one platform must have been really compiled for
+  the run to pass. Without this rule the flag produces a green run that verified
+  nothing, which is the same vacuous pass as §2.2 — the flag exists to tolerate
+  *one* absent toolchain, not to excuse the absence of both.
 - **An absent `Tokens.swift` is neither pass nor fail** — it is reported as not
   present. Absence of a file is not evidence about it.
 - **The compiler's own stderr is surfaced verbatim** on failure. #81's third
@@ -196,6 +231,12 @@ cover the runner's decision logic with an injected fake exec:
 Node 24 and nothing else; `node --test` has to stay green there with zero
 dependencies.
 
+This relies on bare `node --test` from the repo root discovering
+`ci/compile-native-output.test.mjs`, as it already discovers every other
+`ci/*.test.mjs`. Stated because it is load-bearing and `ci/README.md` records
+that discovery here has misfired before: the invocation is **bare `node --test`
+from the repo root**, never `node --test ci/`, which errors on Node >= 21.
+
 ## 6. The four note corrections
 
 Each of these carries one occurrence of the stale claim:
@@ -211,11 +252,19 @@ did not compile anything, and that part of the record is accurate. What changes
 is the false implication that compiling was impossible:
 
 > **Nothing was compiled in this run.** No `swiftc` or `kotlinc` ran; the
-> declaration counts are `grep`-based, not a compiler's verdict. Both compilers
-> were in fact available when this run happened — `swiftc` at `/usr/bin/swiftc`
-> via the Xcode command line tools throughout, `kotlinc` from 2026-08-27 — and
-> this run did not use them. Later runs compile: see
-> `ci/compile-native-output.mjs` (#81).
+> declaration counts are `grep`-based, not a compiler's verdict. `swiftc` was
+> nonetheless available at `/usr/bin/swiftc` via the Xcode command line tools
+> when this run happened, and went unused — the Swift half of this limitation
+> was self-imposed. `kotlinc` was not: it was installed on 2026-08-27, after
+> this run. Later runs compile both: see `ci/compile-native-output.mjs` (#81).
+
+**The two compilers must not be scoped identically, and getting this wrong was
+caught in review.** `kotlinc` was installed 2026-08-27 22:59; the four notes are
+dated 08-21 through 08-26, so it existed on the machine for none of them. A
+correction claiming "both compilers were available" would replace a false
+implication with a false statement — the exact defect this spec exists to
+prevent. #81's own text draws the distinction correctly; any edit that loses it
+is wrong.
 
 ## 7. The decision: not a CI gate
 
@@ -239,6 +288,51 @@ The e2e harness survived at
 token files in `../tokens`, and its `lib/*` symlinks pointing at this checkout.
 It is being reaped — several directories were emptied at 2026-08-28 00:00 — so
 this run also establishes whether it still works while it still does.
+
+### 8.1 If the harness is gone, rebuild it from this section
+
+Everything needed was captured during design, so §8 does not depend on a
+scratchpad surviving. Verified 2026-08-28:
+
+- **Style Dictionary 4.4.0**, installed locally in the harness directory. Not a
+  repo dependency and must not become one (§2.3).
+- **Token source:** `/Users/jordansstudio/Dev/zygarden-frontend` at
+  `libs/shared/util-tokens/src/tokens` — 15 `.json` files. Copy them out; do not
+  build inside the zygarden checkout. (The branch has moved since earlier runs —
+  it is `feature/new-home-page` now, not the `feature/apply-brandguide-styles`
+  named in the #52 spec. The 15 filenames still match.)
+- **Axis filter:** the build drops any filename containing `desktop` or `dark`,
+  leaving the light + mobile axes. This is why the baseline is one flat pair of
+  files and not four.
+- **`packageName`:** `com.zygarden.tokens`.
+- **The module under test is reached through `./lib/*.mjs`** — three per-file
+  symlinks to `dtcg.mjs`, `native-literal.mjs`, `sd-native.mjs` in this
+  checkout's `scripts/lib/`. **Not `scripts/lib`**, which `build.mjs` never
+  reads; repointing that is the no-op #73 was filed over (`ee95020`).
+
+`build.mjs` in full:
+
+```js
+import StyleDictionary from 'style-dictionary';
+import { registerNativeTransforms, nativePlatform, nativeSources } from './lib/sd-native.mjs';
+import { readdirSync } from 'node:fs';
+const TOK = process.argv[2];
+const OUT = process.argv[3];
+const files = readdirSync(TOK).filter(f => f.endsWith('.json') && !f.includes('desktop') && !f.includes('dark')).map(f => `${TOK}/${f}`);
+registerNativeTransforms(StyleDictionary);
+const sd = new StyleDictionary({
+  source: nativeSources(files),
+  preprocessors: ['dtcg/resolve-dual-node'],
+  platforms: {
+    kt: nativePlatform({ platform: 'android-kotlin', buildPath: `${OUT}/`, packageName: 'com.zygarden.tokens' }),
+    swift: nativePlatform({ platform: 'ios-swift', buildPath: `${OUT}/` }),
+  },
+});
+await sd.buildAllPlatforms();
+```
+
+Rebuilding is a fallback, not a fresh baseline: a rebuilt harness proves the same
+thing only if the declaration counts in §8's table still hold.
 
 Build zygarden at `main`, compile both outputs, record in the new note.
 Prediction, to be checked against actual bytes rather than reasoning:
@@ -269,8 +363,8 @@ broken run regardless of what the baseline reported.
   wrong `UIColor` initialiser arity, an `Int` where `CGFloat` is required — will
   pass. Only syntax is asserted. Closing this needs an iOS SDK and a real
   destination target, which is out of proportion here.
-- **The Kotlin stubs are not Compose.** They are five declarations with matching
-  names and shapes. Real `Dp` is a value class with operators and real `Color` a
+- **The Kotlin stubs are not Compose.** They are six declarations with matching
+  names and shapes — `Dp`, `TextUnit`, `.dp`, `.sp`, `.em`, `Color` (§3.1). Real `Dp` is a value class with operators and real `Color` a
   `ULong` wrapper; behaviour differences beyond "this expression resolves and
   typechecks" are not covered.
 - **Neither compiler validates semantics.** `2.dp` where `2.sp` was meant

--- a/docs/superpowers/specs/2026-08-28-compile-verification-design.md
+++ b/docs/superpowers/specs/2026-08-28-compile-verification-design.md
@@ -1,0 +1,292 @@
+# Compile verification for native token output — design
+
+**Issue:** [#81](https://github.com/jrpease/throughline/issues/81) — e2e runs can
+compile their output now; four notes still say they cannot
+**Date:** 2026-08-28
+**Base branch:** `main` (`e45afc4`). No open PRs, so this does not stack.
+
+## 1. What is actually available, measured
+
+Both compilers were run against zygarden's real emitted output during this
+design, not inspected or assumed.
+
+| tool | version | path |
+|---|---|---|
+| `swiftc` | Apple Swift 6.3.2 (`swift-driver` 1.148.6) | `/usr/bin/swiftc` |
+| `kotlinc` | kotlinc-jvm 2.4.10 (JRE 26.0.2.1) | `/opt/homebrew/bin/kotlinc` |
+
+**Kotlin typechecks to real bytecode.** Against the 195-declaration
+`out-52-head/Tokens.kt` from the surviving e2e harness — that build predates
+#64, so it is 195 declarations, not `main`'s current 208 (§8):
+
+```
+$ kotlinc compose-stubs.kt compose-stubs-graphics.kt Tokens.kt -d out2   # scratch names; committed as ci/stubs/compose-{unit,graphics}.kt per §3
+kotlinc exit=0
+$ find out2 -name '*.class'
+out2/com/zygarden/tokens/Tokens.class
+out2/androidx/compose/ui/unit/Dp.class
+out2/androidx/compose/ui/unit/TextUnit.class
+out2/androidx/compose/ui/unit/Compose_stubsKt.class
+out2/androidx/compose/ui/graphics/Color.class
+```
+
+**Swift parses only, and the reason is exact:**
+
+```
+$ swiftc -parse Tokens.swift      # exit=0
+$ swiftc -typecheck Tokens.swift  # exit=1
+Tokens.swift:9:8: error: no such module 'UIKit'
+```
+
+`Tokens.swift` opens `import UIKit` and every colour is a `UIColor(...)`.
+`-parse` does not resolve imports, so it succeeds; `-typecheck` must, so it
+cannot. This is a property of the platform, not a gap to close later.
+
+### 1.1 How much each mode actually catches
+
+Measured on the two literals #70 turned on, because "compiles" is not one
+strength across the two platforms:
+
+| literal | Swift `-parse` | Kotlin |
+|---|---|---|
+| `.5` | **rejected** — "'.5' is not a valid floating point literal; it must be written '0.5'" | **accepted**, `.class` produced |
+| `0100` | **accepted** | **rejected** — "leading zeros are not allowed in integer literals" |
+
+Exactly opposite, as #81 states. This is the measured basis for #70's
+per-platform rule, and it means neither compiler subsumes the other even at the
+literal level. Swift's parse-only mode is weaker than Kotlin's typecheck about
+*types*, but it is not weaker about *syntax* — it catches a class of literal
+defect Kotlin accepts.
+
+## 2. Three corrections to the issue's own text
+
+All three measured, all three change what this spec must do.
+
+### 2.1 The stub set in the issue is insufficient, and cannot be one file
+
+#81 gives roughly ten lines covering `androidx.compose.ui.unit` — `Dp`,
+`TextUnit`, and the `.dp` / `.sp` / `.em` extension properties. Run against real
+output, that set fails:
+
+```
+Tokens.kt:9:28: error: unresolved reference 'graphics'.
+import androidx.compose.ui.graphics.Color
+Tokens.kt:13:23: error: unresolved reference 'Color'.
+  val colorBgCanvas = Color(0xffffffff)
+```
+
+Real output also imports `androidx.compose.ui.graphics.Color` and emits
+`Color(0xffffffff)`. Colours are the largest single category of token, so the
+issue's stub set fails on essentially every real design system, not an edge
+case.
+
+**And it must be two files.** A Kotlin source file carries exactly one `package`
+declaration, so `androidx.compose.ui.unit` and `androidx.compose.ui.graphics`
+cannot share one. The issue's "the stub file", singular, is not achievable.
+
+The colour literal also fixes the stub's type: `0xffffffff` is 4294967295, past
+`Int.MAX_VALUE`, so Kotlin types it `Long` and the stub must be
+`class Color(val value: Long)`.
+
+### 2.2 There is no "e2e procedure" to add a step to
+
+#81's step 2 says to add a compile step "to the e2e procedure". No such durable
+artifact exists. Every e2e run is recorded in its own dated note describing the
+harness that ran it; there is no canonical procedure document, and
+`docs/superpowers/` holds only `notes/`, `plans/`, and `specs/`.
+
+**That absence is a prior decision, not an oversight.** #73 investigated whether
+#55 and #60's evidence was vacuous, and `ee95020` resolved it by scoping the
+procedure text to the harness that ran it. The finding: the recorded steps were
+correct at 10:22 on 2026-08-24 and a silent no-op by 13:46 the same day, when
+`build.mjs` was rewritten to import `./lib/sd-native.mjs`. #52's plan inherited
+the stale text four days later and nearly recorded a false PASS.
+
+The lesson generalises directly to #81: **prose procedure rots silently;
+executable code fails loudly.** A documented compile step is the same artifact
+that already failed once. So the reusable thing must be a committed, runnable
+script, and the notes cite it rather than describe it.
+
+This is also why #81 exists at all — a claim about tooling ("nothing was
+compiled") lived in prose across four notes and went stale without anything
+detecting it.
+
+### 2.3 CI gating is not a toolchain question
+
+#81's step 4 frames the CI decision as needing "a JDK on the runner and the stubs
+to be maintained". The blocker is earlier than that.
+
+`PLATFORMS` in `scripts/lib/sd-native.mjs:365,380` targets Style Dictionary's
+**stock** formatters — `ios-swift/enum.swift` and `compose/object`. ThroughLine
+owns the transforms and the config; it does not own the formatter. There is no
+code path that produces `Tokens.kt` text without Style Dictionary running.
+
+And the repo declares **zero dependencies, with no lockfile and no
+`node_modules`** — deliberately, per `package.json`. So a CI compile gate needs
+Style Dictionary added as a devDependency plus a lockfile plus `npm ci`, plus a
+committed token fixture, before any toolchain question arises.
+
+§7 records the decision this leads to.
+
+## 3. What lands
+
+| # | artifact | kind |
+|---|---|---|
+| 1 | `ci/compile-native-output.mjs` | new runner |
+| 2 | `ci/stubs/compose-unit.kt`, `ci/stubs/compose-graphics.kt` | new stubs |
+| 3 | `ci/compile-native-output.test.mjs` | new tests |
+| 4 | four e2e notes, claim scoped to when it was true | edit |
+| 5 | `ci/README.md` — runner entry + the §7 decision | edit |
+| 6 | `docs/superpowers/notes/2026-08-28-compile-verification-e2e.md` | new note |
+
+`ci/` is the correct home: its README already states these are "**Not** copied
+into user repos — unlike `scripts/`, these guard *this plugin's* own structure",
+and `package.json`'s `files` omits `ci/` entirely. Nothing here reaches the
+published tarball.
+
+## 4. The runner's contract
+
+`node ci/compile-native-output.mjs <dir> [--allow-missing]`
+
+Takes a directory holding `Tokens.kt` and/or `Tokens.swift`. For each file
+present:
+
+- **Kotlin** — `kotlinc ci/stubs/compose-unit.kt ci/stubs/compose-graphics.kt
+  <dir>/Tokens.kt -d <tmp>`. Passes only if the exit status is 0 **and** a
+  `Tokens.class` exists under `<tmp>`.
+- **Swift** — `swiftc -parse <dir>/Tokens.swift`. Passes on exit status 0.
+
+Rules:
+
+- **The asymmetry is printed every run**, not documented. Output reads
+  `Kotlin: typechecked to bytecode` / `Swift: parsed only (UIKit unavailable;
+  -typecheck impossible)`. Every future e2e note then carries the caveat as part
+  of its own transcript, which is the specific failure mode §2.2 describes.
+- **A missing compiler is a failure**, not a skip. A silent skip is the
+  "verification that cannot fail reads identically to one that passed" shape #73
+  was written about. `--allow-missing` downgrades it to a reported skip that does
+  not affect the exit status — for a machine that genuinely has only one
+  toolchain. It must be passed deliberately; it is never the default.
+- **An absent `Tokens.swift` is neither pass nor fail** — it is reported as not
+  present. Absence of a file is not evidence about it.
+- **The compiler's own stderr is surfaced verbatim** on failure. #81's third
+  finding is that the compilers' error text is better evidence than any
+  paraphrase.
+- Exit non-zero if any present platform failed.
+
+**Implementation note.** Exit status must be read from the compiler process
+directly, never through a pipe — during this design `kotlinc ... | head`
+reported `exit=0` while `kotlinc` itself had failed, because the shell reports
+the last command in the pipeline. That is the same false-pass shape as
+everything else in this spec.
+
+## 5. Testing
+
+`ci/` is stdlib-only and every module there has a `.test.mjs` sibling. The tests
+cover the runner's decision logic with an injected fake exec:
+
+- missing compiler → fails; with `--allow-missing` → reports skipped
+- `kotlinc` exit 0 but no `Tokens.class` → fails (guards the "compiles" claim
+  against an empty output directory)
+- Kotlin fails, Swift passes → overall non-zero, both verdicts still reported
+- `Tokens.swift` absent → reported as not present, not as a pass
+- compiler stderr appears in output
+
+**The test suite never invokes a real compiler.** CI is `ubuntu-latest` with
+Node 24 and nothing else; `node --test` has to stay green there with zero
+dependencies.
+
+## 6. The four note corrections
+
+Each of these carries one occurrence of the stale claim:
+
+- `2026-08-21-native-config-e2e-results.md`
+- `2026-08-23-native-literal-validity-e2e.md`
+- `2026-08-24-hoist-dual-nodes-e2e.md`
+- `2026-08-26-unitless-dimension-e2e.md`
+
+The verdicts stand and are not touched. The claim is **scoped to when it was
+true**, the same treatment `ee95020` gave the #55 procedure — the run genuinely
+did not compile anything, and that part of the record is accurate. What changes
+is the false implication that compiling was impossible:
+
+> **Nothing was compiled in this run.** No `swiftc` or `kotlinc` ran; the
+> declaration counts are `grep`-based, not a compiler's verdict. Both compilers
+> were in fact available when this run happened — `swiftc` at `/usr/bin/swiftc`
+> via the Xcode command line tools throughout, `kotlinc` from 2026-08-27 — and
+> this run did not use them. Later runs compile: see
+> `ci/compile-native-output.mjs` (#81).
+
+## 7. The decision: not a CI gate
+
+Recorded in `ci/README.md` with its reasoning, so that reopening it is a
+deliberate act rather than drift:
+
+> Compile verification runs at e2e time, not in CI. Producing `Tokens.kt` at all
+> requires Style Dictionary, because the config targets SD's stock formatters
+> (§2.3); the repo declares zero dependencies and has no lockfile; and
+> `ubuntu-latest` carries neither toolchain. Gating would mean adding a
+> dependency graph, a lockfile, a committed token fixture, a JDK, and a Swift
+> toolchain — to prove that output compiles *under one pinned SD version*, while
+> the version a consumer actually runs stays invisible to us either way. The e2e
+> harness builds real zygarden source, which is stronger evidence than that
+> fixture would be.
+
+## 8. Baseline run, and the falsifiable prediction
+
+The e2e harness survived at
+`395cf4ed-.../scratchpad/e2e` with Style Dictionary installed, all 15 zygarden
+token files in `../tokens`, and its `lib/*` symlinks pointing at this checkout.
+It is being reaped — several directories were emptied at 2026-08-28 00:00 — so
+this run also establishes whether it still works while it still does.
+
+Build zygarden at `main`, compile both outputs, record in the new note.
+Prediction, to be checked against actual bytes rather than reasoning:
+
+| prediction | how it fails |
+|---|---|
+| `Tokens.kt` compiles, exit 0, `Tokens.class` produced | any `kotlinc` diagnostic |
+| `Tokens.swift` parses, exit 0 | any `swiftc -parse` diagnostic |
+| declaration count is 208 Kotlin / 195 Swift | count line disagrees |
+
+**And the control, which matters more than the pass.** #73's durable lesson is
+that a procedure predicting an absence cannot distinguish a sound run from a
+broken one. So the run also feeds the runner known-bad input and requires a
+failure — measured during this design:
+
+```
+val letterSpacingTight = -0.03.em     -> exit=1
+  error: unresolved reference 'unaryMinus' for operator '-'.
+val letterSpacingTight = (-0.03).em   -> exit=0
+```
+
+That is the #64 defect exactly. A run where the control does not fail is a
+broken run regardless of what the baseline reported.
+
+## 9. Limitations, stated rather than hidden
+
+- **Swift is parsed, never typechecked.** A type error in `Tokens.swift` —
+  wrong `UIColor` initialiser arity, an `Int` where `CGFloat` is required — will
+  pass. Only syntax is asserted. Closing this needs an iOS SDK and a real
+  destination target, which is out of proportion here.
+- **The Kotlin stubs are not Compose.** They are five declarations with matching
+  names and shapes. Real `Dp` is a value class with operators and real `Color` a
+  `ULong` wrapper; behaviour differences beyond "this expression resolves and
+  typechecks" are not covered.
+- **Neither compiler validates semantics.** `2.dp` where `2.sp` was meant
+  compiles. This closes the gap between "well-formed literal" and "compiles",
+  which is narrower than "correct" — `tokens:validate-output` and the e2e diff
+  remain the checks for whether the right thing was emitted.
+- **The harness is scratch and unowned.** Nothing in this spec makes the e2e
+  harness durable; it remains a scratchpad artifact that can vanish. The runner
+  and stubs are the only parts that become repo assets.
+
+## 10. Out of scope
+
+- **#77** — discriminating fixtures for absence-shaped PASS conditions. Cited as
+  the source of §8's control, not implemented.
+- **#80** — the `release.yml` gate gap.
+- Every native token fix: #63, #67, #71, #72, #75.
+- Promoting the runner to `scripts/` for consumers. Decided against in design:
+  ThroughLine declares no dependencies and cannot assume a consumer has either
+  toolchain, and there is no demand on record.


### PR DESCRIPTION
Closes #81.

Four e2e notes claimed compiling the generated native token output was impossible. That stopped being true and nothing noticed — which is the same failure mode the notes themselves were written about. This adds a committed compile checker, records why it is deliberately not a CI gate, corrects the four notes, and proves the checker against a real design system.

## What lands

- **`ci/compile-native-output.mjs`** — pure decision function plus a thin CLI, matching the existing `ci/` idiom. `kotlinc` typechecks `Tokens.kt` to real bytecode against `ci/stubs/*.kt`; `swiftc -parse` checks `Tokens.swift` syntax.
- **`ci/stubs/compose-unit.kt`, `ci/stubs/compose-graphics.kt`** — two files, not one: a Kotlin source file carries exactly one `package` declaration.
- **`ci/README.md`** — the not-a-CI-gate decision, with its reasoning, so reopening it is deliberate rather than drift.
- **Four corrected notes**, plus a new e2e note recording a baseline run and a failing control.

## The decision worth reviewing

Compile verification runs at e2e time, not in CI. The blocker is earlier than the toolchain: `PLATFORMS` targets Style Dictionary's *stock* formatters, so no code path here produces `Tokens.kt` without SD running, and the repo declares zero dependencies with no lockfile. Gating would prove output compiles *under one pinned SD version* while the version a consumer actually runs stays invisible either way.

## Corrections the work forced

- **#81's stub set does not work.** Real output imports `androidx.compose.ui.graphics.Color` and emits `Color(0xffffffff)`; the issue's unit-only stubs fail on every colour token.
- **The two compilers must not be scoped identically.** `swiftc` was available throughout and went unused; `kotlinc` was installed 2026-08-27, after all four runs. An earlier draft said "both were available" — a false statement replacing a false implication, caught in review.
- **Swift's parse-only mode is not uniformly weaker.** `swiftc -parse` rejects `.5` while Kotlin accepts it; `0100` is exactly reversed. Neither subsumes the other, which is the measured basis for #70's per-platform rule.

## Evidence

Real zygarden output compiles: 208 Kotlin declarations, 195 Swift — the predicted numbers. The control fails as required: `-0.03.em` gives `unresolved reference 'unaryMinus'`, `(-0.03).em` passes. That is the #64 defect reproduced.

Whole-branch review caught three things no per-task review could see, all fixed here: the checker's own failure output read like success; `typechecked to bytecode` did not disclose it linked against stubs rather than Compose (output real Compose rejects was passing); and a non-default `className` — a public option — was falsely reported broken.

## Verification

421/421 tests, all six CI gates pass. No dependency, lockfile, or `node_modules` added; `package.json` and `.github/` untouched; `files[]` still omits `ci/`, so nothing here ships to consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018etbNQyHfuuGWwmd88T8Zm