### PR TITLE
release.yml runs CI's full gate set, and a test keeps it that way (#80)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,8 @@ jobs:
         run: node scripts/adapters/generate.mjs --check
       - name: Check doc-card builder is up to date
         run: node scripts/build-doc-card-builder.mjs --check
+      - name: Check native adapter config doc is up to date
+        run: node scripts/build-native-adapter-config.mjs --check
       - name: Extract release notes
         run: node ci/extract-changelog.mjs "${GITHUB_REF_NAME#v}" > "$RUNNER_TEMP/notes.md"
       - name: Update npm (trusted publishing needs npm >= 11.5)

--- a/ci/workflow-gates.test.mjs
+++ b/ci/workflow-gates.test.mjs
@@ -1,0 +1,90 @@
+// Guards the invariant #80 was filed over. `release.yml` deliberately re-runs
+// CI's whole gate set before `npm publish` rather than trusting that ci.yml
+// already passed — defence against tagging a commit whose CI never ran on that
+// exact tree. But the two lists are maintained by hand, and they have silently
+// diverged once: 84ff150 added the doc-card gate to both files, 07a1b07 (#50)
+// then added the native-adapter-config gate to ci.yml only. This test fails on
+// the next one.
+//
+// The rule is one-way: every command ci.yml runs must also run in release.yml.
+// release.yml's extras — the tag-version check, changelog extraction, publish —
+// are its own business and unconstrained.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const WORKFLOWS = fileURLToPath(new URL('../.github/workflows/', import.meta.url));
+
+const readWorkflow = (name) => readFileSync(`${WORKFLOWS}${name}`, 'utf8');
+
+// Pulls every `run:` value out of a workflow file by line. This is not a YAML
+// parser and must not become one — `ci/` is stdlib-only, and these two files
+// are ours. `multiline` counts the block forms (`run: |`, `run: >`) whose body
+// this cannot read; a caller that ignores that count has a blind spot.
+function runCommands(yaml) {
+  const commands = [];
+  let multiline = 0;
+  for (const line of yaml.split('\n')) {
+    const match = /^\s*run:\s*(.*)$/.exec(line);
+    if (!match) continue;
+    const value = match[1].trim();
+    if (value === '' || value === '|' || value === '>') multiline += 1;
+    else commands.push(value);
+  }
+  return { commands, multiline };
+}
+
+test('runCommands reads single-line commands and counts the block forms', () => {
+  const { commands, multiline } = runCommands(
+    [
+      'steps:',
+      '  - name: One',
+      '    run: node --test',
+      '  - name: Two',
+      '    run: |',
+      '      echo not read',
+      '  - name: Three',
+      '    run: >',
+      '      echo also not read',
+      '  - name: Four',
+      '    run: node ci/validate-plugin.mjs',
+    ].join('\n'),
+  );
+  assert.deepEqual(commands, ['node --test', 'node ci/validate-plugin.mjs']);
+  assert.equal(multiline, 2);
+});
+
+test('the parser finds ci.yml real commands', () => {
+  const { commands } = runCommands(readWorkflow('ci.yml'));
+  assert.ok(commands.length > 0, 'found no commands in ci.yml — the parser has stopped working');
+  assert.ok(commands.includes('node --test'), 'ci.yml should run the test suite');
+});
+
+test('ci.yml uses no multi-line run blocks', () => {
+  const { multiline } = runCommands(readWorkflow('ci.yml'));
+  assert.equal(
+    multiline,
+    0,
+    'ci.yml gained a `run: |` or `run: >` block. This parser cannot read inside one, so the ' +
+      'parity check below would silently stop covering that gate. Make it a single-line `run:`, ' +
+      'or teach the parser block scalars.',
+  );
+});
+
+test('every command ci.yml runs also runs in release.yml', () => {
+  const ci = runCommands(readWorkflow('ci.yml')).commands;
+  const release = new Set(runCommands(readWorkflow('release.yml')).commands);
+  const missing = ci.filter((command) => !release.has(command));
+  assert.deepEqual(
+    missing,
+    [],
+    `release.yml does not re-run ${missing.length} of CI's gates:\n` +
+      missing.map((command) => `  ${command}`).join('\n') +
+      '\n\nrelease.yml runs the full gate set before publishing, so a gate added to ci.yml ' +
+      'belongs there too. Add the step, matching the existing naming. Comparison is exact, ' +
+      'so the two files must spell the command identically. If a gate genuinely should not ' +
+      'run at release time, that is a decision to make deliberately and record — not to ' +
+      'leave as a silent difference.',
+  );
+});


### PR DESCRIPTION
Closes #80.

## What was wrong

`release.yml` re-runs CI's gates before `npm publish` on purpose — it does not trust that ci.yml already passed, which is what protects against tagging a commit whose CI never ran on that exact tree. It was running five of six.

The missing gate checked `references/native-adapter-config.md`. That file **ships in the published tarball** (`references/` is in `package.json`'s `files`) and is generated from the entire body of `scripts/lib/sd-native.mjs` interleaved with prose held in `scripts/build-native-adapter-config.mjs` — so the two sources can disagree while the doc is still a faithful render of one of them. `--check` is what catches that, and it was the one gate the release path skipped.

**Honest exposure:** not an open hole in practice. ci.yml runs on every push to `main`, so a tag on main's tip was covered, and v0.16.0 was verified that way. The gap was a tag pushed at a commit main's CI never validated.

**It was drift, not a decision** — verified in git, not taken from the issue text:

| commit | ci.yml | release.yml |
|---|:--:|:--:|
| `84ff150` added the doc-card gate | ✅ | ✅ |
| `07a1b07` (#50) added the native-config gate | ✅ | — |
| release.yml touched since `84ff150` | | never |

So the convention was established and then not followed, rather than reconsidered.

## What lands

**`.github/workflows/release.yml`** — the missing step, after the doc-card step, matching the existing naming.

**`ci/workflow-gates.test.mjs`** — closes the mechanism, not just the instance. The two gate lists are maintained by hand and have now silently diverged once; this makes the next divergence a hard test failure.

The invariant is one-way: **every command ci.yml runs must also appear in release.yml.** release.yml's extras — the tag-version check, changelog extraction, `npm publish` — are its own business and unconstrained.

It rides on `node --test`, which both workflows already run, so it costs zero workflow lines and guards itself at release time too.

**It is not a YAML parser and must not become one** — `ci/` is stdlib-only and these two files are ours. It reads `run:` values by line and *counts* the block forms (`run: |`, `run: >`) whose body it cannot see. A separate test fails if ci.yml ever gains one, because a parity check with a silent blind spot is worse than no parity check.

Four tests: the line reader against a fixture; ci.yml has no block scalars; the reader actually found ci.yml's real commands (non-empty and includes `node --test`, so a refactor cannot leave a check that quietly passes on an empty list); and the parity invariant itself, whose failure names the missing commands and says what to do about them.

## Verification

- **The parity test was red before the fix**, naming `node scripts/build-native-adapter-config.mjs --check` exactly. That run was the reproduction.
- `node --test` — **407 pass, 0 fail** (403 on `main`, + 4).
- All five non-test gates PASS locally.
- Both workflow files parsed with PyYAML rather than eyeballed: ci.yml 8 steps, release.yml 13.
- **Both guards mutation-tested.** Injecting a `run: |` block into ci.yml fails the blind-spot test; ci.yml restored to a clean diff afterward.

## Notes

No CHANGELOG entry — matching `fb7a0c9` and `1d8f343`, the repo's precedent for release/CI-infrastructure commits.

No `ci/README.md` change: its "What runs in CI" list is scoped to the `ci/` validators and already omits the three `scripts/` `--check` gates, so a workflow-parity note would be off-topic there. The reasoning lives in the test file's header comment.

The comparison is exact-string, so the same command spelled differently in the two files also fails. For a mirror maintained by hand that points at something worth fixing; the failure message says so.

**The alternative not taken:** a composite action holding the six gates, used by both workflows, would make divergence *impossible* rather than *caught*. It was considered and declined for now — it means reading ci.yml no longer tells you what runs, and it introduces a pattern the repo currently has none of. Still available later if hand-mirroring gets tiresome.

Independent of #82 — zero file overlap, either can land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018etbNQyHfuuGWwmd88T8Zm