### PR TITLE
Infer a typographic role from the reference graph (#63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,14 @@ to [Semantic Versioning](https://semver.org).
   system**, and *which* nine depends on the mode set the build includes — the
   inference reads the reference graph of the files in that build, so a primitive
   referenced only from a desktop typography file is typographic in a desktop
-  build and not in a mobile one. Swift is unchanged, byte for byte; the sp/dp
-  distinction is Compose-only.
+  build and not in a mobile one, and the reverse holds too: on the same source,
+  `text.lg` is referenced only from the mobile file and `text.6xl` only from the
+  desktop one, a straight swap rather than one stray token, and the count of
+  nine is identical on both pins even though the set is not. Swift is unchanged,
+  byte for byte; the sp/dp distinction is Compose-only. To decline the
+  inference for a specific token, stamp
+  `$extensions["com.radicool.throughline"].nativeUnit` to `"device"` (or any
+  value other than `"text"`) on it in source.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Breaking
+
+- **A scale primitive referenced only by typographic members now emits `sp`, not
+  `dp`.** `text.base: "16px"` was a font size only to a human; its role is now
+  taken from the reference graph. On Android the symbol's type changes from `Dp`
+  to `TextUnit`, so a use site like `Modifier.padding(Tokens.textBase)` stops
+  compiling — verified with `kotlinc`, which accepts that line against the old
+  output and rejects it against the new one. That is the point: those symbols
+  were always font sizes. **Nine Kotlin symbols changed on a real 322-token
+  system**, and *which* nine depends on the mode set the build includes — the
+  inference reads the reference graph of the files in that build, so a primitive
+  referenced only from a desktop typography file is typographic in a desktop
+  build and not in a mobile one. Swift is unchanged, byte for byte; the sp/dp
+  distinction is Compose-only.
+
+### Fixed
+
+- **An `em` letter-spacing primitive reaches Compose instead of being dropped.**
+  #64 made `em` emit as a real `.em` TextUnit but only where the role was
+  stamped, which reached the `typography.textStyle.*` members and not the
+  primitives they reference. The graph now reaches those too — three new Kotlin
+  declarations, and Android unmatched source tokens fall from 6 to 3 on the same
+  system.
+
+### Added
+
+- **`tokens:validate-output` names the primitives the graph could not reach.**
+  A dimension nothing references has no structural signal, so no role is
+  inferred — `unreferenced-text-sibling` names it and points at the
+  `$extensions` stamp that settles it. `ambiguous-text-role` names a token
+  referenced by both a typographic and a non-typographic member, which is
+  declined rather than guessed. Both are advisories: reported, never gating.
+
 ## [0.16.0] — 2026-08-27
 
 ### Breaking

--- a/docs/superpowers/notes/2026-08-28-text-role-inference-e2e.md
+++ b/docs/superpowers/notes/2026-08-28-text-role-inference-e2e.md
@@ -1,0 +1,341 @@
+# Text-role inference — end-to-end verification results
+
+**Date:** 2026-08-28
+**Gate for:** #63, the changelog entry that follows it
+**Verdict:** PASS on three of §6's four rows, and a **finding on the fourth**.
+The predicted "nine or ten Kotlin symbols change type, mode-dependent" is
+**nine in both viewport pins** — but a *different* nine. Ten is not reachable by
+any single build. Detail under "Where the measurement disagrees with the spec".
+
+Unit tests prove `textRoleGraph`, `preprocess` and the two advisories behave.
+This run proves Style Dictionary *consumes* them: eight real builds from
+zygarden's DTCG source — before and after, × two viewport pins, × light and dark
+— each validated with `tokens:validate-output` and each compiled.
+
+## Harness
+
+- **Style Dictionary:** `4.4.0` (fresh `npm i style-dictionary@4` in a scratch
+  directory outside this repo; nothing from the throughline tree, and the repo
+  gained no dependency, lockfile or `node_modules`).
+- **Installed by copy, not symlink.**
+- **Source:** `zygarden-frontend`, branch `feature/apply-brandguide-styles`
+  (`480ee9ec`), `libs/shared/util-tokens/src/tokens/` — **15 JSON files, 322
+  `$value` entries**, matching the 2026-08-21 run exactly. Extracted read-only
+  with `git -C … show <branch>:<path>`. That repository was never checked out or
+  modified; it stayed on its own unrelated branch throughout.
+- **Before/after in one harness.** The `after` tree is this branch's working
+  copy; the `before` tree is the same files extracted read-only from `main`
+  (`git show main:…`). Both were built against the identical 15 files, so every
+  delta below is the branch's, not a source or harness difference.
+
+### The install list was stale — a four-file list, not three
+
+The 2026-08-21 note records the install list as exactly three files. **It is now
+four.** Both `sd-native.mjs` and `validate-token-output.mjs` statically import a
+fourth sibling, `scripts/lib/native-literal.mjs`, added by #70 and present on
+`main` since 0.16.0. Installing only the documented three fails at import:
+
+```
+Error [ERR_MODULE_NOT_FOUND]: Cannot find module '…/scripts/lib/native-literal.mjs'
+imported from …/scripts/lib/sd-native.mjs
+```
+
+That was reproduced deliberately by removing the file from a working install.
+
+**This is a stale *note*, not a stale shipping instruction.** The generated,
+CI-gated `references/native-adapter-config.md` already names
+`lib/native-literal.mjs` as a required sibling (lines 21 and 48), so a consumer
+following the shipped docs installs the right set. The three-file list in the
+2026-08-21 note predates #70 and should not be copied forward again.
+
+The staleness is **not** this branch's: this branch's new code lives entirely in
+`scripts/lib/dtcg.mjs`, `scripts/lib/sd-native.mjs` and
+`scripts/validate-token-output.mjs`, all already on the list, and it adds no new
+module. The four-file list is complete for this branch — no other import outside
+`node:*` exists in any of the four.
+
+### `ci/compile-native-output.mjs` is not on this branch
+
+The compile checker (#81) is **not merged**. It exists only on
+`feat/81-compile-verification`, which has not landed on `main`. It was extracted
+read-only for this run, exactly as the zygarden source was:
+
+```bash
+git show feat/81-compile-verification:ci/compile-native-output.mjs
+git show feat/81-compile-verification:ci/stubs/compose-unit.kt
+git show feat/81-compile-verification:ci/stubs/compose-graphics.kt
+```
+
+Anyone re-running this e2e from `main` or from `feat/63-text-role-inference`
+alone will not find that file. Nothing in the repo was changed to accommodate
+it.
+
+**Toolchains present:** `kotlinc` 2.4.10 (JRE 26.0.2.1), `swiftc` 6.3.2
+(`/usr/bin/swiftc`, Xcode CLT). Neither was stubbed or skipped.
+
+## Mode set — read this before quoting any count
+
+The source carries **two orthogonal mode axes**. Building both members of either
+axis in one build is a mode collision that `nativeSources()` rejects, so both
+axes were pinned:
+
+| Axis | Files | How it was handled |
+|---|---|---|
+| light / dark | `color-semantic.{light,dark}.json` | built **both**, separately |
+| desktop / mobile | `spacing-semantic.{desktop,mobile}.json`, `typography-semantic.{desktop,mobile}.json` | built **both pins**, separately |
+
+Eleven files are shared by every build — nine mode-neutral primitives/semantics
+plus the two viewport-pinned files for that pin — and the colour file varies:
+
+```
+NEUTRAL = color-primitives, leading-primitives, radius-primitives,
+          radius-semantic, spacing-primitives, stroke-primitives,
+          stroke-semantic, text-primitives, typography-primitives
+SHARED  = NEUTRAL + spacing-semantic.<pin> + typography-semantic.<pin>
+build   = SHARED + color-semantic.<light|dark>          (12 files each)
+```
+
+Four mode sets × before/after = **eight builds**, all exit 0. The 2026-08-21 run
+pinned mobile only; **this run built both viewport pins**, because §6's headline
+number is the one the viewport axis moves.
+
+Every count in this note is per-build. Light and dark produced identical
+declaration counts and identical advisories on every row below, so the tables
+collapse the colour axis and vary only the viewport pin.
+
+## Counts, against §6's prediction
+
+Commands are the brief's, run against each build's `Tokens.kt` / `Tokens.swift`.
+
+| | before (measured) | §6 predicts | measured, mobile pin | measured, desktop pin |
+|---|--:|--:|--:|--:|
+| Kotlin declarations (`grep -c 'val '`) | 208 | 211 | **211** ✓ | **211** ✓ |
+| Swift declarations (`grep -c 'static let'`) | 195 | 195 | **195** ✓ | **195** ✓ |
+| Android unmatched source tokens | 6 | 3 | **3** ✓ | **3** ✓ |
+| iOS unmatched source tokens | 19 | 19 | **19** ✓ | **19** ✓ |
+| Kotlin symbols changed `dp` → `sp` | — | 9 or 10, mode-dependent | **9** | **9** ✗ |
+
+The `before` column was **measured in this harness**, not carried over from a
+prior note: `main`'s three modules were built against the same 15 files. It
+reproduces the handoff note's 208 / 195 / 6 / 19 exactly.
+
+Supporting counts, same builds:
+
+| | before | after |
+|---|--:|--:|
+| `.sp` occurrences in `Tokens.kt` | 39 | 48 (+9) |
+| `.em` occurrences in `Tokens.kt` | 13 | 16 (+3) |
+
+The +3 `.em` are the three new declarations, and account for 211 − 208 exactly.
+The Swift outputs are **byte-identical** before and after in all four mode sets
+(`diff -q`), which is the strongest form of "Swift is untouched".
+
+### The three new Kotlin declarations
+
+Identical in both viewport pins:
+
+```kotlin
+val typographyLetterSpacingNormal = (0.00).em
+val typographyLetterSpacingTight  = (-0.03).em
+val typographyLetterSpacingWide   = (0.05).em
+```
+
+### The remaining Android unmatched, named
+
+Re-derived with the validator's own exported `flattenDtcg` / `normalizeKey` /
+`extractDeclarations` over each source set:
+
+```
+before, either pin: 6 → gradient.brand.primary, spacing.grid.containerMax,
+                        typography.letterSpacing.{normal,tight,wide,widest}
+after,  either pin: 3 → gradient.brand.primary, spacing.grid.containerMax,
+                        typography.letterSpacing.widest
+```
+
+So §2.1's correction to the issue is confirmed on real output: **6 → 3, not
+6 → 2.** `typography.letterSpacing.widest` is referenced by nothing in any of
+the 15 files, so the reference graph has no edge to reach it by.
+
+## Where the measurement disagrees with the spec
+
+**§6 predicts "nine or ten Kotlin symbols change type, which of the two being
+mode-dependent". Both pins changed nine.** Ten is not reachable by any single
+build, because the two viewport files each drop a *different* `text.*` referrer:
+
+```
+$ grep -ho '{text\.[a-z0-9]*}' typography-semantic.mobile.json  | sort -u
+  {text.2xl} {text.3xl} {text.4xl} {text.5xl} {text.base} {text.lg} {text.sm} {text.xl} {text.xs}
+$ grep -ho '{text\.[a-z0-9]*}' typography-semantic.desktop.json | sort -u
+  {text.2xl} {text.3xl} {text.4xl} {text.5xl} {text.6xl} {text.base} {text.sm} {text.xl} {text.xs}
+```
+
+Nine distinct `text.*` referents each. The union is ten. Neither pin sees ten.
+
+The nine symbols that changed, verbatim from `diff`ing the before and after
+`Tokens.kt`:
+
+| mobile pin | desktop pin |
+|---|---|
+| `textXs textSm textBase textLg textXl text2xl text3xl text4xl text5xl` | `textXs textSm textBase textXl text2xl text3xl text4xl text5xl text6xl` |
+
+`text.lg` ↔ `text.6xl` is a straight swap. §8 names the `text.6xl` half of this
+correctly — its only referrer is in the desktop file. **What §8 does not name is
+the mirror case**: `text.lg`'s only referrer is in the *mobile* file, so a
+desktop build leaves `text.lg` as `18.00.dp` and files an advisory for it.
+
+§1's table ("`text.*`: 10 reached, `xs`–`6xl`") is a **union across all 15
+files**, which §1 itself says. It is not a per-build figure, and §6 read it as
+one. §6's "or ten" should read "nine in each of zygarden's two viewport pins,
+ten only in the union no build sees".
+
+**This does not change the shipped behaviour, only the claim about it.** The
+inference is working exactly as §8 describes; the arithmetic in §6 assumed the
+union rather than a build. The changelog below quotes nine, not "nine or ten".
+
+Nothing else disagreed. §6's other three rows landed exactly.
+
+## Compile verification
+
+`node ci/compile-native-output.mjs <dir>` on all eight builds, each directory
+holding that build's `Tokens.kt` and `Tokens.swift`:
+
+```
+compile-native-output — do the emitted native tokens build?
+
+  [PASS] kotlin: typechecked to bytecode (against ci/stubs, not real Compose)
+  [PASS] swift: parsed only (UIKit unavailable; -typecheck impossible)
+
+  Kotlin is typechecked to bytecode; Swift is parsed only. swiftc -typecheck
+  cannot run here: Tokens.swift imports UIKit, which is unavailable on the
+  macOS command line. Swift syntax is asserted; Swift types are not.
+exit=0
+```
+
+**8 / 8 exit 0**, both platforms PASS in every one. The Kotlin risk this step
+existed to catch — nine symbols changing from `Dp` to `TextUnit` — did not
+materialise as a broken output.
+
+Per `ci/README.md` (on the #81 branch), the strengths are unequal and must be
+quoted that way: **Kotlin is typechecked to bytecode** against 19 lines of
+Compose stubs, which is a real type check of every declaration; **Swift is
+parsed only**, so `Tokens.swift` is asserted to be syntactically valid Swift and
+nothing more.
+
+### The break was demonstrated, not asserted
+
+A PASS only proves the *output* compiles. The changelog claims something
+stronger — that a `Dp` use site *stops* compiling — so that was compiled too:
+
+```kotlin
+// UseSite.kt — stands in for Modifier.padding(Tokens.textBase)
+fun padding(value: Dp): Dp = value
+val leak: Dp = padding(Tokens.textBase)
+```
+
+```
+$ kotlinc <before Tokens.kt> <stubs> UseSite.kt     # main
+(clean — compiles)
+
+$ kotlinc <after Tokens.kt> <stubs> UseSite.kt      # this branch
+UseSite.kt:6:24: error: argument type mismatch: actual type is 'TextUnit', but 'Dp' was expected.
+val leak: Dp = padding(Tokens.textBase)
+                       ^^^^^^^^^^^^^^^
+```
+
+The type really changed at the bytecode level, and the break is the one the
+`Breaking` entry describes.
+
+## Validator reports
+
+Run per output with `--min-match 1` — 16 invocations, one per build per
+platform. Every one **exit 0**, 100% match, zero rule failures.
+
+| build | matched | advisories | unmatched source tokens |
+|---|---|--:|--:|
+| `android-kotlin`, before, both pins, both colours | 208/208 | 5 | 6 |
+| `android-kotlin`, after, both pins, both colours | 211/211 | 10 | 3 |
+| `ios-swift`, before, both pins, both colours | 195/195 | 5 | 19 |
+| `ios-swift`, after, both pins, both colours | 195/195 | 10 | 19 |
+
+The five pre-existing advisories are the `unitless-dimension` notes on
+`leading.{tight,snug,normal,relaxed,loose}`, unchanged by this branch. The five
+new ones are all `unreferenced-text-sibling`. Verbatim, `after` / mobile:
+
+```
+10 advisory note(s) — reported, not gating:
+  - [unitless-dimension] leadingLoose: source "2" for leading.loose is a dimension with no unit, which DTCG §8.2.1 does not permit. It emitted 2, read as a ratio. If it is a ratio, type it "number" (§8.7); if it is a measurement, add the unit you meant.
+  - [unitless-dimension] leadingNormal: source "1.5" for leading.normal is a dimension with no unit, which DTCG §8.2.1 does not permit. It emitted 1.5, read as a ratio. If it is a ratio, type it "number" (§8.7); if it is a measurement, add the unit you meant.
+  - [unitless-dimension] leadingRelaxed: source "1.7" for leading.relaxed is a dimension with no unit, which DTCG §8.2.1 does not permit. It emitted 1.7, read as a ratio. If it is a ratio, type it "number" (§8.7); if it is a measurement, add the unit you meant.
+  - [unitless-dimension] leadingSnug: source "1.25" for leading.snug is a dimension with no unit, which DTCG §8.2.1 does not permit. It emitted 1.25, read as a ratio. If it is a ratio, type it "number" (§8.7); if it is a measurement, add the unit you meant.
+  - [unitless-dimension] leadingTight: source "1.1" for leading.tight is a dimension with no unit, which DTCG §8.2.1 does not permit. It emitted 1.1, read as a ratio. If it is a ratio, type it "number" (§8.7); if it is a measurement, add the unit you meant.
+  - [unreferenced-text-sibling] text.6xl: nothing references it, so no typographic role could be inferred — but tokens in "text" were. It emits as a length, or is dropped entirely if its unit is em. Stamp $extensions["com.radicool.throughline"].nativeUnit = "text" on it in source to settle it, or leave it if it is not a text value.
+  - [unreferenced-text-sibling] text.7xl: …
+  - [unreferenced-text-sibling] text.8xl: …
+  - [unreferenced-text-sibling] text.9xl: …
+  - [unreferenced-text-sibling] typography.letterSpacing.widest: nothing references it, so no typographic role could be inferred — but tokens in "typography.letterSpacing" were. It emits as a length, or is dropped entirely if its unit is em. Stamp $extensions["com.radicool.throughline"].nativeUnit = "text" on it in source to settle it, or leave it if it is not a text value.
+
+3 source token(s) had no matching emitted symbol.
+exit=0
+```
+
+(`text.7xl` / `8xl` / `9xl` carry the same wording as `text.6xl`, elided.)
+
+The `after` / **desktop** advisory set differs by exactly one line, which is the
+finding above surfacing in the instrument that exists to surface it:
+
+```
+  - [unreferenced-text-sibling] text.lg: …      ← instead of text.6xl
+  - [unreferenced-text-sibling] text.7xl: …
+  - [unreferenced-text-sibling] text.8xl: …
+  - [unreferenced-text-sibling] text.9xl: …
+  - [unreferenced-text-sibling] typography.letterSpacing.widest: …
+```
+
+Five advisories in each pin, four common to both, one swapped.
+
+**Zero `ambiguous-text-role` advisories in any of the eight builds.** §1
+measured zero mixed cases on this source and the emitted output agrees, so the
+merge this build performs matches the one §1 measured.
+
+## What this run does NOT establish
+
+1. **Ten symbols was never observed, and cannot be on this source.** Every
+   figure above is per-build. Do not quote "ten" from §1's union table.
+2. **Only zygarden's two viewport pins were built.** A third mode axis, or a
+   consumer whose typography file references the full `text.*` scale, would
+   produce different counts. The inference is mode-dependent by construction
+   (§8) and this run measures two points, not a rule.
+3. **`text.7xl`, `text.8xl`, `text.9xl` and `typography.letterSpacing.widest`
+   are still wrong in the output**, and knowingly so. They are referenced by
+   nothing in any of the 15 files, so no structural signal exists. They emit
+   `72.00.dp` / `96.00.dp` / `128.00.dp` and (for `widest`) nothing at all. The
+   advisory names them; the fix is a source-side `$extensions` stamp.
+4. **Swift was parsed, not typechecked.** `Tokens.swift` imports `UIKit`, which
+   is unavailable on the macOS command line, so `swiftc -parse` is the strongest
+   available check. Swift syntax is asserted; Swift types are not. Since the
+   Swift output is byte-identical to `main`'s, this is not a new gap.
+5. **Kotlin was typechecked against stubs, not against Compose.**
+   `ci/stubs/compose-unit.kt` declares `Dp` and `TextUnit` as plain classes; real
+   Compose makes them value classes. Type *distinctness* is faithful — which is
+   what the `dp`/`sp` claim rests on — but Compose's own semantics are not.
+6. **Colour values are still checked by name only.** Unchanged from the
+   2026-08-21 note and out of scope here; no rule compares an emitted colour to
+   its source.
+7. **Nothing was run on a device.** That `sp` respects the user's font-scale
+   setting is Compose's documented behaviour, not something this run observed.
+8. **One Style Dictionary version.** `4.4.0` only. ThroughLine declares no
+   dependency on Style Dictionary, so the version a consumer runs stays
+   invisible to this evidence either way.
+9. **The compile checker was borrowed from an unmerged branch.** If #81 lands
+   changed, this run's compile evidence was produced by
+   `feat/81-compile-verification` at `7271bed`, not by whatever merges.
+
+## Repo gates, run alongside
+
+```
+$ node --test                                    → 423 pass, 0 fail
+$ node scripts/build-native-adapter-config.mjs --check
+  references/native-adapter-config.md is up to date
+$ node ci/validate-plugin.mjs                    → ✓
+$ node ci/validate-skills.mjs                    → ✓ 12 skills, 5 commands, 4 agents
+```

--- a/docs/superpowers/notes/2026-08-28-text-role-inference-e2e.md
+++ b/docs/superpowers/notes/2026-08-28-text-role-inference-e2e.md
@@ -2,10 +2,12 @@
 
 **Date:** 2026-08-28
 **Gate for:** #63, the changelog entry that follows it
-**Verdict:** PASS on three of §6's four rows, and a **finding on the fourth**.
-The predicted "nine or ten Kotlin symbols change type, mode-dependent" is
-**nine in both viewport pins** — but a *different* nine. Ten is not reachable by
-any single build. Detail under "Where the measurement disagrees with the spec".
+**Verdict:** PASS. All four rows of §6's table landed exactly, and the compile
+step is green on all eight builds. One **finding against §6's prose**: the
+predicted "nine or ten Kotlin symbols change type, mode-dependent" is **nine in
+both viewport pins** — but a *different* nine, and ten is not reachable by any
+single build. The spec has been corrected on that measurement; detail under
+"Where the measurement disagrees with the spec".
 
 Unit tests prove `textRoleGraph`, `preprocess` and the two advisories behave.
 This run proves Style Dictionary *consumes* them: eight real builds from
@@ -28,7 +30,7 @@ zygarden's DTCG source — before and after, × two viewport pins, × light and 
   (`git show main:…`). Both were built against the identical 15 files, so every
   delta below is the branch's, not a source or harness difference.
 
-### The install list was stale — a four-file list, not three
+### Finding 1 — the install list is stale: four files, not three
 
 The 2026-08-21 note records the install list as exactly three files. **It is now
 four.** Both `sd-native.mjs` and `validate-token-output.mjs` statically import a
@@ -42,11 +44,14 @@ imported from …/scripts/lib/sd-native.mjs
 
 That was reproduced deliberately by removing the file from a working install.
 
-**This is a stale *note*, not a stale shipping instruction.** The generated,
-CI-gated `references/native-adapter-config.md` already names
-`lib/native-literal.mjs` as a required sibling (lines 21 and 48), so a consumer
-following the shipped docs installs the right set. The three-file list in the
-2026-08-21 note predates #70 and should not be copied forward again.
+**This misleads the next e2e run, not any consumer.** The generated, CI-gated
+`references/native-adapter-config.md` — the doc a consumer actually follows —
+already names `lib/native-literal.mjs` as a required sibling (lines 21 and 48),
+so the **shipped** instruction is correct and no user is affected. What is wrong
+is the three-file list in the 2026-08-21 e2e note, which predates #70. Anyone
+rebuilding this harness from that note gets `ERR_MODULE_NOT_FOUND` and has to
+rediscover the fourth file, as this run did. It should not be copied forward
+again.
 
 The staleness is **not** this branch's: this branch's new code lives entirely in
 `scripts/lib/dtcg.mjs`, `scripts/lib/sd-native.mjs` and
@@ -54,11 +59,13 @@ The staleness is **not** this branch's: this branch's new code lives entirely in
 module. The four-file list is complete for this branch — no other import outside
 `node:*` exists in any of the four.
 
-### `ci/compile-native-output.mjs` is not on this branch
+### Finding 2 — `ci/compile-native-output.mjs` is not on this branch, or on `main`
 
-The compile checker (#81) is **not merged**. It exists only on
-`feat/81-compile-verification`, which has not landed on `main`. It was extracted
-read-only for this run, exactly as the zygarden source was:
+**Do not go looking for this file in the repo — it is not there.** The compile
+checker (#81, PR **#82**) is **not merged**. It exists only on the branch
+`feat/81-compile-verification` (tip `7271bed`), which has landed on neither
+`main` nor `feat/63-text-role-inference`. It was extracted read-only for this
+run, exactly as the zygarden source was:
 
 ```bash
 git show feat/81-compile-verification:ci/compile-native-output.mjs
@@ -67,8 +74,9 @@ git show feat/81-compile-verification:ci/stubs/compose-graphics.kt
 ```
 
 Anyone re-running this e2e from `main` or from `feat/63-text-role-inference`
-alone will not find that file. Nothing in the repo was changed to accommodate
-it.
+alone will not find that file, and must extract it the same way or wait for #82
+to merge. Nothing in this repo was changed to accommodate it — no file was
+copied in, and no gate was pointed at it.
 
 **Toolchains present:** `kotlinc` 2.4.10 (JRE 26.0.2.1), `swiftc` 6.3.2
 (`/usr/bin/swiftc`, Xcode CLT). Neither was stubbed or skipped.
@@ -178,21 +186,28 @@ The nine symbols that changed, verbatim from `diff`ing the before and after
 |---|---|
 | `textXs textSm textBase textLg textXl text2xl text3xl text4xl text5xl` | `textXs textSm textBase textXl text2xl text3xl text4xl text5xl text6xl` |
 
-`text.lg` ↔ `text.6xl` is a straight swap. §8 names the `text.6xl` half of this
-correctly — its only referrer is in the desktop file. **What §8 does not name is
+`text.lg` ↔ `text.6xl` is a straight swap. §8 as written named the `text.6xl`
+half correctly — its only referrer is in the desktop file — and **did not name
 the mirror case**: `text.lg`'s only referrer is in the *mobile* file, so a
-desktop build leaves `text.lg` as `18.00.dp` and files an advisory for it.
+desktop build leaves `text.lg` as `18.00.dp` and files an advisory for it. That
+omission made the limitation read as one stray token rather than a symmetric
+swap; §8 has since been corrected.
 
 §1's table ("`text.*`: 10 reached, `xs`–`6xl`") is a **union across all 15
 files**, which §1 itself says. It is not a per-build figure, and §6 read it as
-one. §6's "or ten" should read "nine in each of zygarden's two viewport pins,
-ten only in the union no build sees".
+one. §6 has since been corrected to say so.
 
 **This does not change the shipped behaviour, only the claim about it.** The
 inference is working exactly as §8 describes; the arithmetic in §6 assumed the
-union rather than a build. The changelog below quotes nine, not "nine or ten".
+union rather than a build. The changelog quotes nine, not "nine or ten".
 
-Nothing else disagreed. §6's other three rows landed exactly.
+**Resolved in the spec.** On this measurement the spec was corrected rather than
+the number: §6 now states nine in any single build and that ten is unreachable
+by one, §1's table is labelled as a union, and §8's bullet names the
+`text.lg` ↔ `text.6xl` swap and records that the count is stable across pins
+even though the set is not.
+
+Nothing else disagreed. All four rows of §6's table landed exactly.
 
 ## Compile verification
 
@@ -326,7 +341,7 @@ merge this build performs matches the one §1 measured.
 8. **One Style Dictionary version.** `4.4.0` only. ThroughLine declares no
    dependency on Style Dictionary, so the version a consumer runs stays
    invisible to this evidence either way.
-9. **The compile checker was borrowed from an unmerged branch.** If #81 lands
+9. **The compile checker was borrowed from an unmerged branch.** If #82 lands
    changed, this run's compile evidence was produced by
    `feat/81-compile-verification` at `7271bed`, not by whatever merges.
 

--- a/docs/superpowers/notes/2026-08-28-three-open-prs-handoff.md
+++ b/docs/superpowers/notes/2026-08-28-three-open-prs-handoff.md
@@ -1,0 +1,81 @@
+# Three open PRs — handoff
+
+**Date:** 2026-08-28
+**Supersedes:** `2026-08-28-v0.16.0-shipped-handoff.md`, which says **0 open PRs**
+and carries a figure this session disproved. Both were true when written.
+
+## State in one line
+
+`main` is unchanged at `e45afc4`. **Three PRs are open**, all CI-green, all
+mutually independent — zero file overlap between any pair, so they merge in any
+order. Nothing is blocked on anything.
+
+| PR | branch | closes | what it is |
+|---|---|---|---|
+| [#82](https://github.com/jrpease/throughline/pull/82) | `feat/81-compile-verification` | #81 | `ci/compile-native-output.mjs` + stubs; four e2e notes corrected |
+| [#83](https://github.com/jrpease/throughline/pull/83) | `fix/80-release-gate-parity` | #80 | the missing release gate, plus a test that keeps the two lists in sync |
+| [#84](https://github.com/jrpease/throughline/pull/84) | `feat/63-text-role-inference` | #63 | text-role inference from the reference graph |
+
+**#84 is a breaking release** — nine Kotlin symbols change from `Dp` to
+`TextUnit`. Its changelog entry is written and names the opt-out.
+
+**One ordering note:** #84's e2e borrowed `ci/compile-native-output.mjs` from
+#82's unmerged branch, read-only, and its note says so. If #82 is abandoned
+rather than merged, that citation dangles — merging #82 first makes it true
+retroactively. Not a blocker either way.
+
+## What #63 changed, in one paragraph
+
+A dimension referenced **only** by `fontSize`/`letterSpacing`/`lineHeight`
+members is now stamped typographic, so `text.base` emits `sp` and `em` letter
+spacing reaches Compose. Measured on 8 real builds: Kotlin 208 → 211
+declarations, Swift byte-identical, Android unmatched 6 → **3**. A primitive
+*nothing* references is deliberately not inferred — `tokens:validate-output`
+names it instead (`unreferenced-text-sibling`), rather than guessing.
+
+## Corrections this session made to things previously written down
+
+- **"#63 takes Android from 6 unmatched to 2" was wrong — it is 6 → 3.**
+  `typography.letterSpacing.widest` is referenced by nothing, so the graph
+  cannot reach it. The figure had propagated from the issue into the previous
+  handoff note; both occurrences are fixed.
+- **A design spec claimed "nine or ten symbols change, mode-dependent."** The
+  e2e disproved it: nine in any single build, but not the same nine — mobile and
+  desktop swap `text.lg` ↔ `text.6xl`. Ten is a union across all 15 source
+  files. **A merge of all 15 files is not a build** — it is a mode collision
+  `nativeSources()` rejects, and merging anyway hides reference edges. Any
+  measurement against zygarden must state which viewport pin it used.
+- **Five places asserted the old limitation.** One of them,
+  `references/sync-adapters.md`, ships to consumers and had been wrong since
+  **#64**. All five now state the new rule and its remaining gap.
+
+## Open issues filed this session
+
+- **#85** — a group-level `$type` makes the whole native text-role pipeline a
+  silent no-op: nothing stamped, zero `sp` on Android, and no advisory saying
+  so. Pre-existing (#51), not introduced by #63. `flattenDtcgTypes` already
+  implements DTCG 5.2.2 correctly and sits in the same file. **The substantial
+  one.**
+- **#86** — `references/` ships but only one file in it is gated; behaviour
+  claims live in four or five places at once.
+- **#87** — the 2026-08-21 e2e note's harness install list is missing
+  `native-literal.mjs` (required since #70), so a rebuild from it fails. Two-line
+  fix; needs a branch, since every current branch has an open PR.
+
+## Where the backlog stands after these merge
+
+- **#36** — validator silently drops a token on a `normalizeKey` collision. Last
+  of the "instruments" items, outside the contended `sd-native.mjs`.
+- **Native tail** — #57, #58, #61, #62, #67, #71, #72, #75. #71/#72 are one
+  underlying gap in the advisory's type resolution and should be done together.
+- **Consumption layer** — #39–#44. The largest unstarted body of work that is
+  not #48, and the native base it was parked on is now clean.
+- **#48** — native SwiftUI/Compose components. Multi-month; keep it distinct
+  from token work in any roadmap statement.
+
+## Open questions
+
+- **Is a release cadence wanted?** 0.16.0 followed 0.15.0 by two weeks. #84 is
+  breaking, so it forces a version decision when it merges.
+- **#85 changes #51's behaviour**, so fixing it likely needs its own `Breaking`
+  entry. Worth deciding whether it rides the same release as #84 or a later one.

--- a/docs/superpowers/notes/2026-08-28-v0.16.0-shipped-handoff.md
+++ b/docs/superpowers/notes/2026-08-28-v0.16.0-shipped-handoff.md
@@ -36,7 +36,9 @@ Native token coverage against zygarden's real source:
 `typography.letterSpacing.{tight,normal,wide,widest}`, whose leaf names state no
 role — tracked on #63, which now carries that evidence. The other two are a
 `linear-gradient()` and a `100%`, which have no native form at all. So closing
-#63 would take Android to 2 unmatched, both genuinely impossible.
+#63 would take Android to 3 unmatched, not 2 — `typography.letterSpacing.widest`
+is referenced by nothing, so the reference graph cannot reach it and it stays
+dropped alongside the two impossible ones.
 
 **iOS letter spacing is excluded deliberately, not pending.** It is an
 `NSAttributedString` kern in points, needing a font size the token does not
@@ -60,7 +62,7 @@ stub source in the issue body.
 Nothing is blocked. The genuinely open question is which slot is next:
 
 - **#63** — the cheapest meaningful win, and now the *only* fixable native token
-  gap. Takes Android from 6 unmatched to 2.
+  gap. Takes Android from 6 unmatched to 3 — same correction as above.
 - **#80** — `release.yml` runs five of CI's six gates, missing the
   native-adapter-config doc check, and `references/` ships in the tarball. Four
   lines, plus the better question of why two hand-maintained gate lists exist.

--- a/docs/superpowers/plans/2026-08-28-text-role-inference.md
+++ b/docs/superpowers/plans/2026-08-28-text-role-inference.md
@@ -1,0 +1,890 @@
+# Text-Role Inference Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Infer a typographic role for a dimension primitive from the reference graph — a token referenced only by `fontSize`/`letterSpacing`/`lineHeight` members is itself typographic — so `text.base` emits `sp` rather than `dp` and `em` letter-spacing primitives stop being dropped.
+
+**Architecture:** A pure `textRoleGraph(dict)` in `scripts/lib/dtcg.mjs` reads whole-value reference edges off the **unresolved** source tree and returns three things: the referents to stamp, the ambiguous ones to report, and the unreferenced ones to advise about. `preprocess` calls it before resolving and applies the stamps to its clone, so nothing is carried into transform time. `validate-token-output.mjs` calls the same function to raise two non-gating advisories.
+
+**Tech Stack:** Node ≥20, ESM, `node:test` + `node:assert/strict`. Zero dependencies — stdlib only, no lockfile, no `node_modules`.
+
+**Spec:** `docs/superpowers/specs/2026-08-28-text-role-inference-design.md`
+
+## Global Constraints
+
+- **Zero dependencies.** Never add an import outside `node:*` and this repo's own files. No YAML/JSON5/lodash, no dev dependencies.
+- **Run the suite as bare `node --test` from the repo root.** Never `node --test scripts/` — a pathed invocation errors on Node ≥21.
+- **`scripts/lib/sd-native.mjs` is gated.** After ANY edit to it run `node scripts/build-native-adapter-config.mjs` to regenerate `references/native-adapter-config.md`, and commit the regenerated doc in the same commit. `--check` fails CI otherwise. `references/` ships in the published tarball.
+- **Every line of `sd-native.mjs` must fall inside a `@doc-section` pair.** Blank lines and `//` comment lines may sit outside; any line with executable code may not. Each section id needs a matching entry in the generator's `PROSE` array.
+- **The extension namespace is `com.radicool.throughline`.** Address it through the `EXT_NS` constant, never as a literal.
+- **`TEXT_UNIT_NAMES` is exactly `{fontSize, letterSpacing, lineHeight}`** — DTCG §9.8's member names. Do not add to it.
+- **`TEXT_ROLE_UNIT` is `/^-?(?:\d+(?:\.\d+)?|\.\d+)(?:px|rem|em)$/`** — px, rem, em. A unitless value must never be stamped.
+- **Never overwrite an existing `nativeUnit`.** Guard every stamp with `if (!('nativeUnit' in ns))`. This is both the source escape hatch and the opt-out.
+- **`preprocess` must stay idempotent:** `preprocess(preprocess(x))` `deepEqual` `preprocess(x)`.
+- **Match the house comment style.** These modules explain *why*, cite issue numbers and spec sections, and state limits rather than hiding them. Terse code, dense rationale.
+
+---
+
+### Task 1: Move the three shared constants into `dtcg.mjs`
+
+`textRoleGraph` (Task 2) lives in `dtcg.mjs` and needs all three. `sd-native.mjs` imports `dtcg.mjs`, so `dtcg.mjs` importing back would be a cycle. Move them down; leave the rationale comments where they are so the generated doc keeps them.
+
+**Files:**
+- Modify: `scripts/lib/dtcg.mjs` (add constants after the `REF` declaration, line 5)
+- Modify: `scripts/lib/sd-native.mjs:13` (import), `:229`, `:231-233`, `:236-247` (comments and re-export)
+- Test: `scripts/lib/dtcg.test.mjs`
+- Regenerate: `references/native-adapter-config.md`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `TEXT_UNIT_NAMES: Set<string>`, `TEXT_ROLE_UNIT: RegExp`, `EXT_NS: string` — all exported from `scripts/lib/dtcg.mjs`. `EXT_NS` stays exported from `sd-native.mjs` too, via re-export.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `scripts/lib/dtcg.test.mjs`:
+
+```js
+test('the shared text-role constants live here, so textRoleGraph and sd-native cannot drift', () => {
+  assert.deepEqual([...TEXT_UNIT_NAMES].sort(), ['fontSize', 'letterSpacing', 'lineHeight']);
+  assert.equal(EXT_NS, 'com.radicool.throughline');
+  for (const ok of ['16px', '1.5rem', '-0.03em', '.5px']) assert.ok(TEXT_ROLE_UNIT.test(ok), ok);
+  for (const no of ['1.5', '16', '100%', '16dp', '']) assert.ok(!TEXT_ROLE_UNIT.test(no), no);
+});
+```
+
+Add `TEXT_UNIT_NAMES, TEXT_ROLE_UNIT, EXT_NS` to that file's existing import from `./dtcg.mjs`.
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `node --test scripts/lib/dtcg.test.mjs`
+Expected: FAIL — the three names are not exported from `dtcg.mjs` yet.
+
+- [ ] **Step 3: Add the constants to `dtcg.mjs`**
+
+Insert directly after `const REF = /^\{([^}]+)\}$/;` (line 5):
+
+```js
+// The typographic member names DTCG §9.8 fixes at MUST level, the unit gate a
+// text-role dimension must pass, and this project's $extensions namespace.
+//
+// They live here rather than in sd-native.mjs because textRoleGraph below and
+// sd-native.mjs's preprocess apply the identical rules, and sd-native.mjs
+// already imports this file — so the reverse import would be a cycle. Their
+// full rationale stays at the point of use in sd-native.mjs, which is what the
+// generated references/native-adapter-config.md renders.
+export const TEXT_UNIT_NAMES = new Set(['fontSize', 'letterSpacing', 'lineHeight']);
+export const TEXT_ROLE_UNIT = /^-?(?:\d+(?:\.\d+)?|\.\d+)(?:px|rem|em)$/;
+export const EXT_NS = 'com.radicool.throughline';
+```
+
+- [ ] **Step 4: Rewire `sd-native.mjs`**
+
+Change line 13 from:
+
+```js
+import { flattenDtcg, resolveValue, findModeCollisions } from './dtcg.mjs';
+```
+
+to:
+
+```js
+import {
+  flattenDtcg,
+  resolveValue,
+  findModeCollisions,
+  TEXT_UNIT_NAMES,
+  TEXT_ROLE_UNIT,
+  EXT_NS,
+} from './dtcg.mjs';
+```
+
+Then, keeping every existing comment line exactly as it stands:
+
+- Delete only the line `const TEXT_UNIT_NAMES = new Set(['fontSize', 'letterSpacing', 'lineHeight']);` (line 229) and append to the comment block above it:
+
+```js
+// Defined in lib/dtcg.mjs and imported above, so textRoleGraph applies the
+// identical set. Two definitions of this set would drift.
+```
+
+- Replace the line `export const EXT_NS = 'com.radicool.throughline';` (line 233) with:
+
+```js
+export { EXT_NS };
+```
+
+and append to its comment block above:
+
+```js
+// Defined in lib/dtcg.mjs and re-exported here: the transforms and their tests
+// address this key through sd-native.mjs, and that surface does not move.
+```
+
+- Delete only the line `const TEXT_ROLE_UNIT = /^-?(?:\d+(?:\.\d+)?|\.\d+)(?:px|rem|em)$/;` (line 247) and append to the comment block above it:
+
+```js
+// Defined in lib/dtcg.mjs and imported above, for the same reason as
+// TEXT_UNIT_NAMES: textRoleGraph gates on it too.
+```
+
+All three comment blocks stay inside the `preprocess` `@doc-section`. `export { EXT_NS };` is executable and must stay inside it too.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `node --test`
+Expected: PASS, all of them. Nothing about behaviour changed — if any `sd-native` test fails, a constant moved to the wrong place.
+
+- [ ] **Step 6: Regenerate the doc and check the gate**
+
+```bash
+node scripts/build-native-adapter-config.mjs
+node scripts/build-native-adapter-config.mjs --check
+git diff --stat references/native-adapter-config.md
+```
+Expected: `--check` exits 0. The doc diff shows the comment and import changes and nothing else.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/lib/dtcg.mjs scripts/lib/dtcg.test.mjs scripts/lib/sd-native.mjs references/native-adapter-config.md
+git commit -m "refactor: the text-role constants move to dtcg.mjs, where both consumers can reach them (#63)"
+```
+
+---
+
+### Task 2: `textRoleGraph` and `mergeDtcg` in `dtcg.mjs`
+
+The whole inference, as one pure function over an unresolved tree. No consumer yet — Tasks 3 and 4 wire it in.
+
+**Files:**
+- Modify: `scripts/lib/dtcg.mjs` (append both functions)
+- Test: `scripts/lib/dtcg.test.mjs`
+
+**Interfaces:**
+- Consumes: `TEXT_UNIT_NAMES`, `TEXT_ROLE_UNIT`, `EXT_NS`, `REF` from Task 1.
+- Produces:
+  - `mergeDtcg(dicts: object[]) -> object` — deep merge, later dict wins, inputs never mutated.
+  - `textRoleGraph(dict: object) -> { typographic: Set<string>, ambiguous: Array<{path, textLeaves, otherLeaves}>, unreferencedSiblings: Array<{path, group}> }`. All paths are dot-joined and **pre-hoist**.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/lib/dtcg.test.mjs`:
+
+```js
+const graphFixture = () => ({
+  text: {
+    base: { $type: 'dimension', $value: '16px' },
+    huge: { $type: 'dimension', $value: '96px' },
+    stamped: { $type: 'dimension', $value: '72px', $extensions: { [EXT_NS]: { nativeUnit: 'text' } } },
+    ratio: { $type: 'dimension', $value: '1.5' },
+  },
+  space: { md: { $type: 'dimension', $value: '8px' } },
+  typography: {
+    body: {
+      fontSize: { $type: 'dimension', $value: '{text.base}' },
+      lineHeight: { $type: 'dimension', $value: '{text.base}' },
+    },
+    gutter: { $type: 'dimension', $value: '{space.md}' },
+  },
+});
+
+test('a referent whose referrers are all typographic is inferred typographic', () => {
+  const g = textRoleGraph(graphFixture());
+  assert.ok(g.typographic.has('text.base'));
+  assert.ok(!g.typographic.has('space.md'), 'a gutter referrer states no typographic role');
+  assert.deepEqual(g.ambiguous, []);
+});
+
+test('a referent with referrers on both sides is ambiguous, not inferred', () => {
+  const dict = graphFixture();
+  dict.space.pad = { $type: 'dimension', $value: '{text.base}' };
+  const g = textRoleGraph(dict);
+  assert.ok(!g.typographic.has('text.base'), 'counter-evidence declines the stamp');
+  assert.equal(g.ambiguous.length, 1);
+  assert.equal(g.ambiguous[0].path, 'text.base');
+  assert.deepEqual(g.ambiguous[0].textLeaves.sort(), ['fontSize', 'lineHeight']);
+  assert.deepEqual(g.ambiguous[0].otherLeaves, ['pad']);
+});
+
+test('an unreferenced sibling of an inferred token is advised, not inferred', () => {
+  const g = textRoleGraph(graphFixture());
+  const paths = g.unreferencedSiblings.map((u) => u.path);
+  assert.ok(paths.includes('text.huge'), 'nothing references it, but its siblings are typographic');
+  assert.ok(!paths.includes('text.stamped'), 'already closed by a source stamp');
+  assert.ok(!paths.includes('text.ratio'), 'unitless — no size transform would claim it anyway');
+  assert.ok(!paths.includes('space.md'), 'its group holds no inferred token');
+  assert.equal(g.unreferencedSiblings.find((u) => u.path === 'text.huge').group, 'text');
+});
+
+test('an edge to a path that does not exist is collected, not thrown on', () => {
+  const g = textRoleGraph({
+    typography: { body: { fontSize: { $type: 'dimension', $value: '{nope.missing}' } } },
+  });
+  assert.ok(g.typographic.has('nope.missing'), 'the graph reports the edge; the applier skips it');
+  assert.deepEqual(g.unreferencedSiblings, []);
+});
+
+test('a chain through a role-less intermediate is declined at the second hop', () => {
+  const g = textRoleGraph({
+    text: { base: { $type: 'dimension', $value: '16px' } },
+    alias: { x: { $type: 'dimension', $value: '{text.base}' } },
+    typography: { body: { fontSize: { $type: 'dimension', $value: '{alias.x}' } } },
+  });
+  assert.ok(g.typographic.has('alias.x'));
+  assert.ok(!g.typographic.has('text.base'), 'the intermediate leaf name states no role');
+});
+
+test('a dual node is reached at its own path, before any hoist', () => {
+  const g = textRoleGraph({
+    text: { sm: { $type: 'dimension', $value: '14px', lineHeight: { $type: 'dimension', $value: '20px' } } },
+    typography: { body: { fontSize: { $type: 'dimension', $value: '{text.sm}' } } },
+  });
+  assert.ok(g.typographic.has('text.sm'));
+});
+
+test('mergeDtcg lets a later source win and leaves its inputs alone', () => {
+  const a = { typography: { body: { fontSize: { $value: '{text.sm}' } } }, keep: { x: { $value: '1px' } } };
+  const b = { typography: { body: { fontSize: { $value: '{text.lg}' } } } };
+  const merged = mergeDtcg([a, b]);
+  assert.equal(merged.typography.body.fontSize.$value, '{text.lg}');
+  assert.equal(merged.keep.x.$value, '1px');
+  assert.equal(a.typography.body.fontSize.$value, '{text.sm}', 'inputs must not be mutated');
+});
+
+test('a merge can remove a referrer a union would have kept', () => {
+  const desktop = { typography: { body: { fontSize: { $type: 'dimension', $value: '{text.lg}' } } } };
+  const mobile = { typography: { body: { fontSize: { $type: 'dimension', $value: '{text.sm}' } } } };
+  const base = { text: { lg: { $type: 'dimension', $value: '18px' }, sm: { $type: 'dimension', $value: '14px' } } };
+  const g = textRoleGraph(mergeDtcg([base, desktop, mobile]));
+  assert.ok(g.typographic.has('text.sm'));
+  assert.ok(!g.typographic.has('text.lg'), 'the mobile file overwrote the only referrer to text.lg');
+});
+```
+
+Add `textRoleGraph, mergeDtcg` to that file's import from `./dtcg.mjs`.
+
+- [ ] **Step 2: Run and watch them fail**
+
+Run: `node --test scripts/lib/dtcg.test.mjs`
+Expected: FAIL — `textRoleGraph is not a function`.
+
+- [ ] **Step 3: Implement both, appended to `scripts/lib/dtcg.mjs`**
+
+```js
+// Deep merge in list order, later source winning — the same later-wins rule
+// validate-token-output.mjs already applies when it flattens a source list, and
+// what Style Dictionary hands preprocess as one dict.
+//
+// Each source is cloned on the way in. Merging the caller's own objects would
+// mutate the token trees it still holds, and the validator reads them again.
+const isPlainObject = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
+
+function mergeInto(target, src) {
+  for (const [key, val] of Object.entries(src)) {
+    if (isPlainObject(val) && isPlainObject(target[key])) mergeInto(target[key], val);
+    else target[key] = val;
+  }
+  return target;
+}
+
+export function mergeDtcg(dicts) {
+  const out = {};
+  for (const dict of dicts) mergeInto(out, structuredClone(dict));
+  return out;
+}
+
+// A dimension primitive states no typographic role: text.base: "16px" is a font
+// size only to a human, so it emitted as dp, and an em letterSpacing primitive
+// was dropped from native output entirely. #51 sources the role from the member
+// names DTCG §9.8 fixes, which reaches the semantic tokens and not the
+// primitives they reference. This reaches the primitives, structurally.
+//
+// Reads the UNRESOLVED tree: preprocess resolves aliases in place, so by
+// transform time the graph is gone. Nothing needs carrying, because the
+// inference is applied during preprocessing and only the $extensions stamp
+// survives — see sd-native.mjs's applyTextRoleGraph.
+//
+// A referrer whose leaf name is NOT typographic is counter-evidence, not
+// neutral. A dimension referenced by something that is not a typographic member
+// is a length, which is exactly what the dp default already asserts about it.
+// Treating it as neutral would let one stray fontSize reference convert a whole
+// spacing ramp.
+//
+// Single-pass and deliberately not transitive: a chain through an intermediate
+// whose own leaf name states no role is declined at the second hop, because
+// that intermediate is itself counter-evidence. Only whole-value references
+// count; a reference embedded in an expression is resolved by resolveInPlace
+// but is not evidence of a role.
+export function textRoleGraph(dict) {
+  const edges = [];
+  (function walk(node, prefix) {
+    for (const [key, val] of Object.entries(node)) {
+      if (key.startsWith('$') || !isPlainObject(val)) continue;
+      const path = [...prefix, key];
+      if (typeof val.$value === 'string') {
+        const m = REF.exec(val.$value.trim());
+        if (m) edges.push({ to: m[1], leaf: key });
+      }
+      walk(val, path);
+    }
+  })(dict, []);
+
+  const referrers = new Map();
+  for (const edge of edges) {
+    if (!referrers.has(edge.to)) referrers.set(edge.to, []);
+    referrers.get(edge.to).push(edge);
+  }
+
+  const typographic = new Set();
+  const ambiguous = [];
+  for (const [path, rs] of referrers) {
+    const textLeaves = [...new Set(rs.filter((r) => TEXT_UNIT_NAMES.has(r.leaf)).map((r) => r.leaf))];
+    if (textLeaves.length === 0) continue;
+    const otherLeaves = [...new Set(rs.filter((r) => !TEXT_UNIT_NAMES.has(r.leaf)).map((r) => r.leaf))];
+    if (otherLeaves.length) ambiguous.push({ path, textLeaves, otherLeaves });
+    else typographic.add(path);
+  }
+
+  // A primitive nothing references has no structural signal at all, so it is
+  // never inferred. Reported instead, where its group holds one that was: that
+  // is the strongest hint available without guessing, and a silent gap is the
+  // failure this module exists to prevent. A token whose source already stamps
+  // nativeUnit is closed and is not reported.
+  const inferredGroups = new Set([...typographic].map((p) => p.split('.').slice(0, -1).join('.')));
+  const unreferencedSiblings = [];
+  (function walk(node, prefix) {
+    for (const [key, val] of Object.entries(node)) {
+      if (key.startsWith('$') || !isPlainObject(val)) continue;
+      const path = [...prefix, key];
+      const dotted = path.join('.');
+      const group = prefix.join('.');
+      if (
+        '$value' in val &&
+        val.$type === 'dimension' &&
+        TEXT_ROLE_UNIT.test(String(val.$value).trim()) &&
+        !referrers.has(dotted) &&
+        !('nativeUnit' in (val.$extensions?.[EXT_NS] ?? {})) &&
+        inferredGroups.has(group)
+      ) {
+        unreferencedSiblings.push({ path: dotted, group });
+      }
+      walk(val, path);
+    }
+  })(dict, []);
+
+  return { typographic, ambiguous, unreferencedSiblings };
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `node --test scripts/lib/dtcg.test.mjs` then `node --test`
+Expected: PASS, both.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lib/dtcg.mjs scripts/lib/dtcg.test.mjs
+git commit -m "feat: infer a typographic role from the DTCG reference graph (#63)"
+```
+
+---
+
+### Task 3: Apply the inference in `preprocess`, and correct the docs it falsifies
+
+The behaviour change. Also corrects three documented claims — two this change falsifies, one already stale.
+
+**Files:**
+- Modify: `scripts/lib/sd-native.mjs` (new `applyTextRoleGraph`, new `preprocess` body, comment at `:330-334`)
+- Modify: `scripts/build-native-adapter-config.mjs` (the `platform` prose, ~line 126)
+- Test: `scripts/lib/sd-native.test.mjs`
+- Regenerate: `references/native-adapter-config.md`
+
+**Interfaces:**
+- Consumes: `textRoleGraph` from Task 2; `TEXT_ROLE_UNIT`, `EXT_NS` from Task 1.
+- Produces: no new export. `preprocess(dict)` keeps its signature and return shape.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/lib/sd-native.test.mjs`:
+
+```js
+const roleDict = () => ({
+  text: { base: { $type: 'dimension', $value: '16px' }, huge: { $type: 'dimension', $value: '96px' } },
+  space: { md: { $type: 'dimension', $value: '8px' } },
+  typography: {
+    body: { fontSize: { $type: 'dimension', $value: '{text.base}' } },
+    gutter: { $type: 'dimension', $value: '{space.md}' },
+  },
+});
+const stampOf = (node) => node.$extensions?.[EXT_NS]?.nativeUnit;
+
+test('a primitive referenced only by a fontSize is stamped as text', () => {
+  const out = preprocess(roleDict());
+  assert.equal(stampOf(out.text.base), 'text');
+});
+
+test('a primitive referenced by a role-less member is left alone', () => {
+  const out = preprocess(roleDict());
+  assert.equal(stampOf(out.space.md), undefined);
+  assert.equal(stampOf(out.text.huge), undefined, 'nothing references it');
+});
+
+test('inference does not overwrite a role the source stated', () => {
+  const dict = roleDict();
+  dict.text.base.$extensions = { [EXT_NS]: { nativeUnit: 'length' } };
+  const out = preprocess(dict);
+  assert.equal(stampOf(out.text.base), 'length', 'a source opt-out survives the inference');
+});
+
+test('inference never stamps a unitless value', () => {
+  const dict = roleDict();
+  dict.text.base.$value = '1.5';
+  const out = preprocess(dict);
+  assert.equal(stampOf(out.text.base), undefined, 'a ratio is not a text-role dimension');
+});
+
+test('an unresolvable reference does not throw the inference', () => {
+  const dict = { typography: { body: { fontSize: { $type: 'dimension', $value: '{nope.missing}' } } } };
+  const out = preprocess(dict);
+  assert.equal(out.typography.body.fontSize.$value, '{nope.missing}', 'left in place for SD to report');
+});
+
+test('preprocess stays idempotent with the inference in place', () => {
+  const once = preprocess(roleDict());
+  assert.deepEqual(preprocess(once), once);
+});
+
+test('an em letterSpacing primitive reaches Compose once the graph stamps it', () => {
+  const dict = {
+    tracking: { tight: { $type: 'dimension', $value: '-0.03em' } },
+    typography: { body: { letterSpacing: { $type: 'dimension', $value: '{tracking.tight}' } } },
+  };
+  const out = preprocess(dict);
+  assert.equal(stampOf(out.tracking.tight), 'text');
+  const asToken = (n) => ({ ...n, original: { $value: n.$value } });
+  assert.equal(nativeFilter(asToken(out.tracking.tight), 'android-kotlin'), true);
+});
+```
+
+Add `preprocess, nativeFilter, EXT_NS` to that file's import if any is missing.
+
+- [ ] **Step 2: Run and watch them fail**
+
+Run: `node --test scripts/lib/sd-native.test.mjs`
+Expected: FAIL on the stamp assertions; the idempotency and unresolvable-reference tests may already pass.
+
+- [ ] **Step 3: Add `applyTextRoleGraph`**
+
+Insert immediately after `classifyTextUnits`'s closing brace, still inside the `preprocess` `@doc-section`:
+
+```js
+// Runs AFTER classifyTextUnits and BEFORE hoistDualNodes, on the SAME two
+// grounds that pass gives: after, so a role the source or the member name
+// already stated wins; before, because the hoist rewrites text.xs.lineHeight to
+// text.xsLineHeight and the graph's paths are written in pre-hoist names.
+//
+// The three gates are classifyTextUnits's, verbatim — a dimension, a value with
+// a unit, and no role already recorded. A unitless value is never stamped: no
+// size transform claims one since #52, and stamping a ratio as text would still
+// be a claim the source never made.
+//
+// A path may name no node at all. resolveInPlace deliberately leaves an
+// unresolvable reference in place for Style Dictionary to report, so the graph
+// can hold an edge to a token that does not exist. Skip it. This is also what
+// keeps the second preprocess pass from throwing, and idempotency with it.
+function applyTextRoleGraph(node, typographic) {
+  for (const path of typographic) {
+    let target = node;
+    for (const segment of path.split('.')) {
+      target = target && typeof target === 'object' ? target[segment] : undefined;
+    }
+    if (!target || typeof target !== 'object' || !('$value' in target)) continue;
+    if (target.$type !== 'dimension') continue;
+    if (!TEXT_ROLE_UNIT.test(String(target.$value).trim())) continue;
+    target.$extensions ??= {};
+    target.$extensions[EXT_NS] ??= {};
+    const ns = target.$extensions[EXT_NS];
+    if (!('nativeUnit' in ns)) ns.nativeUnit = 'text';
+  }
+  return node;
+}
+```
+
+- [ ] **Step 4: Wire it into `preprocess`**
+
+Replace the opening of `preprocess` — currently:
+
+```js
+export function preprocess(dict) {
+  const collisions = [];
+  const out = hoistDualNodes(
+    classifyTextUnits(resolveInPlace(structuredClone(dict), flattenDtcg(dict))),
+    collisions,
+  );
+```
+
+with:
+
+```js
+export function preprocess(dict) {
+  const collisions = [];
+  // Read from the UNRESOLVED dict, before resolveInPlace flattens the aliases
+  // the graph is made of.
+  const { typographic } = textRoleGraph(dict);
+  const out = hoistDualNodes(
+    applyTextRoleGraph(
+      classifyTextUnits(resolveInPlace(structuredClone(dict), flattenDtcg(dict))),
+      typographic,
+    ),
+    collisions,
+  );
+```
+
+Add `textRoleGraph` to the `./dtcg.mjs` import list at line 13.
+
+- [ ] **Step 5: Correct the three documented claims**
+
+In `scripts/lib/sd-native.mjs`, replace the two bullets at `:330-334` — currently:
+
+```js
+//   - A scale primitive carries no role. text.base: "16px" is a font size only
+//     to a human, so it emits as dp. The semantic tokens referencing it are
+//     correct, and those are what a consumer should reach for.
+//   - An em-valued letterSpacing is filtered out of native output entirely,
+//     rather than emitted as Compose's .em TextUnit.
+```
+
+with:
+
+```js
+//   - A scale primitive states no role, so #63 infers one from the reference
+//     graph: a dimension referenced only by fontSize, letterSpacing or
+//     lineHeight members is itself typographic. text.base: "16px" is stamped
+//     because a fontSize references it. What remains is the primitive NOTHING
+//     references — no structural signal exists for it, so it is not inferred,
+//     and tokens:validate-output raises an unreferenced-text-sibling advisory
+//     naming it rather than leaving the gap silent.
+//   - An em-valued letterSpacing reaches Compose as a real .em TextUnit since
+//     #64, but only where the text role is stamped. A role-less em value is
+//     still filtered out of native output entirely.
+```
+
+In `scripts/build-native-adapter-config.mjs`, replace the first "What remains" bullet at ~line 126 — currently:
+
+```
+- **A bare scale primitive emits as \`dp\`.** \`text.base: "16px"\` is a font size
+  only to a human — no nominal or structural signal marks it — so it is not
+  stamped. The semantic tokens that reference it are, and those are what a
+  consumer should reach for.
+```
+
+with:
+
+```
+- **A scale primitive nothing references emits as \`dp\`.** \`text.base: "16px"\`
+  is a font size only to a human, so #63 takes the role from the reference
+  graph instead: a dimension referenced only by \`fontSize\`, \`letterSpacing\` or
+  \`lineHeight\` members is stamped typographic too. That is structural rather
+  than nominal, so it needs no path convention. A primitive **nothing**
+  references has no signal at all and is not inferred —
+  \`tokens:validate-output\` names it with an \`unreferenced-text-sibling\`
+  advisory, and a source-side \`nativeUnit\` stamp settles it.
+```
+
+- [ ] **Step 6: Run the tests**
+
+Run: `node --test`
+Expected: PASS. A pre-existing `sd-native` test that now fails is a **finding** — report it rather than editing the assertion.
+
+- [ ] **Step 7: Regenerate and gate**
+
+```bash
+node scripts/build-native-adapter-config.mjs
+node scripts/build-native-adapter-config.mjs --check
+```
+Expected: `--check` exits 0.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add scripts/lib/sd-native.mjs scripts/lib/sd-native.test.mjs scripts/build-native-adapter-config.mjs references/native-adapter-config.md
+git commit -m "feat: preprocess stamps a role the reference graph proves (#63)"
+```
+
+---
+
+### Task 4: The two advisories in `tokens:validate-output`
+
+Non-gating notes. The point of the whole task is the token that has **no emitted symbol**, so this cannot ride the existing declaration loop.
+
+**Files:**
+- Modify: `scripts/validate-token-output.mjs` (`validate`, `formatReport`, imports)
+- Test: `scripts/validate-token-output.test.mjs`
+
+**Interfaces:**
+- Consumes: `textRoleGraph`, `mergeDtcg` (Task 2), `EXT_NS` (Task 1).
+- Produces: two advisory shapes on `validate(...).advisories` — `{ rule: 'unreferenced-text-sibling', token, group }` and `{ rule: 'ambiguous-text-role', token, textLeaves, otherLeaves }`. Neither carries `symbol`, and neither affects `ok`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/validate-token-output.test.mjs`:
+
+```js
+const roleSources = () => [
+  {
+    file: 'tokens.json',
+    dtcg: {
+      text: { base: { $type: 'dimension', $value: '16px' }, huge: { $type: 'dimension', $value: '96px' } },
+      tracking: { widest: { $type: 'dimension', $value: '0.15em' }, tight: { $type: 'dimension', $value: '-0.03em' } },
+      typography: {
+        body: {
+          fontSize: { $type: 'dimension', $value: '{text.base}' },
+          letterSpacing: { $type: 'dimension', $value: '{tracking.tight}' },
+        },
+      },
+    },
+  },
+];
+
+test('an unreferenced sibling is advised even though nothing emitted it', () => {
+  const r = validate({
+    sources: roleSources(),
+    output: 'object Tokens {\n  val textBase = 16.00.sp\n}\n',
+    platform: 'android-kotlin',
+    minMatch: 0,
+  });
+  const advised = r.advisories.filter((a) => a.rule === 'unreferenced-text-sibling').map((a) => a.token);
+  assert.ok(advised.includes('tracking.widest'), 'dropped from output entirely — the case that matters');
+  assert.ok(advised.includes('text.huge'));
+  assert.ok(
+    r.advisories.every((a) => a.rule !== 'unreferenced-text-sibling' || !('symbol' in a)),
+    'these advisories name a token path, not a symbol',
+  );
+});
+
+test('an advisory is never a failure', () => {
+  const r = validate({
+    sources: roleSources(),
+    output: 'object Tokens {\n  val textBase = 16.00.sp\n}\n',
+    platform: 'android-kotlin',
+    minMatch: 0,
+  });
+  assert.ok(r.advisories.length > 0, 'the fixture must actually produce advisories');
+  assert.deepEqual(r.failures, [], 'advisories are reported, not gating');
+  // Asserted on failures rather than on r.ok: ok also folds in the match rate,
+  // so a green assertion there could be green for an unrelated reason.
+});
+
+test('a token referenced by both roles is advised as ambiguous', () => {
+  const sources = roleSources();
+  sources[0].dtcg.space = { pad: { $type: 'dimension', $value: '{text.base}' } };
+  const r = validate({
+    sources,
+    output: 'object Tokens {\n  val textBase = 16.00.dp\n}\n',
+    platform: 'android-kotlin',
+    minMatch: 0,
+  });
+  const a = r.advisories.find((x) => x.rule === 'ambiguous-text-role');
+  assert.ok(a, 'both-roles is reported, not silently declined');
+  assert.equal(a.token, 'text.base');
+  assert.deepEqual(a.otherLeaves, ['pad']);
+});
+
+test('formatReport renders a symbol-less advisory without printing undefined', () => {
+  const r = validate({
+    sources: roleSources(),
+    output: 'object Tokens {\n  val textBase = 16.00.sp\n}\n',
+    platform: 'android-kotlin',
+    minMatch: 0,
+  });
+  const text = formatReport(r).join('\n');
+  assert.ok(text.includes('tracking.widest'));
+  assert.ok(!/undefined/.test(text), 'a missing symbol must never reach the report');
+});
+```
+
+- [ ] **Step 2: Run and watch them fail**
+
+Run: `node --test scripts/validate-token-output.test.mjs`
+Expected: FAIL — no such advisories are produced.
+
+- [ ] **Step 3: Extend the imports**
+
+In `scripts/validate-token-output.mjs`, change the `./lib/dtcg.mjs` import to:
+
+```js
+import {
+  flattenDtcg,
+  flattenDtcgTypes,
+  resolveValue,
+  findModeCollisions,
+  textRoleGraph,
+  mergeDtcg,
+  EXT_NS,
+} from './lib/dtcg.mjs';
+```
+
+- [ ] **Step 4: Add the source-side pass**
+
+In `validate`, immediately after the `for (const { symbol, value } of decls)` loop closes and before `const matchRate = ...`:
+
+```js
+  // A SOURCE-side pass, deliberately not part of the loop above. That loop
+  // iterates emitted declarations, and the token this advisory exists for is
+  // the one that was never emitted at all — an em letterSpacing whose role
+  // nothing states is filtered out of native output, so it has no symbol to
+  // hang a note on.
+  //
+  // Merged rather than unioned across sources: the graph must describe the
+  // build that actually ran, and a build merges with the later source winning.
+  // A union would call a token referenced when this build did not reach it,
+  // under-reporting the gap in the one direction that matters.
+  const graph = textRoleGraph(mergeDtcg(sources.map((s) => s.dtcg)));
+  for (const { path, group } of graph.unreferencedSiblings) {
+    advisories.push({ rule: 'unreferenced-text-sibling', token: path, group });
+  }
+  for (const { path, textLeaves, otherLeaves } of graph.ambiguous) {
+    advisories.push({ rule: 'ambiguous-text-role', token: path, textLeaves, otherLeaves });
+  }
+```
+
+- [ ] **Step 5: Render them**
+
+In `formatReport`, replace the body of the advisory loop — currently a single `lines.push(...)` — with:
+
+```js
+    for (const a of r.advisories) {
+      if (a.rule === 'unreferenced-text-sibling') {
+        lines.push(
+          `  - [${a.rule}] ${a.token}: nothing references it, so no typographic role could be inferred — but tokens in "${a.group}" were. It emits as a length, or is dropped entirely if its unit is em. Stamp $extensions["${EXT_NS}"].nativeUnit = "text" on it in source to settle it, or leave it if it is not a text value.`,
+        );
+        continue;
+      }
+      if (a.rule === 'ambiguous-text-role') {
+        lines.push(
+          `  - [${a.rule}] ${a.token}: referenced both by typographic member(s) [${a.textLeaves.join(', ')}] and by [${a.otherLeaves.join(', ')}], so no role was inferred rather than a role being guessed. Stamp $extensions["${EXT_NS}"].nativeUnit in source to settle it.`,
+        );
+        continue;
+      }
+      lines.push(
+        `  - [${a.rule}] ${a.symbol}: source ${JSON.stringify(a.source)} for ${a.token} is a dimension with no unit, which DTCG §8.2.1 does not permit. It emitted ${a.emitted}, read as a ratio. If it is a ratio, type it "number" (§8.7); if it is a measurement, add the unit you meant.`,
+      );
+    }
+```
+
+- [ ] **Step 6: Run the tests**
+
+Run: `node --test`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/validate-token-output.mjs scripts/validate-token-output.test.mjs
+git commit -m "feat: name the primitives the graph could not reach, instead of dropping them silently (#63)"
+```
+
+---
+
+### Task 5: e2e against zygarden, compile the output, then the changelog
+
+The spec's §6 table is a prediction. Measure it. A number that misses is a finding, not a number to edit.
+
+**Files:**
+- Create: `docs/superpowers/notes/2026-08-28-text-role-inference-e2e.md`
+- Modify: `CHANGELOG.md` (`## [Unreleased]`)
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-4.
+- Produces: measured counts for the changelog entry.
+
+- [ ] **Step 1: Build both platforms against real source**
+
+Follow the procedure in `docs/superpowers/notes/2026-08-21-native-config-e2e-results.md`, using zygarden's source at `~/Dev/zygarden-frontend/libs/shared/util-tokens/src/tokens/`.
+
+**Record which mode files the build included, before running it.** Per spec §8 the inference is mode-dependent — `text.6xl`'s only referrer lives in `typography-semantic.desktop.json` — so a count without its mode set cannot be reproduced.
+
+- [ ] **Step 2: Count and compare against the prediction**
+
+```bash
+grep -c 'val ' Tokens.kt
+grep -c 'static let' Tokens.swift
+grep -c '\.sp$\|\.sp[^a-z]' Tokens.kt
+```
+
+| | before | spec §6 predicts | measured |
+|---|--:|--:|--:|
+| Kotlin declarations | 208 | 211 | |
+| Swift declarations | 195 | 195 | |
+| Kotlin symbols changed dp → sp | — | 9 or 10 | |
+
+- [ ] **Step 3: Compile the output**
+
+```bash
+node ci/compile-native-output.mjs <build-dir>
+```
+Expected: exit 0, Kotlin PASS, Swift PASS. A Kotlin failure here is the real risk — `TextUnit` and `Dp` are different types and nine symbols just changed.
+
+- [ ] **Step 4: Run the validator and read the advisories**
+
+```bash
+node scripts/validate-token-output.mjs --source <each json> --output Tokens.kt --platform android-kotlin
+```
+Expected: `unreferenced-text-sibling` naming `typography.letterSpacing.widest` and the unreferenced `text.*` tail. Confirm no `ambiguous-text-role` — spec §1 measured zero on this source, so one appearing means the merge differs from what was measured.
+
+- [ ] **Step 5: Write the note**
+
+Record: the mode set, every count, the full advisory output, the compile result, and any place the measurement disagreed with §6. Say so plainly where it did.
+
+- [ ] **Step 6: Correct the handoff note's stale number**
+
+Spec §2.1 records that `docs/superpowers/notes/2026-08-28-v0.16.0-shipped-handoff.md`
+repeats the issue's wrong figure. Find the line reading:
+
+```
+#63 would take Android to 2 unmatched, both genuinely impossible.
+```
+
+Replace `2 unmatched` with the number Step 2 actually measured, and add one
+clause saying why it is not 2 — `typography.letterSpacing.widest` is referenced
+by nothing, so the reference graph cannot reach it. Do not edit the surrounding
+paragraph.
+
+- [ ] **Step 7: Add the changelog entry**
+
+Under `## [Unreleased]`, using measured numbers, not predicted ones:
+
+```markdown
+### Breaking
+
+- **A scale primitive referenced only by typographic members now emits `sp`, not
+  `dp`.** `text.base: "16px"` was a font size only to a human; its role is now
+  taken from the reference graph. On Android the symbol's type changes from `Dp`
+  to `TextUnit`, so a use site like `Modifier.padding(Tokens.textBase)` stops
+  compiling. That is the point — those symbols were always font sizes. Swift is
+  unchanged; the sp/dp distinction is Compose-only.
+
+### Fixed
+
+- **An `em` letter-spacing primitive reaches Compose instead of being dropped.**
+  #64 made `em` emit as a real `.em` TextUnit but only where the role was
+  stamped, which reached the `typography.textStyle.*` members and not the
+  primitives they reference. The graph now reaches those too.
+
+### Added
+
+- **`tokens:validate-output` names the primitives the graph could not reach.**
+  A dimension nothing references has no structural signal, so no role is
+  inferred — `unreferenced-text-sibling` names it and points at the
+  `$extensions` stamp that settles it. `ambiguous-text-role` names a token
+  referenced by both a typographic and a non-typographic member, which is
+  declined rather than guessed. Both are advisories: reported, never gating.
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add docs/superpowers/notes/2026-08-28-text-role-inference-e2e.md CHANGELOG.md docs/superpowers/notes/2026-08-28-v0.16.0-shipped-handoff.md
+git commit -m "docs: e2e proof of the inference against zygarden, and the changelog (#63)"
+```

--- a/docs/superpowers/specs/2026-08-28-text-role-inference-design.md
+++ b/docs/superpowers/specs/2026-08-28-text-role-inference-design.md
@@ -1,0 +1,263 @@
+# Text-role inference from the reference graph — design
+
+**Issue:** #63 (with the #64 evidence comment)
+**Date:** 2026-08-28
+**Status:** approved in chat, not yet planned
+
+A scale primitive states no typographic role, so `text.base: "16px"` emits as
+`16.00.dp` on Android and `typography.letterSpacing.widest: "0.15em"` is dropped
+from output entirely. #51 sources the role from the member names DTCG §9.8 fixes
+for the typography composite — `fontSize`, `letterSpacing`, `lineHeight` — which
+covers semantic tokens and not the primitives they reference.
+
+This design infers the role for a primitive from the **reference graph**: a
+dimension referenced only by typographic members is itself typographic. That is
+structural rather than nominal, so it needs no `text.*` path convention and no
+spec backing the spec does not give.
+
+## 1. What was measured
+
+Measured on zygarden's real source (`libs/shared/util-tokens/src/tokens/`,
+15 files), not reasoned about. Measured **twice**, because the first measurement
+was wrong in a way worth recording.
+
+Merging the 15 files as a build merges them — later file wins on a colliding
+path — gives 101 edges and reports `text.6xl` as unreferenced. Taking the
+**union** of edges across all 15 files gives **194 edges**, and `text.6xl` has a
+referrer after all: it lives in `typography-semantic.desktop.json`, which
+`typography-semantic.mobile.json` overwrote in the merge.
+
+| token group | tokens | reached | unreferenced |
+|---|--:|--:|--:|
+| `text.*` | 13 | 10 (`xs`–`6xl`) | 3 (`7xl`–`9xl`) |
+| `typography.letterSpacing.*` | 4 | 3 | 1 (`widest`) |
+| **total** | **17** | **13** | **4** |
+
+Every one of the 13 is referenced **only** by leaf names in
+`{fontSize, letterSpacing, lineHeight}`. **Zero mixed cases** across the whole
+source, in either direction: nothing outside these two groups is reached by a
+typographic reference, and nothing inside them is reached by a non-typographic
+one.
+
+The 4 the graph cannot reach are **unreferenced** — nothing in the source points
+at them at all. That is not a shortcoming of the rule; it is the absence of any
+structural signal whatsoever.
+
+**The reach is therefore mode-dependent**, which §8 states as a limitation
+rather than leaving to be discovered.
+
+`$type: "dimension"` sits on each token node directly in this source, not
+inherited from the group, so the propagation gate can mirror
+`classifyTextUnits`'s existing check exactly rather than resolve inherited types.
+
+## 2. Three corrections to the issue's own text
+
+The issue and its comment were written before any of this was measured. Each of
+these was checked rather than assumed, and the design depends on them.
+
+**2.1 "Closing this issue would take Android from 6 unmatched to 2" is wrong.**
+It is **6 → 3**. The 6 are the four `letterSpacing` primitives plus a
+`linear-gradient()` and a `100%`. The graph reaches three of the four;
+`typography.letterSpacing.widest` is referenced by nothing, under either
+measurement in §1, and stays dropped.
+This number was repeated into the v0.16.0 handoff note, which should be
+corrected when this lands.
+
+**2.2 "The graph would have to be captured during `resolveInPlace` and carried,
+most likely on `$extensions`" is not so.** Nothing needs carrying. `preprocess`
+already holds the **unresolved** dict — it clones it before resolving — so the
+graph is computed from the original and the stamp applied to the clone, entirely
+within one `preprocess` call. Only the stamp survives, which is exactly what
+`classifyTextUnits` already does. `resolveInPlace` does not change, and #55's
+`WeakSet` is not involved.
+
+**2.3 "A token referenced by both a `fontSize` and a spacing role has no
+obviously correct answer" — it has one: decline and say so.** Measured, the case
+does not occur on this source at all. The rule is still written for it, because
+a silent guess in an ambiguous case is the failure class this module exists to
+prevent.
+
+Also worth recording: the issue calls the graph "the only option that reaches all
+52 typographic tokens." It does not reach all of them, per §1.
+
+## 3. The rule
+
+A **whole-value reference edge** is `{ from, to, leaf }` where a token's
+authored `$value` is exactly `{some.path}`. A referrer is **typographic** when
+its leaf name is in `TEXT_UNIT_NAMES` = `{fontSize, letterSpacing, lineHeight}`.
+
+A referrer whose leaf name is anything else is **counter-evidence, not neutral.**
+A dimension referenced by something that is not a typographic member is a length
+— which is precisely what the current `dp` default already asserts about it.
+Treating it as neutral would let a single typographic reference convert a
+spacing ramp.
+
+> **Stamp a referent `nativeUnit: "text"` iff it has at least one referrer and
+> every one of its referrers is typographic.**
+
+Then the same three gates `classifyTextUnits` applies, verbatim:
+
+1. `$type === 'dimension'`
+2. the value matches `TEXT_ROLE_UNIT` — so a unitless ratio is never stamped,
+   because stamping one would be a claim the source never made (#52)
+3. `nativeUnit` is not already present — so a source-authored stamp still wins
+
+Gate 3 gives both an **escape hatch** and an **opt-out** for free: a source can
+stamp `nativeUnit: "text"` on a token the graph cannot reach, or stamp anything
+else to decline the inference. Both already work today, by way of the
+`!('nativeUnit' in ns)` guard, and both were verified by running `preprocess`
+rather than read off the source. Neither is documented and nothing pins them.
+
+**Single-pass, not transitive.** A chain `fontSize → {alias.x} → {text.base}`
+is declined at the second hop, because `alias.x`'s leaf name states no role and
+is therefore counter-evidence. Zygarden has no such chain — every edge is
+direct. A fixpoint would need a semantics for the intermediate that cannot be
+justified from the spec, so this is a stated limitation (§8), not an oversight.
+
+## 4. Where the code lives
+
+`textRoleGraph(dict)` goes in **`scripts/lib/dtcg.mjs`**, a pure function over
+the unresolved source tree, returning:
+
+- `typographic: Set<path>` — referents every referrer of which is typographic
+- `ambiguous: [{ path, textLeaves, otherLeaves }]` — declined, reported
+- `unreferencedSiblings: [{ path, group }]` — a `dimension` token with zero
+  referrers, passing `TEXT_ROLE_UNIT`, whose group holds a sibling in
+  `typographic`
+
+`dtcg.mjs` rather than `sd-native.mjs` because there are **two** consumers.
+`validate-token-output.mjs` already imports from `./lib/dtcg.mjs`, and
+`sd-native.mjs` already declares it a sibling dependency in the installation
+prose the generated doc carries. Computing the graph twice in two modules is the
+drift this repo keeps filing issues about.
+
+`TEXT_UNIT_NAMES` moves to `dtcg.mjs` and is exported; `sd-native.mjs` imports
+it. **Its explanatory comment stays in `sd-native.mjs` above the import**, so the
+generated `references/native-adapter-config.md` keeps the DTCG §9.8 rationale
+for why those three names and no others. A reader of the doc sees an import
+rather than a literal set — an accepted, small loss against having one
+definition.
+
+New order inside `preprocess`:
+
+```
+resolveInPlace → classifyTextUnits → applyTextRoleGraph → hoistDualNodes
+```
+
+**Before the hoist**, because the hoist rewrites `text.xs.lineHeight` to
+`text.xsLineHeight` and the edge paths are written in pre-hoist names.
+
+**Idempotency holds without new machinery.** On a second `preprocess` the values
+are already resolved, so there are no whole-value references, so the graph is
+empty and no new stamps appear; the stamps from the first pass survive
+`structuredClone`. This is the same argument `classifyTextUnits` already relies
+on, and `preprocess(preprocess(x))` stays `deepEqual` to `preprocess(x)`.
+
+## 5. The advisory
+
+Two new `tokens:validate-output` advisories, both **reported, not gating**,
+joining `unitless-dimension` under the existing "advisory note(s)" heading:
+
+- **`unreferenced-text-sibling`** — a `dimension` token nothing references, whose
+  group has siblings the graph did infer typographic. Names the token, names the
+  group, and states that a source-side `nativeUnit: "text"` stamp closes it.
+  This is what keeps the 4 from §1 from being a silent gap, and what makes the
+  mode dependence in §8 visible rather than mysterious.
+- **`ambiguous-text-role`** — a token with referrers on both sides. Names both
+  sets of leaf names so the author can see what disagreed.
+
+**One structural wrinkle.** `validate`'s existing loop iterates **emitted
+declarations**, and `typography.letterSpacing.widest` is never emitted — the `em`
+filter drops it. So this advisory cannot ride the declaration loop and needs a
+**source-side** pass. `formatReport`'s advisory rendering also assumes
+`a.symbol` exists; these advisories carry a token path and may carry no symbol
+at all. Both are new shape rather than a tweak, and are the part of this work
+most likely to be got subtly wrong.
+
+## 6. What changes in emitted output
+
+This is a **breaking** change and gets a `Breaking` changelog entry.
+
+The table below is a **prediction to be verified at e2e time against real
+output**, not a claim:
+
+| | now | predicted |
+|---|--:|--:|
+| Kotlin declarations | 208 | 211 |
+| Swift declarations | 195 | 195 |
+| Android unmatched source tokens | 6 | 3 |
+| iOS unmatched source tokens | 19 | 19 |
+
+- `letterSpacing.{tight,normal,wide}` stop being filtered out of Compose output
+  and emit as `.em` TextUnits — the three new declarations.
+- `text.xs`–`text.5xl` change from `16.00.dp` (type `Dp`) to `16.00.sp` (type
+  `TextUnit`), and `text.6xl` joins them in a build whose mode set includes the
+  desktop typography file. **Nine or ten Kotlin symbols change type**, which of
+  the two being mode-dependent per §8 — so the e2e records the mode set it built
+  rather than reporting a bare number. A consumer using `Tokens.textBase` at a
+  `Modifier.padding` site stops compiling. That is the break, and it is the
+  correct one: those symbols were always font sizes.
+- Swift is untouched. The `sp`/`dp` distinction is Compose-only, and iOS letter
+  spacing stays deliberately excluded (§9).
+
+`ci/compile-native-output.mjs` (#81) verifies the new Kotlin actually compiles
+rather than merely differing.
+
+## 7. Testing
+
+**Unit, on `textRoleGraph`** — fixtures covering: referrers all typographic;
+referrers mixed; zero referrers; a chain through a role-less intermediate; a
+unitless referent; a dual node (`$value` plus a `lineHeight` child, since that
+is the shape this source is full of); and a referent already carrying a source
+stamp.
+
+**Unit, on `preprocess`** — that the stamp lands, that idempotency holds, that
+the escape hatch and the opt-out both work. The last two work today by accident
+of a guard nobody tests; this pins them.
+
+**Unit, on `validate`** — both advisories, including the case that matters most:
+an advisory for a token that has **no emitted symbol**.
+
+**e2e against zygarden's real source** — build both platforms, run
+`ci/compile-native-output.mjs` on the output, and diff declaration counts and
+unmatched counts against §6's table. A prediction that misses is a finding, not
+a number to edit.
+
+## 8. Limitations, stated rather than discovered later
+
+- **Four tokens remain unfixed** on this source, and any source's unreferenced
+  primitives will too. They are named by an advisory, not silently skipped.
+- **The inference is mode-dependent.** `textRoleGraph` sees the dict the build
+  merged, so a primitive referenced only from the desktop typography set is
+  inferred typographic in a desktop build and not in a mobile one — the same
+  token emitting `sp` in one and `dp` in the other. `text.6xl` is exactly this
+  case on zygarden. This follows from inferring anything from a reference graph
+  at all and is not separately fixable; the `unreferenced-text-sibling` advisory
+  is what makes it visible, and a source-side stamp is what settles it. The e2e
+  must record which mode set it built, or its counts cannot be reproduced.
+- **No transitive inference.** A reference chain through a role-less
+  intermediate is declined.
+- **Whole-value references only.** A role-less token holding an interpolated
+  expression that embeds a reference contributes no edge. `resolveInPlace`
+  handles those for resolution; they are not evidence of a role.
+- **The inference is only as good as the source's naming.** It rests entirely on
+  DTCG §9.8's three member names, exactly as #51 does. A source naming its font
+  size `typography.body.size` is reached by neither, and stamps `$extensions`
+  itself.
+
+## 9. Out of scope
+
+- **Group-unanimity inference** — treating every member of a group as
+  typographic when its referenced members unanimously are. It reaches 17/17 on
+  zygarden and was **considered and declined**: a source whose non-typographic
+  usage is not expressed as DTCG references (component CSS reading the custom
+  property directly) would have an entire spacing ramp silently become `sp`,
+  with no edge anywhere to contradict it. That is a guess wearing the costume of
+  a structural rule.
+- **A `text.*` path convention** — no spec backing, misfires on any source using
+  `text.*` for copy strings. Rejected in the issue and still rejected.
+- **iOS letter spacing** — an `NSAttributedString` kern in points needs a font
+  size the token does not carry, so no constant Swift could emit is right at
+  every font size. Excluded deliberately, unchanged here.
+- **Making the inference configurable.** The escape hatch and opt-out in §3
+  already cover the cases a flag would, per token, from the source.

--- a/docs/superpowers/specs/2026-08-28-text-role-inference-design.md
+++ b/docs/superpowers/specs/2026-08-28-text-role-inference-design.md
@@ -21,11 +21,14 @@ Measured on zygarden's real source (`libs/shared/util-tokens/src/tokens/`,
 15 files), not reasoned about. Measured **twice**, because the first measurement
 was wrong in a way worth recording.
 
-Merging the 15 files as a build merges them — later file wins on a colliding
-path — gives 101 edges and reports `text.6xl` as unreferenced. Taking the
-**union** of edges across all 15 files gives **194 edges**, and `text.6xl` has a
-referrer after all: it lives in `typography-semantic.desktop.json`, which
-`typography-semantic.mobile.json` overwrote in the merge.
+Merging all 15 files with the later-file-wins rule a real build applies to a
+colliding path — though no real build could take all 15 at once; a 15-file
+source list collides both mode axes at once, and `nativeSources()` rejects
+that as a mode collision — gives 101 edges and reports `text.6xl` as
+unreferenced. Taking the **union** of edges across all 15 files gives **194
+edges**, and `text.6xl` has a referrer after all: it lives in
+`typography-semantic.desktop.json`, which `typography-semantic.mobile.json`
+overwrote in the merge.
 
 | token group | tokens | reached (**union**) | unreferenced |
 |---|--:|--:|--:|

--- a/docs/superpowers/specs/2026-08-28-text-role-inference-design.md
+++ b/docs/superpowers/specs/2026-08-28-text-role-inference-design.md
@@ -27,11 +27,16 @@ path — gives 101 edges and reports `text.6xl` as unreferenced. Taking the
 referrer after all: it lives in `typography-semantic.desktop.json`, which
 `typography-semantic.mobile.json` overwrote in the merge.
 
-| token group | tokens | reached | unreferenced |
+| token group | tokens | reached (**union**) | unreferenced |
 |---|--:|--:|--:|
 | `text.*` | 13 | 10 (`xs`–`6xl`) | 3 (`7xl`–`9xl`) |
 | `typography.letterSpacing.*` | 4 | 3 | 1 (`widest`) |
 | **total** | **17** | **13** | **4** |
+
+**"Reached" here is the union across all 15 files, not what any one build
+sees.** No single build reaches 10 `text.*` tokens, because the viewport axis
+must be pinned and each pin drops a different referrer — see §6 and §8. Read
+this table as the ceiling the source could support, never as a per-build count.
 
 Every one of the 13 is referenced **only** by leaf names in
 `{fontSize, letterSpacing, lineHeight}`. **Zero mixed cases** across the whole
@@ -278,11 +283,16 @@ output**, not a claim:
 
 - `letterSpacing.{tight,normal,wide}` stop being filtered out of Compose output
   and emit as `.em` TextUnits — the three new declarations.
-- `text.xs`–`text.5xl` change from `16.00.dp` (type `Dp`) to `16.00.sp` (type
-  `TextUnit`), and `text.6xl` joins them in a build whose mode set includes the
-  desktop typography file. **Nine or ten Kotlin symbols change type**, which of
-  the two being mode-dependent per §8 — so the e2e records the mode set it built
-  rather than reporting a bare number. A consumer using `Tokens.textBase` at a
+- **Nine Kotlin symbols change type** from `Dp` to `TextUnit` — `16.00.dp`
+  becomes `16.00.sp` — in *any* single build, on either viewport pin. **Ten is
+  unreachable by any single build.** The two pins reach nine each and it is not
+  the same nine: `typography-semantic.mobile.json` references
+  `text.{xs,sm,base,lg,xl,2xl,3xl,4xl,5xl}` and
+  `typography-semantic.desktop.json` references
+  `text.{xs,sm,base,xl,2xl,3xl,4xl,5xl,6xl}` — a straight `text.lg` ↔ `text.6xl`
+  swap. Ten is the union across both files (§1), which no build merges. So the
+  e2e records the mode set it built, because the *set* is mode-dependent even
+  though the *count* is not. A consumer using `Tokens.textBase` at a
   `Modifier.padding` site stops compiling. That is the break, and it is the
   correct one: those symbols were always font sizes.
 - Swift is untouched. The `sp`/`dp` distinction is Compose-only, and iOS letter
@@ -326,14 +336,20 @@ a number to edit.
 
 - **Four tokens remain unfixed** on this source, and any source's unreferenced
   primitives will too. They are named by an advisory, not silently skipped.
-- **The inference is mode-dependent.** `textRoleGraph` sees the dict the build
-  merged, so a primitive referenced only from the desktop typography set is
-  inferred typographic in a desktop build and not in a mobile one — the same
-  token emitting `sp` in one and `dp` in the other. `text.6xl` is exactly this
-  case on zygarden. This follows from inferring anything from a reference graph
-  at all and is not separately fixable; the `unreferenced-text-sibling` advisory
-  is what makes it visible, and a source-side stamp is what settles it. The e2e
-  must record which mode set it built, or its counts cannot be reproduced.
+- **The inference is mode-dependent, and symmetrically so.** `textRoleGraph`
+  sees the dict the build merged, so a primitive referenced only from one
+  viewport's typography set is inferred typographic in that build and not in the
+  other — the same token emitting `sp` in one and `dp` in the other. On zygarden
+  this is a **swap, not one stray token**: `text.6xl` is referenced only from
+  `typography-semantic.desktop.json`, and `text.lg` only from
+  `typography-semantic.mobile.json`. Each pin therefore stamps nine and files an
+  advisory for the one it lost. **The count is stable across pins even though
+  the set is not**, which is what makes this easy to miss: comparing bare totals
+  between two mode sets shows no difference at all. This follows from inferring
+  anything from a reference graph and is not separately fixable; the
+  `unreferenced-text-sibling` advisory is what makes it visible, and a
+  source-side stamp is what settles it. The e2e must record which mode set it
+  built, or its counts cannot be reproduced.
 - **No transitive inference.** A reference chain through a role-less
   intermediate is declined.
 - **Whole-value references only.** A role-less token holding an interpolated

--- a/docs/superpowers/specs/2026-08-28-text-role-inference-design.md
+++ b/docs/superpowers/specs/2026-08-28-text-role-inference-design.md
@@ -138,6 +138,23 @@ for why those three names and no others. A reader of the doc sees an import
 rather than a literal set — an accepted, small loss against having one
 definition.
 
+**`TEXT_ROLE_UNIT` and `EXT_NS` move with it, by the same rule.**
+`textRoleGraph` needs `TEXT_ROLE_UNIT` for gate 2 and for defining
+`unreferencedSiblings`, and needs `EXT_NS` to skip a token whose source already
+carries a stamp. Both live in `sd-native.mjs` today, and `sd-native.mjs` imports
+`dtcg.mjs` (line 13) — so `dtcg.mjs` reaching back for either would be an import
+**cycle**. All three constants therefore move to `dtcg.mjs`, each keeping its
+explanatory comment at the import site in `sd-native.mjs` so the generated doc
+keeps its rationale. `sd-native.mjs` **re-exports `EXT_NS`**, which is already
+part of its public surface: the transforms and their tests address the same key.
+
+This is also what keeps the validator's install footprint unchanged.
+`dtcg.mjs`'s own header records that it is copied alongside
+`validate-token-output.mjs`, while `sd-native.mjs` installs separately. Putting
+`EXT_NS` in `dtcg.mjs` lets the advisory read the stamp without
+`validate-token-output.mjs` acquiring a new install-time sibling — which would
+otherwise be a real consequence of a decision that looks purely cosmetic.
+
 New order inside `preprocess`:
 
 ```
@@ -147,11 +164,64 @@ resolveInPlace → classifyTextUnits → applyTextRoleGraph → hoistDualNodes
 **Before the hoist**, because the hoist rewrites `text.xs.lineHeight` to
 `text.xsLineHeight` and the edge paths are written in pre-hoist names.
 
-**Idempotency holds without new machinery.** On a second `preprocess` the values
-are already resolved, so there are no whole-value references, so the graph is
-empty and no new stamps appear; the stamps from the first pass survive
-`structuredClone`. This is the same argument `classifyTextUnits` already relies
-on, and `preprocess(preprocess(x))` stays `deepEqual` to `preprocess(x)`.
+**Idempotency holds — but not for the obvious reason, and the obvious reason is
+false.** It is tempting to say a second `preprocess` finds every value resolved
+and so collects no edges. That is not quite true: `resolveInPlace` deliberately
+leaves an **unresolvable** reference in place (`sd-native.mjs:103-105`) for Style
+Dictionary to report, and such a value still looks like a whole-value reference
+on a second pass. The edge set is not necessarily empty.
+
+It holds for a narrower reason. An unresolvable reference names a path that does
+not exist, so there is no referent node to stamp. **`applyTextRoleGraph` must
+therefore tolerate an edge whose referent is missing and skip it rather than
+throw** — on the first pass as much as the second. Given that, every stamp a
+second pass could apply is one the first already applied, gate 3 declines to
+overwrite it, the stamps survive `structuredClone`, and
+`preprocess(preprocess(x))` stays `deepEqual` to `preprocess(x)`.
+
+### 4.1 Files touched, and what the doc gate requires
+
+| file | change |
+|---|---|
+| `scripts/lib/dtcg.mjs` | `textRoleGraph`, `mergeDtcg`, the three moved constants |
+| `scripts/lib/sd-native.mjs` | `applyTextRoleGraph` in `preprocess`; imports the constants, re-exports `EXT_NS` |
+| `scripts/validate-token-output.mjs` | the source-side advisory pass |
+| `scripts/build-native-adapter-config.mjs` | `platform` prose (below) |
+| `references/native-adapter-config.md` | regenerated, never hand-edited |
+| `scripts/lib/dtcg.test.mjs`, `scripts/lib/sd-native.test.mjs`, `scripts/validate-token-output.test.mjs` | §7 |
+| `CHANGELOG.md` | a `Breaking` entry |
+
+`scripts/lib/sd-native.mjs` is gated by
+`node scripts/build-native-adapter-config.mjs --check`, which regenerates
+`references/native-adapter-config.md` from the module's own source between
+`@doc-section` markers, interleaved with prose held in the generator. **Every
+line of the module must fall inside a `@doc-section` pair, and every section
+needs a matching prose entry** — the generator throws otherwise. So the new code
+goes inside the existing `preprocess` section, and the gate is re-run and the
+regenerated doc committed in the same change. `references/` ships in the
+published tarball, so a stale doc here reaches consumers.
+
+**This change falsifies two documented claims. Correcting them is part of the
+work, not a follow-up:**
+
+1. `scripts/lib/sd-native.mjs:330-332` — "A scale primitive carries no role.
+   `text.base: "16px"` is a font size only to a human, so it emits as dp."
+   No longer true of a referenced primitive.
+2. `scripts/build-native-adapter-config.mjs:126` — "no nominal or structural
+   signal marks it." The structural signal is exactly what this design adds.
+
+Neither should simply be deleted. Both must state the new rule **and** its
+remaining gap — the unreferenced tail of §1 — or the doc will overclaim in the
+opposite direction.
+
+**A third claim in the same comment is already stale, before this change.**
+`sd-native.mjs:333-334` says an em-valued letterSpacing "is filtered out of
+native output entirely, rather than emitted as Compose's `.em` TextUnit." #64
+made that false for a **stamped** em value; it holds only for a role-less one.
+The generator's own prose already reflects #64 and this comment does not. It is
+corrected here rather than filed separately, because this change rewrites the
+same bullet list and makes the bullet wronger — three more tokens become
+stamped.
 
 ## 5. The advisory
 
@@ -173,6 +243,24 @@ filter drops it. So this advisory cannot ride the declaration loop and needs a
 `a.symbol` exists; these advisories carry a token path and may carry no symbol
 at all. Both are new shape rather than a tweak, and are the part of this work
 most likely to be got subtly wrong.
+
+**A token whose source already stamps `nativeUnit` is excluded from
+`unreferencedSiblings`** — it is closed already, and naming it would be noise.
+This is why `textRoleGraph` needs `EXT_NS`, and why §4 moves it.
+
+**Which tree the graph runs on.** `preprocess` receives one dict. `validate`
+receives `sources` as an **array**, and today only ever flattens them
+(`Object.assign` over `flattenDtcg` results), which destroys the group structure
+`unreferencedSiblings` needs. So `dtcg.mjs` also gains **`mergeDtcg(dicts)`**: a
+deep merge, later source winning — matching both the later-wins semantics
+`validate` already applies to values and the single merged dict Style Dictionary
+hands `preprocess`. The validator merges first, then calls `textRoleGraph` once.
+
+Deliberately a merge and **not** a union of per-source graphs. §1 is itself a
+demonstration that the two differ. The advisory exists to describe the build that
+was actually run, and a build merges; a union would report a token as reached
+when the build did not reach it, under-reporting the gap in the one direction
+that matters.
 
 ## 6. What changes in emitted output
 
@@ -215,8 +303,19 @@ stamp.
 the escape hatch and the opt-out both work. The last two work today by accident
 of a guard nobody tests; this pins them.
 
+**Unit, on `textRoleGraph`, for the cases §4 and §5 forced** — an edge whose
+referent does not exist (must skip, not throw); a token already carrying a
+source `nativeUnit` stamp (excluded from `unreferencedSiblings`); and
+`mergeDtcg` over two mode files that disagree, with the graph computed on the
+merged result, asserting the §1 behaviour that a later file's overwrite can
+remove a referrer.
+
 **Unit, on `validate`** — both advisories, including the case that matters most:
 an advisory for a token that has **no emitted symbol**.
+
+**The doc gate** — `node scripts/build-native-adapter-config.mjs --check` passes
+after regeneration, and the regenerated `references/native-adapter-config.md` is
+committed alongside. Per §4.1 this is a gate, not a nicety.
 
 **e2e against zygarden's real source** — build both platforms, run
 `ci/compile-native-output.mjs` on the output, and diff declaration counts and
@@ -240,6 +339,12 @@ a number to edit.
 - **Whole-value references only.** A role-less token holding an interpolated
   expression that embeds a reference contributes no edge. `resolveInPlace`
   handles those for resolution; they are not evidence of a role.
+- **A group-level `$type` is not seen.** The propagation gate mirrors
+  `classifyTextUnits`'s direct `val.$type === 'dimension'` check, so a source
+  declaring `$type` once on the group and not on each token is unreachable by
+  the inference. This is a pre-existing property of `classifyTextUnits` rather
+  than something introduced here, and zygarden declares `$type` on every token
+  node — but it is a real limit and this list claims to be complete.
 - **The inference is only as good as the source's naming.** It rests entirely on
   DTCG §9.8's three member names, exactly as #51 does. A source naming its font
   size `typography.body.size` is reached by neither, and stamps `$extensions`

--- a/references/native-adapter-config.md
+++ b/references/native-adapter-config.md
@@ -504,19 +504,24 @@ dependency on it.
 // That last one is fixed for tokens whose role a DTCG source actually states:
 // classifyTextUnits stamps fontSize, letterSpacing and lineHeight members, and
 // the sp transform gates on the stamp rather than on a $type DTCG never emits.
-// Two limits remain, both Android-only and both measured rather than
-// theoretical — see docs/superpowers/notes/2026-08-21-native-config-e2e-results.md:
+// Two limits remain, one Android-only and one affecting both platforms, both
+// measured rather than theoretical — see
+// docs/superpowers/notes/2026-08-28-text-role-inference-e2e.md:
 //
 //   - A scale primitive states no role, so #63 infers one from the reference
 //     graph: a dimension referenced only by fontSize, letterSpacing or
 //     lineHeight members is itself typographic. text.base: "16px" is stamped
-//     because a fontSize references it. What remains is the primitive NOTHING
-//     references — no structural signal exists for it, so it is not inferred,
-//     and tokens:validate-output raises an unreferenced-text-sibling advisory
-//     naming it rather than leaving the gap silent.
+//     because a fontSize references it. A primitive NOTHING references stays
+//     dp on Android — no structural signal exists for it, so it is not
+//     inferred, and tokens:validate-output raises an unreferenced-text-sibling
+//     advisory naming it rather than leaving the gap silent. This is not the
+//     complete list of remaining limits (spec §8 names five more); the one a
+//     consumer is likeliest to hit is mode dependence — the same token can
+//     emit sp in one build and dp in another, because the graph only sees the
+//     files that build includes.
 //   - An em-valued letterSpacing reaches Compose as a real .em TextUnit since
 //     #64, but only where the text role is stamped. A role-less em value is
-//     still filtered out of native output entirely.
+//     still filtered out of native output entirely, on both platforms.
 //
 // The third — a unitless ratio emitting as dp — is fixed by #52: no size
 // transform claims a unitless value, so it emits bare on both platforms, and

--- a/references/native-adapter-config.md
+++ b/references/native-adapter-config.md
@@ -52,7 +52,14 @@ consumer's repo.
 
 ```js
 import { readFileSync } from 'node:fs';
-import { flattenDtcg, resolveValue, findModeCollisions } from './dtcg.mjs';
+import {
+  flattenDtcg,
+  resolveValue,
+  findModeCollisions,
+  TEXT_UNIT_NAMES,
+  TEXT_ROLE_UNIT,
+  EXT_NS,
+} from './dtcg.mjs';
 import { isValidLiteral, GRAMMAR, CSS_CONSTRUCT } from './native-literal.mjs';
 ```
 
@@ -295,11 +302,16 @@ function hoistDualNodes(node, collisions, prefix = [], groupType = undefined) {
 // sibling tokens in a group. Reading them there mirrors the spec's vocabulary;
 // it is not a guarantee the spec makes. A source naming its font size
 // typography.body.size sets $extensions itself and is honoured below.
-const TEXT_UNIT_NAMES = new Set(['fontSize', 'letterSpacing', 'lineHeight']);
+//
+// Defined in lib/dtcg.mjs and imported above, so textRoleGraph applies the
+// identical set. Two definitions of this set would drift.
 
 // Reverse-DNS, per DTCG's $extensions convention. Exported because the
 // transforms and their tests address the same key.
-export const EXT_NS = 'com.radicool.throughline';
+//
+// Defined in lib/dtcg.mjs and re-exported here: the transforms and their tests
+// address this key through sd-native.mjs, and that surface does not move.
+export { EXT_NS };
 
 // px and rem only. magnitude() reads a bare number as an unscaled ratio, so a
 // lineHeight authored "1.5" would otherwise be stamped and emit 1.50.sp —
@@ -313,7 +325,9 @@ export const EXT_NS = 'com.radicool.throughline';
 // em-valued letterSpacing is a text-role dimension like any other. It is still
 // a unit — the gate's job is to exclude the UNITLESS value, whose role the
 // source never stated.
-const TEXT_ROLE_UNIT = /^-?(?:\d+(?:\.\d+)?|\.\d+)(?:px|rem|em)$/;
+//
+// Defined in lib/dtcg.mjs and imported above, for the same reason as
+// TEXT_UNIT_NAMES: textRoleGraph gates on it too.
 
 // Runs AFTER resolveInPlace and BEFORE hoistDualNodes. Both halves matter.
 //

--- a/references/native-adapter-config.md
+++ b/references/native-adapter-config.md
@@ -59,6 +59,7 @@ import {
   TEXT_UNIT_NAMES,
   TEXT_ROLE_UNIT,
   EXT_NS,
+  textRoleGraph,
 } from './dtcg.mjs';
 import { isValidLiteral, GRAMMAR, CSS_CONSTRUCT } from './native-literal.mjs';
 ```
@@ -366,10 +367,47 @@ function classifyTextUnits(node) {
   return node;
 }
 
+// Runs AFTER classifyTextUnits and BEFORE hoistDualNodes, on the SAME two
+// grounds that pass gives: after, so a role the source or the member name
+// already stated wins; before, because the hoist rewrites text.xs.lineHeight to
+// text.xsLineHeight and the graph's paths are written in pre-hoist names.
+//
+// The three gates are classifyTextUnits's, verbatim — a dimension, a value with
+// a unit, and no role already recorded. A unitless value is never stamped: no
+// size transform claims one since #52, and stamping a ratio as text would still
+// be a claim the source never made.
+//
+// A path may name no node at all. resolveInPlace deliberately leaves an
+// unresolvable reference in place for Style Dictionary to report, so the graph
+// can hold an edge to a token that does not exist. Skip it. This is also what
+// keeps the second preprocess pass from throwing, and idempotency with it.
+function applyTextRoleGraph(node, typographic) {
+  for (const path of typographic) {
+    let target = node;
+    for (const segment of path.split('.')) {
+      target = target && typeof target === 'object' ? target[segment] : undefined;
+    }
+    if (!target || typeof target !== 'object' || !('$value' in target)) continue;
+    if (target.$type !== 'dimension') continue;
+    if (!TEXT_ROLE_UNIT.test(String(target.$value).trim())) continue;
+    target.$extensions ??= {};
+    target.$extensions[EXT_NS] ??= {};
+    const ns = target.$extensions[EXT_NS];
+    if (!('nativeUnit' in ns)) ns.nativeUnit = 'text';
+  }
+  return node;
+}
+
 export function preprocess(dict) {
   const collisions = [];
+  // Read from the UNRESOLVED dict, before resolveInPlace flattens the aliases
+  // the graph is made of.
+  const { typographic } = textRoleGraph(dict);
   const out = hoistDualNodes(
-    classifyTextUnits(resolveInPlace(structuredClone(dict), flattenDtcg(dict))),
+    applyTextRoleGraph(
+      classifyTextUnits(resolveInPlace(structuredClone(dict), flattenDtcg(dict))),
+      typographic,
+    ),
     collisions,
   );
   if (collisions.length) {
@@ -414,10 +452,14 @@ now emit `sp`, with the Swift output byte-identical.
 
 What remains:
 
-- **A bare scale primitive emits as `dp`.** `text.base: "16px"` is a font size
-  only to a human — no nominal or structural signal marks it — so it is not
-  stamped. The semantic tokens that reference it are, and those are what a
-  consumer should reach for.
+- **A scale primitive nothing references emits as `dp`.** `text.base: "16px"`
+  is a font size only to a human, so #63 takes the role from the reference
+  graph instead: a dimension referenced only by `fontSize`, `letterSpacing` or
+  `lineHeight` members is stamped typographic too. That is structural rather
+  than nominal, so it needs no path convention. A primitive **nothing**
+  references has no signal at all and is not inferred —
+  `tokens:validate-output` names it with an `unreferenced-text-sibling`
+  advisory, and a source-side `nativeUnit` stamp settles it.
 - **An `em` letter spacing reaches Compose but not Swift.** `size/unit-aware/compose-em`
   emits it as a real `.em` TextUnit, parenthesised — `(-0.03).em` — because
   `-0.03.em` parses as `-(0.03.em)` and needs an `unaryMinus` operator, while
@@ -465,11 +507,16 @@ dependency on it.
 // Two limits remain, both Android-only and both measured rather than
 // theoretical — see docs/superpowers/notes/2026-08-21-native-config-e2e-results.md:
 //
-//   - A scale primitive carries no role. text.base: "16px" is a font size only
-//     to a human, so it emits as dp. The semantic tokens referencing it are
-//     correct, and those are what a consumer should reach for.
-//   - An em-valued letterSpacing is filtered out of native output entirely,
-//     rather than emitted as Compose's .em TextUnit.
+//   - A scale primitive states no role, so #63 infers one from the reference
+//     graph: a dimension referenced only by fontSize, letterSpacing or
+//     lineHeight members is itself typographic. text.base: "16px" is stamped
+//     because a fontSize references it. What remains is the primitive NOTHING
+//     references — no structural signal exists for it, so it is not inferred,
+//     and tokens:validate-output raises an unreferenced-text-sibling advisory
+//     naming it rather than leaving the gap silent.
+//   - An em-valued letterSpacing reaches Compose as a real .em TextUnit since
+//     #64, but only where the text role is stamped. A role-less em value is
+//     still filtered out of native output entirely.
 //
 // The third — a unitless ratio emitting as dp — is fixed by #52: no size
 // transform claims a unitless value, so it emits bare on both platforms, and

--- a/references/sync-adapters.md
+++ b/references/sync-adapters.md
@@ -77,9 +77,12 @@ not exercise. The `dp`/`sp` split itself is no longer among them: font sizes and
 line heights whose role a DTCG source states — the `fontSize`, `letterSpacing`
 and `lineHeight` member names of §9.8's typography composite — now emit as
 `sp`. What remains is narrower and documented in
-`${CLAUDE_PLUGIN_ROOT}/references/native-adapter-config.md`: a bare scale
-primitive carries no role and stays `dp`, and an `em` letterSpacing is
-filtered out rather than emitted as `.em`.
+`${CLAUDE_PLUGIN_ROOT}/references/native-adapter-config.md`: a scale primitive
+**nothing references** carries no role and stays `dp`, named by a
+`tokens:validate-output` `unreferenced-text-sibling` advisory; and an `em`
+letterSpacing reaches Compose as a real `.em` TextUnit but is excluded from
+Swift deliberately, since letter spacing there needs a font size no constant
+Swift value could carry.
 `tokens:validate-output` remains what decides whether any adapter can be
 trusted, and re-promotion is available to any adapter that passes it against a
 real source.

--- a/scripts/build-native-adapter-config.mjs
+++ b/scripts/build-native-adapter-config.mjs
@@ -123,10 +123,14 @@ now emit \`sp\`, with the Swift output byte-identical.
 
 What remains:
 
-- **A bare scale primitive emits as \`dp\`.** \`text.base: "16px"\` is a font size
-  only to a human — no nominal or structural signal marks it — so it is not
-  stamped. The semantic tokens that reference it are, and those are what a
-  consumer should reach for.
+- **A scale primitive nothing references emits as \`dp\`.** \`text.base: "16px"\`
+  is a font size only to a human, so #63 takes the role from the reference
+  graph instead: a dimension referenced only by \`fontSize\`, \`letterSpacing\` or
+  \`lineHeight\` members is stamped typographic too. That is structural rather
+  than nominal, so it needs no path convention. A primitive **nothing**
+  references has no signal at all and is not inferred —
+  \`tokens:validate-output\` names it with an \`unreferenced-text-sibling\`
+  advisory, and a source-side \`nativeUnit\` stamp settles it.
 - **An \`em\` letter spacing reaches Compose but not Swift.** \`size/unit-aware/compose-em\`
   emits it as a real \`.em\` TextUnit, parenthesised — \`(-0.03).em\` — because
   \`-0.03.em\` parses as \`-(0.03.em)\` and needs an \`unaryMinus\` operator, while

--- a/scripts/lib/dtcg.mjs
+++ b/scripts/lib/dtcg.mjs
@@ -4,6 +4,18 @@
 
 const REF = /^\{([^}]+)\}$/;
 
+// The typographic member names DTCG §9.8 fixes at MUST level, the unit gate a
+// text-role dimension must pass, and this project's $extensions namespace.
+//
+// They live here rather than in sd-native.mjs because textRoleGraph below and
+// sd-native.mjs's preprocess apply the identical rules, and sd-native.mjs
+// already imports this file — so the reverse import would be a cycle. Their
+// full rationale stays at the point of use in sd-native.mjs, which is what the
+// generated references/native-adapter-config.md renders.
+export const TEXT_UNIT_NAMES = new Set(['fontSize', 'letterSpacing', 'lineHeight']);
+export const TEXT_ROLE_UNIT = /^-?(?:\d+(?:\.\d+)?|\.\d+)(?:px|rem|em)$/;
+export const EXT_NS = 'com.radicool.throughline';
+
 // Flatten nested DTCG groups into { "dot.path": rawValue }. Skips $-prefixed meta keys.
 //
 // A node carrying BOTH a $value and children yields its own value AND is descended

--- a/scripts/lib/dtcg.mjs
+++ b/scripts/lib/dtcg.mjs
@@ -97,3 +97,107 @@ export function findModeCollisions(sources) {
   }
   return collisions;
 }
+
+// Deep merge in list order, later source winning — the same later-wins rule
+// validate-token-output.mjs already applies when it flattens a source list, and
+// what Style Dictionary hands preprocess as one dict.
+//
+// Each source is cloned on the way in. Merging the caller's own objects would
+// mutate the token trees it still holds, and the validator reads them again.
+const isPlainObject = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
+
+function mergeInto(target, src) {
+  for (const [key, val] of Object.entries(src)) {
+    if (isPlainObject(val) && isPlainObject(target[key])) mergeInto(target[key], val);
+    else target[key] = val;
+  }
+  return target;
+}
+
+export function mergeDtcg(dicts) {
+  const out = {};
+  for (const dict of dicts) mergeInto(out, structuredClone(dict));
+  return out;
+}
+
+// A dimension primitive states no typographic role: text.base: "16px" is a font
+// size only to a human, so it emitted as dp, and an em letterSpacing primitive
+// was dropped from native output entirely. #51 sources the role from the member
+// names DTCG §9.8 fixes, which reaches the semantic tokens and not the
+// primitives they reference. This reaches the primitives, structurally.
+//
+// Reads the UNRESOLVED tree: preprocess resolves aliases in place, so by
+// transform time the graph is gone. Nothing needs carrying, because the
+// inference is applied during preprocessing and only the $extensions stamp
+// survives — see sd-native.mjs's applyTextRoleGraph.
+//
+// A referrer whose leaf name is NOT typographic is counter-evidence, not
+// neutral. A dimension referenced by something that is not a typographic member
+// is a length, which is exactly what the dp default already asserts about it.
+// Treating it as neutral would let one stray fontSize reference convert a whole
+// spacing ramp.
+//
+// Single-pass and deliberately not transitive: a chain through an intermediate
+// whose own leaf name states no role is declined at the second hop, because
+// that intermediate is itself counter-evidence. Only whole-value references
+// count; a reference embedded in an expression is resolved by resolveInPlace
+// but is not evidence of a role.
+export function textRoleGraph(dict) {
+  const edges = [];
+  (function walk(node, prefix) {
+    for (const [key, val] of Object.entries(node)) {
+      if (key.startsWith('$') || !isPlainObject(val)) continue;
+      const path = [...prefix, key];
+      if (typeof val.$value === 'string') {
+        const m = REF.exec(val.$value.trim());
+        if (m) edges.push({ to: m[1], leaf: key });
+      }
+      walk(val, path);
+    }
+  })(dict, []);
+
+  const referrers = new Map();
+  for (const edge of edges) {
+    if (!referrers.has(edge.to)) referrers.set(edge.to, []);
+    referrers.get(edge.to).push(edge);
+  }
+
+  const typographic = new Set();
+  const ambiguous = [];
+  for (const [path, rs] of referrers) {
+    const textLeaves = [...new Set(rs.filter((r) => TEXT_UNIT_NAMES.has(r.leaf)).map((r) => r.leaf))];
+    if (textLeaves.length === 0) continue;
+    const otherLeaves = [...new Set(rs.filter((r) => !TEXT_UNIT_NAMES.has(r.leaf)).map((r) => r.leaf))];
+    if (otherLeaves.length) ambiguous.push({ path, textLeaves, otherLeaves });
+    else typographic.add(path);
+  }
+
+  // A primitive nothing references has no structural signal at all, so it is
+  // never inferred. Reported instead, where its group holds one that was: that
+  // is the strongest hint available without guessing, and a silent gap is the
+  // failure this module exists to prevent. A token whose source already stamps
+  // nativeUnit is closed and is not reported.
+  const inferredGroups = new Set([...typographic].map((p) => p.split('.').slice(0, -1).join('.')));
+  const unreferencedSiblings = [];
+  (function walk(node, prefix) {
+    for (const [key, val] of Object.entries(node)) {
+      if (key.startsWith('$') || !isPlainObject(val)) continue;
+      const path = [...prefix, key];
+      const dotted = path.join('.');
+      const group = prefix.join('.');
+      if (
+        '$value' in val &&
+        val.$type === 'dimension' &&
+        TEXT_ROLE_UNIT.test(String(val.$value).trim()) &&
+        !referrers.has(dotted) &&
+        !('nativeUnit' in (val.$extensions?.[EXT_NS] ?? {})) &&
+        inferredGroups.has(group)
+      ) {
+        unreferencedSiblings.push({ path: dotted, group });
+      }
+      walk(val, path);
+    }
+  })(dict, []);
+
+  return { typographic, ambiguous, unreferencedSiblings };
+}

--- a/scripts/lib/dtcg.test.mjs
+++ b/scripts/lib/dtcg.test.mjs
@@ -1,6 +1,14 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { flattenDtcg, flattenDtcgTypes, resolveValue, findModeCollisions } from './dtcg.mjs';
+import {
+  flattenDtcg,
+  flattenDtcgTypes,
+  resolveValue,
+  findModeCollisions,
+  TEXT_UNIT_NAMES,
+  TEXT_ROLE_UNIT,
+  EXT_NS,
+} from './dtcg.mjs';
 
 // text.sm is a DUAL-NODE token: it carries its own $value AND a child.
 const dtcg = {
@@ -134,4 +142,11 @@ test('flattenDtcgTypes lets an own $type beat an inherited one', () => {
 test('flattenDtcgTypes returns undefined where nothing supplies a type', () => {
   const types = flattenDtcgTypes({ g: { a: { $value: '1.5' } } });
   assert.equal(types['g.a'], undefined);
+});
+
+test('the shared text-role constants live here, so textRoleGraph and sd-native cannot drift', () => {
+  assert.deepEqual([...TEXT_UNIT_NAMES].sort(), ['fontSize', 'letterSpacing', 'lineHeight']);
+  assert.equal(EXT_NS, 'com.radicool.throughline');
+  for (const ok of ['16px', '1.5rem', '-0.03em', '.5px']) assert.ok(TEXT_ROLE_UNIT.test(ok), ok);
+  for (const no of ['1.5', '16', '100%', '16dp', '']) assert.ok(!TEXT_ROLE_UNIT.test(no), no);
 });

--- a/scripts/lib/dtcg.test.mjs
+++ b/scripts/lib/dtcg.test.mjs
@@ -8,6 +8,8 @@ import {
   TEXT_UNIT_NAMES,
   TEXT_ROLE_UNIT,
   EXT_NS,
+  textRoleGraph,
+  mergeDtcg,
 } from './dtcg.mjs';
 
 // text.sm is a DUAL-NODE token: it carries its own $value AND a child.
@@ -149,4 +151,93 @@ test('the shared text-role constants live here, so textRoleGraph and sd-native c
   assert.equal(EXT_NS, 'com.radicool.throughline');
   for (const ok of ['16px', '1.5rem', '-0.03em', '.5px']) assert.ok(TEXT_ROLE_UNIT.test(ok), ok);
   for (const no of ['1.5', '16', '100%', '16dp', '']) assert.ok(!TEXT_ROLE_UNIT.test(no), no);
+});
+
+const graphFixture = () => ({
+  text: {
+    base: { $type: 'dimension', $value: '16px' },
+    huge: { $type: 'dimension', $value: '96px' },
+    stamped: { $type: 'dimension', $value: '72px', $extensions: { [EXT_NS]: { nativeUnit: 'text' } } },
+    ratio: { $type: 'dimension', $value: '1.5' },
+  },
+  space: { md: { $type: 'dimension', $value: '8px' } },
+  typography: {
+    body: {
+      fontSize: { $type: 'dimension', $value: '{text.base}' },
+      lineHeight: { $type: 'dimension', $value: '{text.base}' },
+    },
+    gutter: { $type: 'dimension', $value: '{space.md}' },
+  },
+});
+
+test('a referent whose referrers are all typographic is inferred typographic', () => {
+  const g = textRoleGraph(graphFixture());
+  assert.ok(g.typographic.has('text.base'));
+  assert.ok(!g.typographic.has('space.md'), 'a gutter referrer states no typographic role');
+  assert.deepEqual(g.ambiguous, []);
+});
+
+test('a referent with referrers on both sides is ambiguous, not inferred', () => {
+  const dict = graphFixture();
+  dict.space.pad = { $type: 'dimension', $value: '{text.base}' };
+  const g = textRoleGraph(dict);
+  assert.ok(!g.typographic.has('text.base'), 'counter-evidence declines the stamp');
+  assert.equal(g.ambiguous.length, 1);
+  assert.equal(g.ambiguous[0].path, 'text.base');
+  assert.deepEqual(g.ambiguous[0].textLeaves.sort(), ['fontSize', 'lineHeight']);
+  assert.deepEqual(g.ambiguous[0].otherLeaves, ['pad']);
+});
+
+test('an unreferenced sibling of an inferred token is advised, not inferred', () => {
+  const g = textRoleGraph(graphFixture());
+  const paths = g.unreferencedSiblings.map((u) => u.path);
+  assert.ok(paths.includes('text.huge'), 'nothing references it, but its siblings are typographic');
+  assert.ok(!paths.includes('text.stamped'), 'already closed by a source stamp');
+  assert.ok(!paths.includes('text.ratio'), 'unitless — no size transform would claim it anyway');
+  assert.ok(!paths.includes('space.md'), 'it has a referrer (typography.gutter), so it was never a candidate');
+  assert.equal(g.unreferencedSiblings.find((u) => u.path === 'text.huge').group, 'text');
+});
+
+test('an edge to a path that does not exist is collected, not thrown on', () => {
+  const g = textRoleGraph({
+    typography: { body: { fontSize: { $type: 'dimension', $value: '{nope.missing}' } } },
+  });
+  assert.ok(g.typographic.has('nope.missing'), 'the graph reports the edge; the applier skips it');
+  assert.deepEqual(g.unreferencedSiblings, []);
+});
+
+test('a chain through a role-less intermediate is declined at the second hop', () => {
+  const g = textRoleGraph({
+    text: { base: { $type: 'dimension', $value: '16px' } },
+    alias: { x: { $type: 'dimension', $value: '{text.base}' } },
+    typography: { body: { fontSize: { $type: 'dimension', $value: '{alias.x}' } } },
+  });
+  assert.ok(g.typographic.has('alias.x'));
+  assert.ok(!g.typographic.has('text.base'), 'the intermediate leaf name states no role');
+});
+
+test('a dual node is reached at its own path, before any hoist', () => {
+  const g = textRoleGraph({
+    text: { sm: { $type: 'dimension', $value: '14px', lineHeight: { $type: 'dimension', $value: '20px' } } },
+    typography: { body: { fontSize: { $type: 'dimension', $value: '{text.sm}' } } },
+  });
+  assert.ok(g.typographic.has('text.sm'));
+});
+
+test('mergeDtcg lets a later source win and leaves its inputs alone', () => {
+  const a = { typography: { body: { fontSize: { $value: '{text.sm}' } } }, keep: { x: { $value: '1px' } } };
+  const b = { typography: { body: { fontSize: { $value: '{text.lg}' } } } };
+  const merged = mergeDtcg([a, b]);
+  assert.equal(merged.typography.body.fontSize.$value, '{text.lg}');
+  assert.equal(merged.keep.x.$value, '1px');
+  assert.equal(a.typography.body.fontSize.$value, '{text.sm}', 'inputs must not be mutated');
+});
+
+test('a merge can remove a referrer a union would have kept', () => {
+  const desktop = { typography: { body: { fontSize: { $type: 'dimension', $value: '{text.lg}' } } } };
+  const mobile = { typography: { body: { fontSize: { $type: 'dimension', $value: '{text.sm}' } } } };
+  const base = { text: { lg: { $type: 'dimension', $value: '18px' }, sm: { $type: 'dimension', $value: '14px' } } };
+  const g = textRoleGraph(mergeDtcg([base, desktop, mobile]));
+  assert.ok(g.typographic.has('text.sm'));
+  assert.ok(!g.typographic.has('text.lg'), 'the mobile file overwrote the only referrer to text.lg');
 });

--- a/scripts/lib/sd-native.mjs
+++ b/scripts/lib/sd-native.mjs
@@ -376,19 +376,24 @@ export function preprocess(dict) {
 // That last one is fixed for tokens whose role a DTCG source actually states:
 // classifyTextUnits stamps fontSize, letterSpacing and lineHeight members, and
 // the sp transform gates on the stamp rather than on a $type DTCG never emits.
-// Two limits remain, both Android-only and both measured rather than
-// theoretical — see docs/superpowers/notes/2026-08-21-native-config-e2e-results.md:
+// Two limits remain, one Android-only and one affecting both platforms, both
+// measured rather than theoretical — see
+// docs/superpowers/notes/2026-08-28-text-role-inference-e2e.md:
 //
 //   - A scale primitive states no role, so #63 infers one from the reference
 //     graph: a dimension referenced only by fontSize, letterSpacing or
 //     lineHeight members is itself typographic. text.base: "16px" is stamped
-//     because a fontSize references it. What remains is the primitive NOTHING
-//     references — no structural signal exists for it, so it is not inferred,
-//     and tokens:validate-output raises an unreferenced-text-sibling advisory
-//     naming it rather than leaving the gap silent.
+//     because a fontSize references it. A primitive NOTHING references stays
+//     dp on Android — no structural signal exists for it, so it is not
+//     inferred, and tokens:validate-output raises an unreferenced-text-sibling
+//     advisory naming it rather than leaving the gap silent. This is not the
+//     complete list of remaining limits (spec §8 names five more); the one a
+//     consumer is likeliest to hit is mode dependence — the same token can
+//     emit sp in one build and dp in another, because the graph only sees the
+//     files that build includes.
 //   - An em-valued letterSpacing reaches Compose as a real .em TextUnit since
 //     #64, but only where the text role is stamped. A role-less em value is
-//     still filtered out of native output entirely.
+//     still filtered out of native output entirely, on both platforms.
 //
 // The third — a unitless ratio emitting as dp — is fixed by #52: no size
 // transform claims a unitless value, so it emits bare on both platforms, and

--- a/scripts/lib/sd-native.mjs
+++ b/scripts/lib/sd-native.mjs
@@ -10,7 +10,14 @@
 // scripts/build-native-adapter-config.mjs. Edit the code here, then regenerate.
 // @doc-section imports
 import { readFileSync } from 'node:fs';
-import { flattenDtcg, resolveValue, findModeCollisions } from './dtcg.mjs';
+import {
+  flattenDtcg,
+  resolveValue,
+  findModeCollisions,
+  TEXT_UNIT_NAMES,
+  TEXT_ROLE_UNIT,
+  EXT_NS,
+} from './dtcg.mjs';
 import { isValidLiteral, GRAMMAR, CSS_CONSTRUCT } from './native-literal.mjs';
 // @doc-section-end imports
 
@@ -226,11 +233,16 @@ function hoistDualNodes(node, collisions, prefix = [], groupType = undefined) {
 // sibling tokens in a group. Reading them there mirrors the spec's vocabulary;
 // it is not a guarantee the spec makes. A source naming its font size
 // typography.body.size sets $extensions itself and is honoured below.
-const TEXT_UNIT_NAMES = new Set(['fontSize', 'letterSpacing', 'lineHeight']);
+//
+// Defined in lib/dtcg.mjs and imported above, so textRoleGraph applies the
+// identical set. Two definitions of this set would drift.
 
 // Reverse-DNS, per DTCG's $extensions convention. Exported because the
 // transforms and their tests address the same key.
-export const EXT_NS = 'com.radicool.throughline';
+//
+// Defined in lib/dtcg.mjs and re-exported here: the transforms and their tests
+// address this key through sd-native.mjs, and that surface does not move.
+export { EXT_NS };
 
 // px and rem only. magnitude() reads a bare number as an unscaled ratio, so a
 // lineHeight authored "1.5" would otherwise be stamped and emit 1.50.sp —
@@ -244,7 +256,9 @@ export const EXT_NS = 'com.radicool.throughline';
 // em-valued letterSpacing is a text-role dimension like any other. It is still
 // a unit — the gate's job is to exclude the UNITLESS value, whose role the
 // source never stated.
-const TEXT_ROLE_UNIT = /^-?(?:\d+(?:\.\d+)?|\.\d+)(?:px|rem|em)$/;
+//
+// Defined in lib/dtcg.mjs and imported above, for the same reason as
+// TEXT_UNIT_NAMES: textRoleGraph gates on it too.
 
 // Runs AFTER resolveInPlace and BEFORE hoistDualNodes. Both halves matter.
 //

--- a/scripts/lib/sd-native.mjs
+++ b/scripts/lib/sd-native.mjs
@@ -17,6 +17,7 @@ import {
   TEXT_UNIT_NAMES,
   TEXT_ROLE_UNIT,
   EXT_NS,
+  textRoleGraph,
 } from './dtcg.mjs';
 import { isValidLiteral, GRAMMAR, CSS_CONSTRUCT } from './native-literal.mjs';
 // @doc-section-end imports
@@ -297,10 +298,47 @@ function classifyTextUnits(node) {
   return node;
 }
 
+// Runs AFTER classifyTextUnits and BEFORE hoistDualNodes, on the SAME two
+// grounds that pass gives: after, so a role the source or the member name
+// already stated wins; before, because the hoist rewrites text.xs.lineHeight to
+// text.xsLineHeight and the graph's paths are written in pre-hoist names.
+//
+// The three gates are classifyTextUnits's, verbatim — a dimension, a value with
+// a unit, and no role already recorded. A unitless value is never stamped: no
+// size transform claims one since #52, and stamping a ratio as text would still
+// be a claim the source never made.
+//
+// A path may name no node at all. resolveInPlace deliberately leaves an
+// unresolvable reference in place for Style Dictionary to report, so the graph
+// can hold an edge to a token that does not exist. Skip it. This is also what
+// keeps the second preprocess pass from throwing, and idempotency with it.
+function applyTextRoleGraph(node, typographic) {
+  for (const path of typographic) {
+    let target = node;
+    for (const segment of path.split('.')) {
+      target = target && typeof target === 'object' ? target[segment] : undefined;
+    }
+    if (!target || typeof target !== 'object' || !('$value' in target)) continue;
+    if (target.$type !== 'dimension') continue;
+    if (!TEXT_ROLE_UNIT.test(String(target.$value).trim())) continue;
+    target.$extensions ??= {};
+    target.$extensions[EXT_NS] ??= {};
+    const ns = target.$extensions[EXT_NS];
+    if (!('nativeUnit' in ns)) ns.nativeUnit = 'text';
+  }
+  return node;
+}
+
 export function preprocess(dict) {
   const collisions = [];
+  // Read from the UNRESOLVED dict, before resolveInPlace flattens the aliases
+  // the graph is made of.
+  const { typographic } = textRoleGraph(dict);
   const out = hoistDualNodes(
-    classifyTextUnits(resolveInPlace(structuredClone(dict), flattenDtcg(dict))),
+    applyTextRoleGraph(
+      classifyTextUnits(resolveInPlace(structuredClone(dict), flattenDtcg(dict))),
+      typographic,
+    ),
     collisions,
   );
   if (collisions.length) {
@@ -341,11 +379,16 @@ export function preprocess(dict) {
 // Two limits remain, both Android-only and both measured rather than
 // theoretical — see docs/superpowers/notes/2026-08-21-native-config-e2e-results.md:
 //
-//   - A scale primitive carries no role. text.base: "16px" is a font size only
-//     to a human, so it emits as dp. The semantic tokens referencing it are
-//     correct, and those are what a consumer should reach for.
-//   - An em-valued letterSpacing is filtered out of native output entirely,
-//     rather than emitted as Compose's .em TextUnit.
+//   - A scale primitive states no role, so #63 infers one from the reference
+//     graph: a dimension referenced only by fontSize, letterSpacing or
+//     lineHeight members is itself typographic. text.base: "16px" is stamped
+//     because a fontSize references it. What remains is the primitive NOTHING
+//     references — no structural signal exists for it, so it is not inferred,
+//     and tokens:validate-output raises an unreferenced-text-sibling advisory
+//     naming it rather than leaving the gap silent.
+//   - An em-valued letterSpacing reaches Compose as a real .em TextUnit since
+//     #64, but only where the text role is stamped. A role-less em value is
+//     still filtered out of native output entirely.
 //
 // The third — a unitless ratio emitting as dp — is fixed by #52: no size
 // transform claims a unitless value, so it emits bare on both platforms, and

--- a/scripts/lib/sd-native.test.mjs
+++ b/scripts/lib/sd-native.test.mjs
@@ -1320,11 +1320,14 @@ const emSpacing = () => ({
 });
 
 // The role comes from the LEAF name, so this reaches the 13
-// typography.textStyle.*.letterSpacing tokens — which is where a consumer
-// should reach anyway. It does not reach the four
-// typography.letterSpacing.{tight,normal,wide,widest} primitives, whose leaf
-// names are tight/normal/wide/widest and which therefore state no role. That
-// is the same documented limit as a bare scale primitive (#63), not a new one.
+// typography.textStyle.*.letterSpacing tokens directly — which is where a
+// consumer should reach anyway. Since #63, the reference graph reaches
+// further: typography.letterSpacing.tight is referenced by
+// textStyle.h1.letterSpacing, and that referrer's own leaf name is
+// typographic, so the graph infers tight is typographic too and
+// applyTextRoleGraph stamps it. What still isn't reached is a primitive
+// NOTHING references — on a real source, typography.letterSpacing.widest —
+// because no structural signal, nominal or referential, exists for it.
 test('classifyTextUnits stamps an em letterSpacing, not only px and rem', () => {
   const out = preprocess({
     typography: {
@@ -1337,7 +1340,11 @@ test('classifyTextUnits stamps an em letterSpacing, not only px and rem', () => 
   });
   assert.equal(roleOf(out.typography.textStyle.h1.letterSpacing), 'text', 'resolved alias');
   assert.equal(roleOf(out.typography.textStyle.h2.letterSpacing), 'text', 'authored directly');
-  assert.equal(roleOf(out.typography.letterSpacing.tight), undefined, 'primitive states no role');
+  assert.equal(
+    roleOf(out.typography.letterSpacing.tight),
+    'text',
+    'the reference graph reaches it: textStyle.h1.letterSpacing references it, and letterSpacing is a typographic leaf name (#63)',
+  );
 });
 
 test('nativeFilter keeps a text-role em on Compose and drops it on Swift', () => {

--- a/scripts/lib/sd-native.test.mjs
+++ b/scripts/lib/sd-native.test.mjs
@@ -1401,3 +1401,60 @@ test('the emitted em value is a valid Kotlin literal by our own grammar', () => 
   const v = collectTransforms().get('size/unit-aware/compose-em').transform(emSpacing());
   assert.equal(hasNativeForm({ $value: v }, 'android-kotlin'), true);
 });
+
+const roleDict = () => ({
+  text: { base: { $type: 'dimension', $value: '16px' }, huge: { $type: 'dimension', $value: '96px' } },
+  space: { md: { $type: 'dimension', $value: '8px' } },
+  typography: {
+    body: { fontSize: { $type: 'dimension', $value: '{text.base}' } },
+    gutter: { $type: 'dimension', $value: '{space.md}' },
+  },
+});
+const stampOf = (node) => node.$extensions?.[EXT_NS]?.nativeUnit;
+
+test('a primitive referenced only by a fontSize is stamped as text', () => {
+  const out = preprocess(roleDict());
+  assert.equal(stampOf(out.text.base), 'text');
+});
+
+test('a primitive referenced by a role-less member is left alone', () => {
+  const out = preprocess(roleDict());
+  assert.equal(stampOf(out.space.md), undefined);
+  assert.equal(stampOf(out.text.huge), undefined, 'nothing references it');
+});
+
+test('inference does not overwrite a role the source stated', () => {
+  const dict = roleDict();
+  dict.text.base.$extensions = { [EXT_NS]: { nativeUnit: 'length' } };
+  const out = preprocess(dict);
+  assert.equal(stampOf(out.text.base), 'length', 'a source opt-out survives the inference');
+});
+
+test('inference never stamps a unitless value', () => {
+  const dict = roleDict();
+  dict.text.base.$value = '1.5';
+  const out = preprocess(dict);
+  assert.equal(stampOf(out.text.base), undefined, 'a ratio is not a text-role dimension');
+});
+
+test('an unresolvable reference does not throw the inference', () => {
+  const dict = { typography: { body: { fontSize: { $type: 'dimension', $value: '{nope.missing}' } } } };
+  const out = preprocess(dict);
+  assert.equal(out.typography.body.fontSize.$value, '{nope.missing}', 'left in place for SD to report');
+});
+
+test('preprocess stays idempotent with the inference in place', () => {
+  const once = preprocess(roleDict());
+  assert.deepEqual(preprocess(once), once);
+});
+
+test('an em letterSpacing primitive reaches Compose once the graph stamps it', () => {
+  const dict = {
+    tracking: { tight: { $type: 'dimension', $value: '-0.03em' } },
+    typography: { body: { letterSpacing: { $type: 'dimension', $value: '{tracking.tight}' } } },
+  };
+  const out = preprocess(dict);
+  assert.equal(stampOf(out.tracking.tight), 'text');
+  const asToken = (n) => ({ ...n, original: { $value: n.$value } });
+  assert.equal(nativeFilter(asToken(out.tracking.tight), 'android-kotlin'), true);
+});

--- a/scripts/lib/sd-native.test.mjs
+++ b/scripts/lib/sd-native.test.mjs
@@ -926,6 +926,21 @@ test('preprocess stamps a dual-node child before the hoist consumes its name', (
   assert.equal(roleOf(out.text.xs), undefined);
 });
 
+// applyTextRoleGraph must ALSO run before hoistDualNodes, for the same reason
+// as classifyTextUnits above: the graph is built from resolveInPlace's
+// PRE-hoist paths ("text.sm.cap"), and hoistDualNodes renames that child to
+// "text.smCap" — a name the graph never wrote down. Reversing the two calls
+// in preprocess leaves this child unstamped and a 12px font size silently
+// emits 12.00.dp.
+test('preprocess stamps a dual-node child reached only via the reference graph, before the hoist renames it', () => {
+  const out = preprocess({
+    text: { sm: { $type: 'dimension', $value: '14px', cap: { $type: 'dimension', $value: '12px' } } },
+    typography: { body: { fontSize: { $type: 'dimension', $value: '{text.sm.cap}' } } },
+  });
+  assert.equal(out.text.smCap.$value, '12px');
+  assert.equal(roleOf(out.text.smCap), 'text');
+});
+
 // magnitude() reads a bare number as a ratio. Stamping one would emit
 // 1.50.sp — which compiles and renders 1.5sp text, trading a loud failure for
 // a silent one. leading.normal stays the separate defect it already is.
@@ -1328,7 +1343,7 @@ const emSpacing = () => ({
 // applyTextRoleGraph stamps it. What still isn't reached is a primitive
 // NOTHING references — on a real source, typography.letterSpacing.widest —
 // because no structural signal, nominal or referential, exists for it.
-test('classifyTextUnits stamps an em letterSpacing, not only px and rem', () => {
+test('preprocess stamps a direct em letterSpacing, and applyTextRoleGraph reaches one only the reference graph connects', () => {
   const out = preprocess({
     typography: {
       letterSpacing: { tight: { $type: 'dimension', $value: '-0.03em' } },

--- a/scripts/validate-token-output.mjs
+++ b/scripts/validate-token-output.mjs
@@ -7,7 +7,15 @@
 import { readFileSync } from 'node:fs';
 import { parseArgs } from 'node:util';
 import { pathToFileURL } from 'node:url';
-import { flattenDtcg, flattenDtcgTypes, resolveValue, findModeCollisions } from './lib/dtcg.mjs';
+import {
+  flattenDtcg,
+  flattenDtcgTypes,
+  resolveValue,
+  findModeCollisions,
+  textRoleGraph,
+  mergeDtcg,
+  EXT_NS,
+} from './lib/dtcg.mjs';
 import { parseLiteral, isValidLiteral, GRAMMAR } from './lib/native-literal.mjs';
 
 // Re-exported so consumers (and the test file) keep one import surface.
@@ -209,6 +217,24 @@ export function validate({ sources, output, platform, minMatch = 0.5 }) {
     }
   }
 
+  // A SOURCE-side pass, deliberately not part of the loop above. That loop
+  // iterates emitted declarations, and the token this advisory exists for is
+  // the one that was never emitted at all — an em letterSpacing whose role
+  // nothing states is filtered out of native output, so it has no symbol to
+  // hang a note on.
+  //
+  // Merged rather than unioned across sources: the graph must describe the
+  // build that actually ran, and a build merges with the later source winning.
+  // A union would call a token referenced when this build did not reach it,
+  // under-reporting the gap in the one direction that matters.
+  const graph = textRoleGraph(mergeDtcg(sources.map((s) => s.dtcg)));
+  for (const { path, group } of graph.unreferencedSiblings) {
+    advisories.push({ rule: 'unreferenced-text-sibling', token: path, group });
+  }
+  for (const { path, textLeaves, otherLeaves } of graph.ambiguous) {
+    advisories.push({ rule: 'ambiguous-text-role', token: path, textLeaves, otherLeaves });
+  }
+
   const matchRate = decls.length ? matched / decls.length : 0;
   const ok = failures.length === 0 && collisions.length === 0 && matched > 0 && matchRate >= minMatch;
 
@@ -260,6 +286,18 @@ export function formatReport(r) {
   if (r.advisories?.length) {
     lines.push(`\n${r.advisories.length} advisory note(s) — reported, not gating:`);
     for (const a of r.advisories) {
+      if (a.rule === 'unreferenced-text-sibling') {
+        lines.push(
+          `  - [${a.rule}] ${a.token}: nothing references it, so no typographic role could be inferred — but tokens in "${a.group}" were. It emits as a length, or is dropped entirely if its unit is em. Stamp $extensions["${EXT_NS}"].nativeUnit = "text" on it in source to settle it, or leave it if it is not a text value.`,
+        );
+        continue;
+      }
+      if (a.rule === 'ambiguous-text-role') {
+        lines.push(
+          `  - [${a.rule}] ${a.token}: referenced both by typographic member(s) [${a.textLeaves.join(', ')}] and by [${a.otherLeaves.join(', ')}], so no role was inferred rather than a role being guessed. Stamp $extensions["${EXT_NS}"].nativeUnit in source to settle it.`,
+        );
+        continue;
+      }
       lines.push(
         `  - [${a.rule}] ${a.symbol}: source ${JSON.stringify(a.source)} for ${a.token} is a dimension with no unit, which DTCG §8.2.1 does not permit. It emitted ${a.emitted}, read as a ratio. If it is a ratio, type it "number" (§8.7); if it is a measurement, add the unit you meant.`,
       );

--- a/scripts/validate-token-output.mjs
+++ b/scripts/validate-token-output.mjs
@@ -288,7 +288,7 @@ export function formatReport(r) {
     for (const a of r.advisories) {
       if (a.rule === 'unreferenced-text-sibling') {
         lines.push(
-          `  - [${a.rule}] ${a.token}: nothing references it, so no typographic role could be inferred — but tokens in "${a.group}" were. It emits as a length, or is dropped entirely if its unit is em. Stamp $extensions["${EXT_NS}"].nativeUnit = "text" on it in source to settle it, or leave it if it is not a text value.`,
+          `  - [${a.rule}] ${a.token}: nothing references it, so no typographic role could be inferred — but tokens in "${a.group}" were. It emits as a length, or is dropped entirely if its unit is em. On Compose, stamping $extensions["${EXT_NS}"].nativeUnit = "text" on it in source settles it; on Swift there is no sp/dp distinction to settle, and a stamped em still would not emit there. Leave it as is if it is not a text value.`,
         );
         continue;
       }

--- a/scripts/validate-token-output.test.mjs
+++ b/scripts/validate-token-output.test.mjs
@@ -562,3 +562,75 @@ test('formatReport renders an invalid-literal failure with the stop position', (
   assert.match(lines, /offset 7/);
   assert.match(lines, /quoted/);
 });
+
+const roleSources = () => [
+  {
+    file: 'tokens.json',
+    dtcg: {
+      text: { base: { $type: 'dimension', $value: '16px' }, huge: { $type: 'dimension', $value: '96px' } },
+      tracking: { widest: { $type: 'dimension', $value: '0.15em' }, tight: { $type: 'dimension', $value: '-0.03em' } },
+      typography: {
+        body: {
+          fontSize: { $type: 'dimension', $value: '{text.base}' },
+          letterSpacing: { $type: 'dimension', $value: '{tracking.tight}' },
+        },
+      },
+    },
+  },
+];
+
+test('an unreferenced sibling is advised even though nothing emitted it', () => {
+  const r = validate({
+    sources: roleSources(),
+    output: 'object Tokens {\n  val textBase = 16.00.sp\n}\n',
+    platform: 'android-kotlin',
+    minMatch: 0,
+  });
+  const advised = r.advisories.filter((a) => a.rule === 'unreferenced-text-sibling').map((a) => a.token);
+  assert.ok(advised.includes('tracking.widest'), 'dropped from output entirely — the case that matters');
+  assert.ok(advised.includes('text.huge'));
+  assert.ok(
+    r.advisories.every((a) => a.rule !== 'unreferenced-text-sibling' || !('symbol' in a)),
+    'these advisories name a token path, not a symbol',
+  );
+});
+
+test('an advisory is never a failure', () => {
+  const r = validate({
+    sources: roleSources(),
+    output: 'object Tokens {\n  val textBase = 16.00.sp\n}\n',
+    platform: 'android-kotlin',
+    minMatch: 0,
+  });
+  assert.ok(r.advisories.length > 0, 'the fixture must actually produce advisories');
+  assert.deepEqual(r.failures, [], 'advisories are reported, not gating');
+  // Asserted on failures rather than on r.ok: ok also folds in the match rate,
+  // so a green assertion there could be green for an unrelated reason.
+});
+
+test('a token referenced by both roles is advised as ambiguous', () => {
+  const sources = roleSources();
+  sources[0].dtcg.space = { pad: { $type: 'dimension', $value: '{text.base}' } };
+  const r = validate({
+    sources,
+    output: 'object Tokens {\n  val textBase = 16.00.dp\n}\n',
+    platform: 'android-kotlin',
+    minMatch: 0,
+  });
+  const a = r.advisories.find((x) => x.rule === 'ambiguous-text-role');
+  assert.ok(a, 'both-roles is reported, not silently declined');
+  assert.equal(a.token, 'text.base');
+  assert.deepEqual(a.otherLeaves, ['pad']);
+});
+
+test('formatReport renders a symbol-less advisory without printing undefined', () => {
+  const r = validate({
+    sources: roleSources(),
+    output: 'object Tokens {\n  val textBase = 16.00.sp\n}\n',
+    platform: 'android-kotlin',
+    minMatch: 0,
+  });
+  const text = formatReport(r).join('\n');
+  assert.ok(text.includes('tracking.widest'));
+  assert.ok(!/undefined/.test(text), 'a missing symbol must never reach the report');
+});


### PR DESCRIPTION
Closes #63.

## The problem

A scale primitive states no typographic role. `text.base: "16px"` is a font size only to a human, so it emitted `16.00.dp` on Android, and `typography.letterSpacing.tight: "-0.03em"` was dropped from native output **entirely** — `nativeFilter` keeps `em` only where the text role is stamped.

#51 sources the role from the member names DTCG §9.8 fixes — `fontSize`, `letterSpacing`, `lineHeight`. That reaches semantic tokens and not the primitives they reference.

## The rule

> A dimension referenced **only** by typographic members is itself typographic.

Structural rather than nominal, so it needs no `text.*` path convention and no spec backing the spec doesn't give.

A non-typographic referrer is **counter-evidence, not neutral** — a dimension referenced by something that isn't a typographic member is a length, which is what the `dp` default already asserts. That's what stops one stray `fontSize` reference converting an entire spacing ramp, and it's why a chain through a role-less intermediate is declined at the second hop.

Then the same three gates `classifyTextUnits` already applies, verbatim: `$type === 'dimension'`, a value with a unit, and no role already recorded. The third gate is both the **escape hatch** and the **opt-out** — and both already worked, by way of a guard nothing tested. They're pinned now.

**The issue's own "why this is non-trivial" was over-worried.** It argued the graph must survive into transform time via `$extensions`. It doesn't: `preprocess` already holds the unresolved dict, so the graph is computed there and only the stamp survives. `resolveInPlace` is untouched and #55's `WeakSet` is uninvolved.

## Measured, on 8 real builds

Mobile **and** desktop pins × light/dark × before/after. Style Dictionary 4.4.0 in a scratch install; the repo gains no dependency.

| | before | after |
|---|--:|--:|
| Kotlin declarations | 208 | **211** |
| Swift declarations | 195 | 195 (byte-identical) |
| Android unmatched source tokens | 6 | **3** |
| iOS unmatched | 19 | 19 |

Compile check 8/8 exit 0. And the break itself was compiled, not asserted: a `Dp` use site of `Tokens.textBase` builds against `main` and fails against this branch with `actual type is 'TextUnit', but 'Dp' was expected`.

## Two corrections this work forced

**The issue said "6 unmatched → 2". It's 6 → 3.** `typography.letterSpacing.widest` is referenced by nothing, so the graph cannot reach it. That figure had already been repeated into the v0.16.0 handoff note; both occurrences are corrected.

**My own spec §6 said "nine or ten symbols, mode-dependent". The e2e disproved it.** It is nine in any single build on either pin — but not the same nine: mobile and desktop each reach nine distinct `text.*`, swapping `text.lg` ↔ `text.6xl`. Ten is a union across all 15 source files, which §6 misread as a per-build count. The spec was corrected, not the measurement. The count is stable across pins while the set is not, which is what made it easy to miss.

## Five stale claims, in five places

The old limitation had been written down in `sd-native.mjs` (twice), the doc generator's prose, a test comment, and `references/sync-adapters.md`. All five now state the new rule **and** its remaining gap. One of them — `em` letter spacing being "filtered out entirely" — had been false since **#64** and never caught, because nothing gates prose.

## What is deliberately not fixed

A primitive **nothing** references has no structural signal, so no role is inferred. Rather than guess, `tokens:validate-output` names it: `unreferenced-text-sibling` points at the token and the `$extensions` stamp that settles it, and `ambiguous-text-role` names a token referenced by both kinds of member. Both are advisories — reported, never gating. Five fire per build on zygarden; zero `ambiguous-text-role`, as predicted.

**Group unanimity was considered and declined** (spec §9): it reaches every token, but a source whose non-typographic usage isn't expressed as DTCG references would have a whole spacing ramp silently become `sp`.

## Verification

- 424/424 tests, six CI gates green, doc regenerated.
- **The ordering pin was proven to fail before being kept.** `applyTextRoleGraph` must run before `hoistDualNodes`; swapping them left the suite green except a doc-freshness gate. The new test returns `undefined` instead of `'text'` under the swap — verified, then restored.
- Whole-branch review on the most capable model, one fix wave, one scoped re-review, all findings addressed.

## Known limitation, not introduced here

On a source declaring `$type` only at group level, nothing is stamped — `classifyTextUnits` is a no-op too, so Android emits zero `sp` with no advisory saying so. Pre-existing and recorded in spec §8. `dtcg.mjs` already exports `flattenDtcgTypes`, which implements DTCG 5.2.2 correctly, so the machinery is in the same file. Worth a follow-up issue.

Independent of #82 and #83 — no file overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018etbNQyHfuuGWwmd88T8Zm