### PR TITLE
A group-level $type no longer makes the text-role pipeline a silent no-op (#85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,25 +10,39 @@ to [Semantic Versioning](https://semver.org).
 
 - **A `$type` declared on the group now reaches the text-role pipeline.** DTCG
   5.2.2 says a token's own `$type` wins, otherwise the nearest ancestor group's.
-  Both stamping passes read the token's own literal `$type` instead, so a source
-  that declares `$type` once per group — entirely legal DTCG — was invisible to
-  them. On such a source the pipeline was **a silent no-op with a green build**:
-  no `sp`, no `em` letter spacing, and no advisory saying so, because the
-  advisory that exists to report a silent gap gated on own-`$type` too. All
-  three now resolve the type properly. Measured by re-encoding a real 322-token
-  system so `$type` sits on the group — the same tokens, legally rewritten, which
-  a correct pipeline must emit identically: **it now does, byte for byte, and
-  before this it did not.** Twelve Kotlin symbols move. Nine font sizes go back
-  from `dp` to `sp`, so a use site like `Modifier.padding(Tokens.textBase)` stops
-  compiling — the same breakage 0.17.0 described, now reaching the sources 0.17.0
-  could not see. Three `em` letterSpacing symbols reappear that were being
-  dropped from Compose output entirely, taking the file from 205 declarations to
-  208. Swift is unchanged, byte for byte. The per-token opt-out is unchanged:
-  stamp `$extensions["com.radicool.throughline"].nativeUnit` to `"device"`.
+  Both stamping passes and the advisory that reports their gaps read the token's
+  own literal `$type` instead, so a source that declares `$type` once per group —
+  entirely legal DTCG — was invisible to all three at once. All three now resolve
+  the type properly.
+
+  **Whether this changes your build depends on how you wire the preprocessor,
+  and most builds will not change.** Style Dictionary runs global preprocessors,
+  then its own `typeDtcgDelegate` — which is 5.2.2, pushing each group's `$type`
+  onto its descendants — then platform preprocessors. `nativePlatform` registers
+  ours at platform level, downstream of that delegation, so **a build wired only
+  through `nativePlatform` never had this defect and is byte-identical.** The
+  build affected is the one that *also* declares `dtcg/resolve-dual-node` at top
+  level, which is the wiring our own usage snippet shows: there the first pass
+  runs before any delegation, and the group's `$type` is not yet visible.
+
+  On that wiring, measured against a real system re-encoded so `$type` sits on
+  the group — the same tokens said a second legal way, which a correct pipeline
+  must emit identically: **it now does, byte for byte, and before this it did
+  not.** Twelve Kotlin symbols move. Nine font sizes go from `dp` back to `sp`,
+  so a use site like `Modifier.padding(Tokens.textBase)` stops compiling — the
+  same breakage 0.17.0 described, now reaching sources 0.17.0 could not see.
+  Three `em` letterSpacing symbols reappear that were being dropped from Compose
+  output entirely, taking the file from 205 declarations to 208. Swift is
+  unchanged, byte for byte. The per-token opt-out is unchanged: stamp
+  `$extensions["com.radicool.throughline"].nativeUnit` to `"device"`.
+
+  Not a total no-op even on the affected wiring, though it was reported as one:
+  the member-name pass keeps working wherever the typographic members carry
+  their own `$type`, so that build still emitted 39 `sp`. What was completely
+  undone is the reference-graph inference — everything 0.17.0 added.
 
   A source that types every token node — which is what Figma-derived extracts
-  emit, and what our validation target does — is **byte-identical** before and
-  after. If your build does not change, this is why.
+  emit — is byte-identical on either wiring.
 
 ## [0.17.0] — 2026-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Breaking
+
+- **A `$type` declared on the group now reaches the text-role pipeline.** DTCG
+  5.2.2 says a token's own `$type` wins, otherwise the nearest ancestor group's.
+  Both stamping passes read the token's own literal `$type` instead, so a source
+  that declares `$type` once per group — entirely legal DTCG — was invisible to
+  them. On such a source the pipeline was **a silent no-op with a green build**:
+  no `sp`, no `em` letter spacing, and no advisory saying so, because the
+  advisory that exists to report a silent gap gated on own-`$type` too. All
+  three now resolve the type properly. Measured by re-encoding a real 322-token
+  system so `$type` sits on the group — the same tokens, legally rewritten, which
+  a correct pipeline must emit identically: **it now does, byte for byte, and
+  before this it did not.** Twelve Kotlin symbols move. Nine font sizes go back
+  from `dp` to `sp`, so a use site like `Modifier.padding(Tokens.textBase)` stops
+  compiling — the same breakage 0.17.0 described, now reaching the sources 0.17.0
+  could not see. Three `em` letterSpacing symbols reappear that were being
+  dropped from Compose output entirely, taking the file from 205 declarations to
+  208. Swift is unchanged, byte for byte. The per-token opt-out is unchanged:
+  stamp `$extensions["com.radicool.throughline"].nativeUnit` to `"device"`.
+
+  A source that types every token node — which is what Figma-derived extracts
+  emit, and what our validation target does — is **byte-identical** before and
+  after. If your build does not change, this is why.
+
 ## [0.17.0] — 2026-08-31
 
 ### Breaking

--- a/docs/superpowers/notes/2026-08-31-group-type-resolution-e2e.md
+++ b/docs/superpowers/notes/2026-08-31-group-type-resolution-e2e.md
@@ -3,8 +3,12 @@
 **Date:** 2026-08-31
 **Gate for:** the #85 fix — routing all three text-role gates through DTCG 5.2.2
 resolved types instead of each token's own literal `$type`.
-**Verdict:** PASS. The fix makes two legal encodings of the same source emit
-**byte-identical** output. Released 0.17.0 does not: it loses 12 symbols.
+**Verdict:** PASS, with a scope correction the first draft of this note got
+wrong. The fix makes two legal encodings of the same source emit
+**byte-identical** output. Released 0.17.0 does not — but only on one of the two
+documented preprocessor wirings, and this run originally varied the token
+encoding while holding that wiring fixed without saying so. Twelve symbols
+differ: nine present-but-mistyped, three absent.
 
 ## Why this run exists
 
@@ -32,16 +36,31 @@ were gone while the directory tree survived. Anyone reading a note that says
   and a rebuild from it fails at import. This run is direct evidence for #87.
 - **Branch:** `fix/85-group-type-resolution`; the "main" column is `a349453`,
   which is 0.17.0 as published.
+- **Preprocessor wiring — the input that decides the whole result, and the one
+  the first draft of this note failed to record.** Two wirings are documented.
+  `build.mjs` declares `dtcg/resolve-dual-node` at **top level** *and* gets it
+  again from `nativePlatform`; `build-platform-only.mjs` omits the top-level
+  line. Style Dictionary 4.4.0 runs global preprocessors, then `typeDtcgDelegate`
+  — its own implementation of 5.2.2 — then platform preprocessors
+  (`StyleDictionary.js:340`, `:348`, `:440`). So the platform-only wiring has
+  already had group types delegated onto its tokens before our pass runs, and
+  never saw the defect.
 
 ## The fixture, and why it is legal rather than contrived
 
 `group-type.mjs` re-encodes the source so `$type` sits on the **group** instead
 of on each token, wherever a group's direct token children all agree on one
-type. It moved `$type` off **167 of 322 tokens**.
+type. It moved `$type` off **167 tokens**.
+
+**Denominator, corrected:** this source holds **318** `$value` entries across
+its 15 files, and **211** under the light+mobile pin the build uses. The "322"
+that appears throughout this repo's notes belongs to
+`libs/shared/util-tokens/src/tokens/`, a path that no longer exists; the figure
+was carried forward without being recounted.
 
 This is not a mutation of meaning. DTCG 5.2.2 says a token's own `$type` wins,
 otherwise the nearest ancestor group's — so both encodings describe the same
-322 tokens, and a correct pipeline **must** emit the same bytes for both. That
+211 tokens, and a correct pipeline **must** emit the same bytes for both. That
 is the discriminating property #77 asks for: the PASS condition is not an empty
 diff against nothing, it is agreement between two encodings that are required to
 agree.
@@ -65,6 +84,21 @@ No regression on the validation target, which is also why no previous e2e caught
 this bug.
 
 ## Result — the group-typed encoding
+
+### The wiring decides whether the bug exists at all
+
+| wiring | main (0.17.0) | with the fix |
+|---|---|---|
+| `nativePlatform` only | 208 decls / 48 `sp` | 208 / 48 — **identical** |
+| + top-level `preprocessors` | 205 / 39 | 208 / 48 |
+
+A consumer wired only through `nativePlatform` was never affected: Style
+Dictionary's own `typeDtcgDelegate` had already done 5.2.2 for them. The wiring
+that breaks is the one our usage snippet teaches, which is why the fix is still
+needed — but "every consumer is affected" was never true, and the first draft of
+this note implied it.
+
+### On the affected wiring
 
 | | main (0.17.0 as released) | with the fix |
 |---|---|---|
@@ -127,7 +161,32 @@ exit=0
   by this run.
 - **The issue's severity ranking is right for the wrong reason.** It is not that
   more tokens are affected than expected — it is that everything 0.17.0 shipped
-  four days ago is undone by a re-encoding the spec explicitly permits.
+  four days ago is undone by a re-encoding the spec explicitly permits, on the
+  wiring the docs teach.
+- **"Zero `sp`" is not covered by a unit test, as an earlier draft of this note
+  claimed.** No test in this repo runs Style Dictionary — `fakeStyleDictionary`
+  is a registration spy — so no test measures emitted `sp` at all. The tests
+  assert the `$extensions` stamp; the step from "no stamp" to "no `sp`" also
+  depends on the transform filters. Stated correctly: the *stamp* half is unit
+  tested, the *emission* half is only ever measured by a run like this one.
+
+## A second defect this run surfaced, pre-existing
+
+`preprocess` is **not idempotent** where the hoist invents a typographic name.
+`a.font` with a child `size` camel-joins to `a.fontSize`: pass 1 correctly
+declines (`size` is not a typographic member name, and classification runs
+before the hoist), and pass 2 sees a key named `fontSize` the source never
+authored and stamps it.
+
+**This predates #85** — verified against `a349453`, where it fires whenever the
+hoisted child carries its own `$type`. The #85 change *widens* it, since the
+group's type now also reaches such a child. It changes no emitted output in
+either wiring, because `typeDtcgDelegate` types the hoisted child between the
+two passes anyway. Pinned in both directions by test and filed, rather than
+repaired here: the repair belongs with the hoist, not with type resolution.
+
+Worth noting because idempotency is asserted unconditionally in four comments
+that ship through `references/native-adapter-config.md`.
 
 ## Open question this run did not settle
 
@@ -145,7 +204,8 @@ under cover of #85 — which is the mistake #63 was careful not to make here.
 ```
 $ cd <harness>
 $ node group-type.mjs tokens tokens-grouped     # moved $type off 167 tokens
-$ node build.mjs tokens        out-85-head
+$ node build.mjs tokens        out-85-head        # top-level + platform wiring
 $ node build.mjs tokens-grouped out-85g-head
 $ diff out-85-head/Tokens.kt out-85g-head/Tokens.kt   # empty, with the fix
+$ node build-platform-only.mjs tokens-grouped out-85p-main   # unaffected wiring
 ```

--- a/docs/superpowers/notes/2026-08-31-group-type-resolution-e2e.md
+++ b/docs/superpowers/notes/2026-08-31-group-type-resolution-e2e.md
@@ -1,0 +1,151 @@
+# Group-level `$type` (#85) — e2e against zygarden
+
+**Date:** 2026-08-31
+**Gate for:** the #85 fix — routing all three text-role gates through DTCG 5.2.2
+resolved types instead of each token's own literal `$type`.
+**Verdict:** PASS. The fix makes two legal encodings of the same source emit
+**byte-identical** output. Released 0.17.0 does not: it loses 12 symbols.
+
+## Why this run exists
+
+#85 claims a group-level `$type` makes the native text-role pipeline a silent
+no-op. Unit tests can show the stamp appears; they cannot show what Compose
+actually receives. This run measures the emitted output — running the
+preprocessor is not running the pipeline.
+
+## Harness
+
+**Rebuilt**, because the prior session's harness had been partly cleared from
+`/private/tmp` — `build.mjs`, `tokens/` and `node_modules/style-dictionary`
+were gone while the directory tree survived. Anyone reading a note that says
+"reused, still alive" should check before believing it.
+
+- **Style Dictionary:** 4.4.0, installed fresh in the harness directory.
+- **Source:** the same 15 zygarden token files, from
+  `~/Dev/zygarden-brand-guide/libs/tokens/src/tokens/`. Read-only; that repo was
+  not modified.
+- **Mode pin:** light + mobile (the build drops any filename containing
+  `desktop` or `dark`) — 12 of the 15 files, matching every prior run.
+- **Module install, by copy and not symlink:** `lib/dtcg.mjs`,
+  `lib/native-literal.mjs`, `lib/sd-native.mjs`. **Three files, not the two the
+  2026-08-21 note lists** — that note's install list omits `native-literal.mjs`
+  and a rebuild from it fails at import. This run is direct evidence for #87.
+- **Branch:** `fix/85-group-type-resolution`; the "main" column is `a349453`,
+  which is 0.17.0 as published.
+
+## The fixture, and why it is legal rather than contrived
+
+`group-type.mjs` re-encodes the source so `$type` sits on the **group** instead
+of on each token, wherever a group's direct token children all agree on one
+type. It moved `$type` off **167 of 322 tokens**.
+
+This is not a mutation of meaning. DTCG 5.2.2 says a token's own `$type` wins,
+otherwise the nearest ancestor group's — so both encodings describe the same
+322 tokens, and a correct pipeline **must** emit the same bytes for both. That
+is the discriminating property #77 asks for: the PASS condition is not an empty
+diff against nothing, it is agreement between two encodings that are required to
+agree.
+
+A node carrying a `$value` is a token, not a group (DTCG 6.1), so the script
+never makes a dual node an inheritance source. Dual-node children keep their own
+`$type`. This fixture therefore tests group inheritance only, not the hoist
+carry — see the open question below.
+
+## Control — the fix changes nothing on the source as authored
+
+zygarden types every token node, so 5.2.2 inheritance never fires on it. Both
+builds of the **unmodified** source:
+
+```
+Tokens.kt    IDENTICAL
+Tokens.swift IDENTICAL
+```
+
+No regression on the validation target, which is also why no previous e2e caught
+this bug.
+
+## Result — the group-typed encoding
+
+| | main (0.17.0 as released) | with the fix |
+|---|---|---|
+| Kotlin declarations | **205** | **208** |
+| `.sp` occurrences | **39** | **48** |
+| unmatched source tokens | 6 | 3 |
+| `unreferenced-text-sibling` advisories | **0** | **5** |
+| vs. the per-token-typed build | differs | **byte-identical** |
+
+**Twelve symbols, in two groups.**
+
+Nine font sizes regress from `sp` to `dp` — `textXs`, `textSm`, `textBase`,
+`textLg`, `textXl`, `text2xl`, `text3xl`, `text4xl`, `text5xl`. That is #51's
+accessibility fix silently un-applied: Android text stops responding to the
+user's system font-size setting.
+
+Three letterSpacing symbols **vanish entirely** — `typographyLetterSpacingTight`,
+`...Normal`, `...Wide`, which is why the declaration count falls 208 → 205. An
+`em` value with no text role has no native form and is filtered out of Compose
+output, so the tokens are not wrong, they are absent.
+
+Swift is byte-identical in every combination. The sp/dp distinction is
+Compose-only.
+
+## The silent half, confirmed exactly
+
+On main, against the group-typed source, `tokens:validate-output` reports:
+
+```
+tokens:validate-output — 205/205 emitted symbols matched a source token (100%)
+5 advisory note(s) — reported, not gating:      (all unitless-dimension)
+6 source token(s) had no matching emitted symbol.
+```
+
+**Zero `unreferenced-text-sibling` advisories.** A green run, a 100% match, and
+nothing anywhere saying the text-role pipeline did not fire. With the fix, five
+fire and name the tokens the graph could not reach — `text.6xl` through
+`text.9xl` and `typography.letterSpacing.widest`.
+
+## Compile verification
+
+`ci/compile-native-output.mjs` (#82) against the fixed output:
+
+```
+[PASS] kotlin: typechecked to bytecode (against ci/stubs, not real Compose)
+[PASS] swift: parsed only (UIKit unavailable; -typecheck impossible)
+exit=0
+```
+
+## Corrections to what #85 says
+
+- **The issue says "nothing is stamped at all" and "zero `sp`".** On this source
+  it is 39 `sp`, not zero — a *partial* no-op. The member-name pass (#51) keeps
+  working wherever the typographic members carry their own `$type`, and in
+  zygarden they sit in mixed-type groups (`fontSize` beside `fontFamily` and
+  `fontWeight`) that cannot legally hoist a shared type. The **graph-inference
+  half is a total no-op**: all nine of 0.17.0's headline symbols, plus the three
+  em letterSpacing tokens, are lost. "Zero `sp`" needs a source that also
+  group-types its typographic members; that shape is covered by unit test, not
+  by this run.
+- **The issue's severity ranking is right for the wrong reason.** It is not that
+  more tokens are affected than expected — it is that everything 0.17.0 shipped
+  four days ago is undone by a re-encoding the spec explicitly permits.
+
+## Open question this run did not settle
+
+`hoistDualNodes` carries a dual node's `$type` onto a hoisted child where DTCG
+inheritance supplies none. That carry runs **after** classification — it must,
+because classification matches on the leaf name the hoist consumes. So a child
+typed *only* by the carry is never stamped as text. Unchanged by this fix and
+left alone deliberately: the carry is the hoist repairing what the hoist broke,
+not a reading of the source, and stamping on an invented type would be a claim
+the source never made. Pinned by test, filed separately rather than changed
+under cover of #85 — which is the mistake #63 was careful not to make here.
+
+## Reproduce
+
+```
+$ cd <harness>
+$ node group-type.mjs tokens tokens-grouped     # moved $type off 167 tokens
+$ node build.mjs tokens        out-85-head
+$ node build.mjs tokens-grouped out-85g-head
+$ diff out-85-head/Tokens.kt out-85g-head/Tokens.kt   # empty, with the fix
+```

--- a/docs/superpowers/specs/2026-08-24-compose-text-unit-design.md
+++ b/docs/superpowers/specs/2026-08-24-compose-text-unit-design.md
@@ -282,13 +282,20 @@ twice and none falls through the partition. Transitive re-runs are harmless
 regardless, because `authored()` reads `original.$value` rather than the
 running value.
 
-**Stated limit — the `$type` check reads the token's own key.** A typeless
-child that would inherit `dimension` from its parent is not classified,
-because `hoistDualNodes` copies the parent's `$type` down *after*
-classification has run. §4 puts classification before the hoist for an
-unrelated and stronger reason — the leaf name — and this limit is the price of
-that ordering. zygarden's dual-node children all carry their own `$type`, so
-the §7.1 prediction is unaffected. This is the same class of limit as §3.2's naming
+**Stated limit — narrowed by #85, not removed.** As written this said "the
+`$type` check reads the token's own key", which stopped being true when #85
+routed classification through a DTCG 5.2.2 resolution: a child that inherits
+`dimension` from an enclosing **group** is now classified.
+
+What survives is the narrower half this paragraph was really about. A typeless
+child of a **dual node** with no enclosing group type is still not classified,
+because DTCG gives it no type at all — a node carrying a `$value` is a token,
+not an inheritance source (6.1) — and the only thing that types it is
+`hoistDualNodes` copying the parent's `$type` down *after* classification has
+run. §4 puts classification before the hoist for an unrelated and stronger
+reason — the leaf name — and this limit is the price of that ordering.
+zygarden's dual-node children all carry their own `$type`, so the §7.1
+prediction is unaffected. This is the same class of limit as §3.2's naming
 caveat: narrow, real, and documented rather than papered over.
 
 **The override is trusted, and only partly guarded.** Requirement 1 applies to

--- a/references/native-adapter-config.md
+++ b/references/native-adapter-config.md
@@ -54,6 +54,7 @@ consumer's repo.
 import { readFileSync } from 'node:fs';
 import {
   flattenDtcg,
+  flattenDtcgTypes,
   resolveValue,
   findModeCollisions,
   TEXT_UNIT_NAMES,
@@ -342,13 +343,21 @@ export { EXT_NS };
 // on is gone. Matching a suffix against the camel-joined name instead would
 // couple the rule to the hoist's naming scheme, and case-insensitively it
 // false-positives on names like baselineHeight.
-function classifyTextUnits(node) {
+//
+// The type comes from `types`, a DTCG 5.2.2 resolution of the whole tree, not
+// from the token's own literal $type. Reading val.$type made this pass blind to
+// a source that declares $type once on the group — legal DTCG, and on it the
+// pass stamped nothing, so Android emitted no sp at all and no advisory said so
+// (#85). A token's own $type still wins; the group's applies only where the
+// token states none.
+function classifyTextUnits(node, types, prefix = []) {
   for (const [key, val] of Object.entries(node)) {
     if (key.startsWith('$') || !val || typeof val !== 'object') continue;
+    const path = [...prefix, key];
     if (
       TEXT_UNIT_NAMES.has(key) &&
       '$value' in val &&
-      val.$type === 'dimension' &&
+      types[path.join('.')] === 'dimension' &&
       TEXT_ROLE_UNIT.test(String(val.$value).trim())
     ) {
       val.$extensions ??= {};
@@ -362,7 +371,7 @@ function classifyTextUnits(node) {
       // the pass idempotent.
       if (!('nativeUnit' in ns)) ns.nativeUnit = 'text';
     }
-    classifyTextUnits(val);
+    classifyTextUnits(val, types, path);
   }
   return node;
 }
@@ -373,7 +382,9 @@ function classifyTextUnits(node) {
 // text.xsLineHeight and the graph's paths are written in pre-hoist names.
 //
 // The three gates are classifyTextUnits's, verbatim — a dimension, a value with
-// a unit, and no role already recorded. A unitless value is never stamped: no
+// a unit, and no role already recorded. Both passes read the SAME resolved-type
+// map, which is what makes them agree by construction rather than by two copies
+// of DTCG 5.2.2 staying in step. A unitless value is never stamped: no
 // size transform claims one since #52, and stamping a ratio as text would still
 // be a claim the source never made.
 //
@@ -381,14 +392,14 @@ function classifyTextUnits(node) {
 // unresolvable reference in place for Style Dictionary to report, so the graph
 // can hold an edge to a token that does not exist. Skip it. This is also what
 // keeps the second preprocess pass from throwing, and idempotency with it.
-function applyTextRoleGraph(node, typographic) {
+function applyTextRoleGraph(node, typographic, types) {
   for (const path of typographic) {
     let target = node;
     for (const segment of path.split('.')) {
       target = target && typeof target === 'object' ? target[segment] : undefined;
     }
     if (!target || typeof target !== 'object' || !('$value' in target)) continue;
-    if (target.$type !== 'dimension') continue;
+    if (types[path] !== 'dimension') continue;
     if (!TEXT_ROLE_UNIT.test(String(target.$value).trim())) continue;
     target.$extensions ??= {};
     target.$extensions[EXT_NS] ??= {};
@@ -403,11 +414,17 @@ export function preprocess(dict) {
   // Read from the UNRESOLVED dict, before resolveInPlace flattens the aliases
   // the graph is made of.
   const { typographic } = textRoleGraph(dict);
+  const resolved = resolveInPlace(structuredClone(dict), flattenDtcg(dict));
+  // DTCG 5.2.2 types for the whole tree, walked once and shared by both passes
+  // below. Neither writes $type or moves a node, so one map is correct for
+  // both, and sharing it is what makes them agree by construction rather than
+  // by two copies of the same rule staying in step (#85).
+  //
+  // Computed on the RESOLVED clone, which is the tree both passes read.
+  // resolveInPlace rewrites $value strings only, so the types are the source's.
+  const types = flattenDtcgTypes(resolved);
   const out = hoistDualNodes(
-    applyTextRoleGraph(
-      classifyTextUnits(resolveInPlace(structuredClone(dict), flattenDtcg(dict))),
-      typographic,
-    ),
+    applyTextRoleGraph(classifyTextUnits(resolved, types), typographic, types),
     collisions,
   );
   if (collisions.length) {

--- a/references/native-adapter-config.md
+++ b/references/native-adapter-config.md
@@ -346,10 +346,21 @@ export { EXT_NS };
 //
 // The type comes from `types`, a DTCG 5.2.2 resolution of the whole tree, not
 // from the token's own literal $type. Reading val.$type made this pass blind to
-// a source that declares $type once on the group — legal DTCG, and on it the
-// pass stamped nothing, so Android emitted no sp at all and no advisory said so
-// (#85). A token's own $type still wins; the group's applies only where the
-// token states none.
+// a source that declares $type once on the group — legal DTCG, and on such a
+// source the reference-graph inference stamped nothing at all (#85). A token's
+// own $type still wins; the group's applies only where the token states none.
+//
+// WHERE THIS MATTERS, measured rather than assumed. Style Dictionary runs
+// global preprocessors, THEN its own typeDtcgDelegate — which is 5.2.2, pushing
+// each group's $type onto its descendants — then platform preprocessors
+// (StyleDictionary.js:340, :348, :440 in 4.4.0). nativePlatform registers this
+// preprocessor at PLATFORM level, downstream of that delegation, so a build
+// wired only through nativePlatform never saw the defect: on a group-typed
+// re-encoding of a real system it emits the same 208 declarations and 48 sp
+// either way. The defect reaches the build that ALSO declares this preprocessor
+// at top level, which is the wiring the usage snippet above shows — there the
+// first pass runs before any delegation. Resolving the type here makes both
+// wirings agree instead of depending on which one a consumer copied.
 function classifyTextUnits(node, types, prefix = []) {
   for (const [key, val] of Object.entries(node)) {
     if (key.startsWith('$') || !val || typeof val !== 'object') continue;

--- a/scripts/lib/dtcg.mjs
+++ b/scripts/lib/dtcg.mjs
@@ -178,6 +178,12 @@ export function textRoleGraph(dict) {
   // failure this module exists to prevent. A token whose source already stamps
   // nativeUnit is closed and is not reported.
   const inferredGroups = new Set([...typographic].map((p) => p.split('.').slice(0, -1).join('.')));
+  // DTCG 5.2.2, not the token's own literal $type: a source that declares
+  // $type once on the group and not on each token is legal DTCG, and gating on
+  // val.$type made this walk blind to it — so the advisory that exists to name
+  // a silent gap was itself silent on the shape where the whole pipeline goes
+  // quiet (#85).
+  const types = flattenDtcgTypes(dict);
   const unreferencedSiblings = [];
   (function walk(node, prefix) {
     for (const [key, val] of Object.entries(node)) {
@@ -187,7 +193,7 @@ export function textRoleGraph(dict) {
       const group = prefix.join('.');
       if (
         '$value' in val &&
-        val.$type === 'dimension' &&
+        types[dotted] === 'dimension' &&
         TEXT_ROLE_UNIT.test(String(val.$value).trim()) &&
         !referrers.has(dotted) &&
         !('nativeUnit' in (val.$extensions?.[EXT_NS] ?? {})) &&

--- a/scripts/lib/dtcg.test.mjs
+++ b/scripts/lib/dtcg.test.mjs
@@ -198,6 +198,29 @@ test('an unreferenced sibling of an inferred token is advised, not inferred', ()
   assert.equal(g.unreferencedSiblings.find((u) => u.path === 'text.huge').group, 'text');
 });
 
+// #85. DTCG 5.2.2 lets a source declare $type once on the group. This walk gated
+// on the token's own literal $type, so on such a source it named nothing — the
+// advisory that exists to report a silent gap was itself silent on the one shape
+// where the whole text-role pipeline goes quiet.
+test('an unreferenced sibling is advised where the group supplies the $type', () => {
+  const g = textRoleGraph({
+    text: { $type: 'dimension', base: { $value: '16px' }, huge: { $value: '96px' } },
+    typography: { body: { fontSize: { $type: 'dimension', $value: '{text.base}' } } },
+  });
+  assert.deepEqual(
+    g.unreferencedSiblings.map((u) => u.path),
+    ['text.huge'],
+  );
+});
+
+test('a token own $type still beats the group $type in the sibling walk', () => {
+  const g = textRoleGraph({
+    text: { $type: 'dimension', base: { $value: '16px' }, huge: { $value: '96px', $type: 'string' } },
+    typography: { body: { fontSize: { $type: 'dimension', $value: '{text.base}' } } },
+  });
+  assert.deepEqual(g.unreferencedSiblings, [], 'huge is a string, whatever its group says');
+});
+
 test('an edge to a path that does not exist is collected, not thrown on', () => {
   const g = textRoleGraph({
     typography: { body: { fontSize: { $type: 'dimension', $value: '{nope.missing}' } } },

--- a/scripts/lib/sd-native.mjs
+++ b/scripts/lib/sd-native.mjs
@@ -277,10 +277,21 @@ export { EXT_NS };
 //
 // The type comes from `types`, a DTCG 5.2.2 resolution of the whole tree, not
 // from the token's own literal $type. Reading val.$type made this pass blind to
-// a source that declares $type once on the group — legal DTCG, and on it the
-// pass stamped nothing, so Android emitted no sp at all and no advisory said so
-// (#85). A token's own $type still wins; the group's applies only where the
-// token states none.
+// a source that declares $type once on the group — legal DTCG, and on such a
+// source the reference-graph inference stamped nothing at all (#85). A token's
+// own $type still wins; the group's applies only where the token states none.
+//
+// WHERE THIS MATTERS, measured rather than assumed. Style Dictionary runs
+// global preprocessors, THEN its own typeDtcgDelegate — which is 5.2.2, pushing
+// each group's $type onto its descendants — then platform preprocessors
+// (StyleDictionary.js:340, :348, :440 in 4.4.0). nativePlatform registers this
+// preprocessor at PLATFORM level, downstream of that delegation, so a build
+// wired only through nativePlatform never saw the defect: on a group-typed
+// re-encoding of a real system it emits the same 208 declarations and 48 sp
+// either way. The defect reaches the build that ALSO declares this preprocessor
+// at top level, which is the wiring the usage snippet above shows — there the
+// first pass runs before any delegation. Resolving the type here makes both
+// wirings agree instead of depending on which one a consumer copied.
 function classifyTextUnits(node, types, prefix = []) {
   for (const [key, val] of Object.entries(node)) {
     if (key.startsWith('$') || !val || typeof val !== 'object') continue;

--- a/scripts/lib/sd-native.mjs
+++ b/scripts/lib/sd-native.mjs
@@ -12,6 +12,7 @@
 import { readFileSync } from 'node:fs';
 import {
   flattenDtcg,
+  flattenDtcgTypes,
   resolveValue,
   findModeCollisions,
   TEXT_UNIT_NAMES,
@@ -273,13 +274,21 @@ export { EXT_NS };
 // on is gone. Matching a suffix against the camel-joined name instead would
 // couple the rule to the hoist's naming scheme, and case-insensitively it
 // false-positives on names like baselineHeight.
-function classifyTextUnits(node) {
+//
+// The type comes from `types`, a DTCG 5.2.2 resolution of the whole tree, not
+// from the token's own literal $type. Reading val.$type made this pass blind to
+// a source that declares $type once on the group — legal DTCG, and on it the
+// pass stamped nothing, so Android emitted no sp at all and no advisory said so
+// (#85). A token's own $type still wins; the group's applies only where the
+// token states none.
+function classifyTextUnits(node, types, prefix = []) {
   for (const [key, val] of Object.entries(node)) {
     if (key.startsWith('$') || !val || typeof val !== 'object') continue;
+    const path = [...prefix, key];
     if (
       TEXT_UNIT_NAMES.has(key) &&
       '$value' in val &&
-      val.$type === 'dimension' &&
+      types[path.join('.')] === 'dimension' &&
       TEXT_ROLE_UNIT.test(String(val.$value).trim())
     ) {
       val.$extensions ??= {};
@@ -293,7 +302,7 @@ function classifyTextUnits(node) {
       // the pass idempotent.
       if (!('nativeUnit' in ns)) ns.nativeUnit = 'text';
     }
-    classifyTextUnits(val);
+    classifyTextUnits(val, types, path);
   }
   return node;
 }
@@ -304,7 +313,9 @@ function classifyTextUnits(node) {
 // text.xsLineHeight and the graph's paths are written in pre-hoist names.
 //
 // The three gates are classifyTextUnits's, verbatim — a dimension, a value with
-// a unit, and no role already recorded. A unitless value is never stamped: no
+// a unit, and no role already recorded. Both passes read the SAME resolved-type
+// map, which is what makes them agree by construction rather than by two copies
+// of DTCG 5.2.2 staying in step. A unitless value is never stamped: no
 // size transform claims one since #52, and stamping a ratio as text would still
 // be a claim the source never made.
 //
@@ -312,14 +323,14 @@ function classifyTextUnits(node) {
 // unresolvable reference in place for Style Dictionary to report, so the graph
 // can hold an edge to a token that does not exist. Skip it. This is also what
 // keeps the second preprocess pass from throwing, and idempotency with it.
-function applyTextRoleGraph(node, typographic) {
+function applyTextRoleGraph(node, typographic, types) {
   for (const path of typographic) {
     let target = node;
     for (const segment of path.split('.')) {
       target = target && typeof target === 'object' ? target[segment] : undefined;
     }
     if (!target || typeof target !== 'object' || !('$value' in target)) continue;
-    if (target.$type !== 'dimension') continue;
+    if (types[path] !== 'dimension') continue;
     if (!TEXT_ROLE_UNIT.test(String(target.$value).trim())) continue;
     target.$extensions ??= {};
     target.$extensions[EXT_NS] ??= {};
@@ -334,11 +345,17 @@ export function preprocess(dict) {
   // Read from the UNRESOLVED dict, before resolveInPlace flattens the aliases
   // the graph is made of.
   const { typographic } = textRoleGraph(dict);
+  const resolved = resolveInPlace(structuredClone(dict), flattenDtcg(dict));
+  // DTCG 5.2.2 types for the whole tree, walked once and shared by both passes
+  // below. Neither writes $type or moves a node, so one map is correct for
+  // both, and sharing it is what makes them agree by construction rather than
+  // by two copies of the same rule staying in step (#85).
+  //
+  // Computed on the RESOLVED clone, which is the tree both passes read.
+  // resolveInPlace rewrites $value strings only, so the types are the source's.
+  const types = flattenDtcgTypes(resolved);
   const out = hoistDualNodes(
-    applyTextRoleGraph(
-      classifyTextUnits(resolveInPlace(structuredClone(dict), flattenDtcg(dict))),
-      typographic,
-    ),
+    applyTextRoleGraph(classifyTextUnits(resolved, types), typographic, types),
     collisions,
   );
   if (collisions.length) {

--- a/scripts/lib/sd-native.test.mjs
+++ b/scripts/lib/sd-native.test.mjs
@@ -969,11 +969,64 @@ test('preprocess stamps rem as well as px', () => {
   assert.equal(roleOf(out.t.fontSize), 'text');
 });
 
-// The $type check reads the token's OWN key, so a fontSize typed something
-// else is not swept in.
+// A token's OWN $type wins over one it inherits (DTCG 5.2.2), so a fontSize
+// typed something else is not swept in — including where the enclosing group
+// types everything around it dimension.
 test('preprocess does not stamp a fontSize that is not dimension-typed', () => {
   const out = preprocess({ t: { fontSize: { $value: '30px', $type: 'string' } } });
   assert.equal(roleOf(out.t.fontSize), undefined);
+  const under = preprocess({ t: { $type: 'dimension', fontSize: { $value: '30px', $type: 'string' } } });
+  assert.equal(roleOf(under.t.fontSize), undefined, 'own $type beats the group');
+});
+
+// #85. A source that declares $type once on the group and not on each token is
+// legal DTCG, and both stamping passes gated on the token's own literal $type —
+// so on such a source NOTHING was stamped: Android emitted zero sp, every font
+// size rendered as dp ignoring the user's system font-size setting, and no
+// advisory fired. #51's accessibility fix, silently un-applied, on a shape no
+// gate could see. Unrealised on zygarden, which types every token node, which is
+// why no e2e caught it.
+test('preprocess stamps a fontSize whose $type comes from the enclosing group', () => {
+  const out = preprocess({
+    typography: { $type: 'dimension', h1: { fontSize: { $value: '30px' } } },
+  });
+  assert.equal(roleOf(out.typography.h1.fontSize), 'text');
+});
+
+// The graph half of the same gap. applyTextRoleGraph mirrored classifyTextUnits'
+// own-$type check deliberately (#63), so the inference 0.17.0 shipped was a
+// no-op on exactly the sources the classifier could not read either.
+test('preprocess stamps a graph-inferred primitive whose $type comes from the group', () => {
+  const out = preprocess({
+    text: { $type: 'dimension', base: { $value: '16px' } },
+    typography: { body: { fontSize: { $type: 'dimension', $value: '{text.base}' } } },
+  });
+  assert.equal(roleOf(out.text.base), 'text');
+});
+
+// A dual node is a token, not a group (DTCG 6.1), so it is not its child's
+// inheritance source — the enclosing GROUP is, before and after the hoist.
+test('a dual-node child typed by an enclosing group is stamped', () => {
+  const out = preprocess({
+    text: { $type: 'dimension', sm: { $value: '14px', lineHeight: { $value: '20px' } } },
+  });
+  assert.equal(roleOf(out.text.smLineHeight), 'text');
+});
+
+// The interaction #85 said a fix had to decide rather than assume. Where NO
+// enclosing group supplies a type, DTCG determines none for this child, and the
+// only thing that types it is hoistDualNodes' carry — which runs AFTER
+// classification, because classification must run before the hoist consumes the
+// leaf name it matches on. So a child typed only by the carry is not stamped.
+// Unchanged by #85 and left that way on purpose: the carry is the hoist
+// repairing what the hoist broke, not a reading of the source, and stamping on
+// an invented type would be a claim the source never made. Filed separately.
+test('a child typed only by the hoist carry is not stamped as text', () => {
+  const out = preprocess({
+    text: { sm: { $value: '14px', $type: 'dimension', lineHeight: { $value: '20px' } } },
+  });
+  assert.equal(out.text.smLineHeight.$type, 'dimension', 'the carry supplies the type');
+  assert.equal(roleOf(out.text.smLineHeight), undefined, 'but classification already ran');
 });
 
 // The override, and the reason this design needs no new config parameter.

--- a/scripts/lib/sd-native.test.mjs
+++ b/scripts/lib/sd-native.test.mjs
@@ -1013,6 +1013,34 @@ test('a dual-node child typed by an enclosing group is stamped', () => {
   assert.equal(roleOf(out.text.smLineHeight), 'text');
 });
 
+// preprocess is NOT idempotent where the hoist invents a typographic name, and
+// was not before #85 either. `a.font` + child `size` camel-join to `a.fontSize`:
+// pass 1 correctly declines, because `size` is not a typographic member name and
+// classification runs before the hoist. Pass 2 sees a key named `fontSize` that
+// the source never authored, and stamps it.
+//
+// Pinned in BOTH directions because #85 widened the hole rather than opening it.
+// On main the second pass fired wherever the hoisted child carried its own
+// $type; resolving the group's type means it now also fires where the child
+// inherits one. Neither changes emitted output in the documented wiring, where
+// Style Dictionary's typeDtcgDelegate runs between the two passes and types the
+// hoisted child anyway. Filed rather than fixed here: the repair belongs with
+// the hoist, not with #85's type resolution.
+test('preprocess is not idempotent where the hoist invents a typographic name', () => {
+  const own = () => ({
+    a: { font: { $value: '2px', $type: 'dimension', size: { $value: '16px', $type: 'dimension' } } },
+  });
+  const onceOwn = preprocess(own());
+  assert.equal(roleOf(onceOwn.a.fontSize), undefined, 'pass 1 declines the authored name "size"');
+  assert.equal(roleOf(preprocess(structuredClone(onceOwn)).a.fontSize), 'text', 'pass 2 stamps it');
+
+  // The same shape, typed by the group instead — the half #85 added.
+  const inherited = () => ({ a: { $type: 'dimension', font: { $value: '2px', size: { $value: '16px' } } } });
+  const onceInherited = preprocess(inherited());
+  assert.equal(roleOf(onceInherited.a.fontSize), undefined);
+  assert.equal(roleOf(preprocess(structuredClone(onceInherited)).a.fontSize), 'text');
+});
+
 // The interaction #85 said a fix had to decide rather than assume. Where NO
 // enclosing group supplies a type, DTCG determines none for this child, and the
 // only thing that types it is hoistDualNodes' carry — which runs AFTER


### PR DESCRIPTION
Closes #85. Filed along the way: #89 (hoist-carry classification gap), #90 (idempotency).

## The bug

DTCG 5.2.2: a token's own `$type` wins, otherwise the nearest ancestor group's. All three text-role gates read the token's **own literal** `$type` instead — `classifyTextUnits` (#51), `applyTextRoleGraph` (#63, mirroring it deliberately), and `textRoleGraph`'s `unreferencedSiblings` walk.

A source that declares `$type` once per group is invisible to all three at once — including to the advisory whose entire job is to report a silent gap.

## Who is actually affected — corrected after review

Style Dictionary runs global preprocessors → its own `typeDtcgDelegate` (which *is* 5.2.2) → platform preprocessors (`StyleDictionary.js:340`, `:348`, `:440`). `nativePlatform` registers ours at **platform** level, downstream of that delegation.

| wiring | main (0.17.0) | this branch |
|---|---|---|
| `nativePlatform` only | 208 decls / 48 `sp` | 208 / 48 — **identical, never affected** |
| + top-level `preprocessors` | 205 / 39 | 208 / 48 |

The affected wiring is the one our own usage snippet teaches, so the fix is needed — but the first draft of this PR and its changelog entry claimed the breakage unconditionally. Both now state the condition.

## The fix

All three gates route through `flattenDtcgTypes`, which already implemented 5.2.2 correctly and sat in the same file. `preprocess` walks it once and hands the same map to both stamping passes — they agreed before because one copied the other's check verbatim, and they agree now because there is one map.

## Verified at the emitted-output layer

Re-encoded a real system so `$type` sits on the group wherever a group's children agree — **167 tokens** (of 318 across 15 files; **211** under the light+mobile pin the build uses). Same tokens, legally stated a second way, so a correct pipeline **must** emit them identically.

- Unmodified source, before vs after: **byte-identical** — no regression, and why no earlier e2e caught this.
- Affected wiring, group-typed: **205 → 208 declarations, 39 → 48 `sp`**, and the fixed build is byte-identical to the per-token-typed one.
- Twelve Kotlin symbols: nine font sizes falling back `sp` → `dp` (#51's accessibility fix undone), three `em` letterSpacing symbols dropped from Compose entirely.
- On `main` the validator emitted **zero** `unreferenced-text-sibling` advisories against that source — green build, 100% match, nothing saying the pipeline never ran. With the fix, five fire and name the tokens.

Compile-verified with `ci/compile-native-output.mjs` (#82): `kotlinc` to bytecode, `swiftc` parse.

Full run, including the platform-only row and the corrected denominator: `docs/superpowers/notes/2026-08-31-group-type-resolution-e2e.md`.

## Corrections this branch makes to things already written down

- **"322 tokens" is stale.** The source has 318 entries, 211 under the pin. 322 belongs to a source path that no longer exists and had been carried forward for ten days. The numerator, 167, reproduces exactly.
- **#85 says "nothing is stamped" and "zero `sp`".** Measured: 39 `sp` — a *partial* no-op. The member-name pass survives wherever typographic members carry their own `$type`. The **graph half is the total no-op**: everything 0.17.0 shipped.
- **The note claimed the zero-`sp` shape was "covered by unit test".** It is not — nothing here runs Style Dictionary under test, so no test measures emitted `sp` at all.
- **`specs/2026-08-24-compose-text-unit-design.md:285`** stated the old limit as live. Narrowed rather than deleted: its dual-node half survives, as #89.

## Deliberately not fixed here

- **#89** — `hoistDualNodes`' `$type` carry runs after classification, so a child typed *only* by that carry is still not stamped. Different mechanism.
- **#90** — `preprocess` is not idempotent where the hoist invents a typographic name (`a.font` + `size` → `a.fontSize`). **Verified pre-existing on `main`**; this branch widens it rather than opening it, and it changes no emitted output in either wiring. Pinned in both directions by test so a fix has something to turn green.

## Tests

453 pass. Seven new; **four fail against `main`** (the bug in each gate), three pass on both by design — they pin unchanged or pre-existing behaviour.