### PR TITLE
The 2026-08-21 e2e note's install list is three files and needs four (#87)

### DIFF
--- a/docs/superpowers/notes/2026-08-21-native-config-e2e-results.md
+++ b/docs/superpowers/notes/2026-08-21-native-config-e2e-results.md
@@ -18,7 +18,19 @@ source, each validated with `tokens:validate-output`.
   directory, nothing from the throughline repo's own tree).
 - **Installed by copy, not symlink** — proving the Task 6 install list is
   complete: `scripts/lib/sd-native.mjs`, `scripts/lib/dtcg.mjs`,
-  `scripts/validate-token-output.mjs`. Nothing else was needed.
+  `scripts/validate-token-output.mjs`. Nothing else was needed **on this date**.
+
+  > **Correction (2026-08-31, #87).** The list has been **four** files since
+  > #70, which made `sd-native.mjs` import `scripts/lib/native-literal.mjs`;
+  > `validate-token-output.mjs` imports it too. Rebuilding the harness from the
+  > three-file list above fails at module resolution, which is how this was
+  > found — by an `ENOENT`, not by reading. Add
+  > `scripts/lib/native-literal.mjs`. The three-file list was accurate when
+  > written and is left in place, because this note is a dated record of what
+  > ran, not a live install guide. The **shipped** guide in
+  > `references/native-adapter-config.md` and the `token-sync-layer` skill were
+  > never wrong: both say "all four files, as a set" and warn that copying any
+  > without the others breaks at import. No consumer was affected.
 - **Source:** `zygarden-frontend`, branch `feature/apply-brandguide-styles`,
   `libs/shared/util-tokens/src/tokens/` — **15 JSON files, 322 `$value`
   entries**, extracted read-only with `git -C … show <branch>:<path>`. That
@@ -310,7 +322,8 @@ this is what the re-run measured.
 extracted zygarden token files, same `build.mjs`. The three installed module
 files (`scripts/lib/sd-native.mjs`, `scripts/lib/dtcg.mjs`,
 `scripts/validate-token-output.mjs`) were re-copied from the repo first, so the
-fixed code is what ran. `out/` was deleted before building.
+fixed code is what ran. `out/` was deleted before building. (Four files today —
+see the correction under **Harness** above.)
 
 ```
 $ node build.mjs


### PR DESCRIPTION
Closes #87.

Since #70, `sd-native.mjs` imports `lib/native-literal.mjs` — and `validate-token-output.mjs` imports it too. The 2026-08-21 note's harness list names three files and says "Nothing else was needed", so rebuilding from it fails at module resolution.

Found by `ENOENT` twice: once during #63's e2e, and again this session rebuilding the harness for #85.

## What this does

Leaves the three-file list in place and puts a **dated correction beside it**, rather than editing it in silently. The note records what ran on 2026-08-21 and was accurate then — rewriting it would erase the fact that the list went stale and nothing caught it. A second reference later in the note gets a pointer to that correction.

## Scope, checked rather than assumed

The **shipped** guidance was never wrong. `references/native-adapter-config.md`, `skills/token-sync-layer/SKILL.md`, and all three adapters say *"all four files, as a set"* and warn that copying any without the others breaks at import. **No consumer following shipped documentation was affected** — only someone reproducing this e2e.

That is the whole scope: one stale note, no code, no behaviour change.