### PR TITLE
A normalizeKey collision fails the run instead of misreporting a correct token (#36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Breaking
+
+- **`tokens:validate-output` fails on two source paths that reduce to one symbol
+  name.** `color.bg.canvas` and `colorBg.canvas` both normalize to
+  `colorbgcanvas`, and the second silently overwrote the first — so the loser was
+  never checked, and every emitted symbol on that key was compared against
+  whichever path happened to sort last. Both directions measured: with only the
+  winner's symbol in the output the run was **green with a token unverified**;
+  with both symbols present it reported a **`unit-fidelity` failure naming a
+  token that was correct**, which is worse, because a confident wrong diagnosis
+  sends you to the wrong file.
+
+  This gates rather than advises because it is not only a matching problem.
+  Style Dictionary does not dedupe the two paths: the build emits
+  `val colorBgCanvas` **twice**, and `kotlinc` rejects the file with "conflicting
+  declarations". The source is ambiguous for native output and the generated file
+  is broken. Rename either side in source.
+
+  A build with no such collision is unaffected, which is every build we can
+  measure — the real 322-token system this is validated against has none, an
+  assumption the original spec accepted on fixture evidence and that is now
+  checked on every run.
+
+### Fixed
+
+- **The "naming convention does not line up" diagnosis no longer fires when a
+  collision is the real cause.** Excluded tokens can drop the match count to
+  zero, and the old message confidently blamed the adapter. It now names the
+  collisions instead.
+
 ## [0.18.0] — 2026-08-31
 
 ### Breaking

--- a/docs/superpowers/notes/2026-08-31-normalize-key-collision-e2e.md
+++ b/docs/superpowers/notes/2026-08-31-normalize-key-collision-e2e.md
@@ -1,0 +1,98 @@
+# normalizeKey collisions (#36) — measured through the real pipeline
+
+**Date:** 2026-08-31
+**Gate for:** the #36 fix — detecting source paths that reduce to one symbol name.
+**Verdict:** PASS, and the defect is worse than the issue recorded: the emitted
+Kotlin **does not compile**, which no one had checked.
+
+## Why this run exists
+
+#36 describes a validator blind spot: two source paths normalizing to one key,
+the later silently overwriting the earlier. It was accepted as a deferred minor
+on fixture evidence. Nobody had put the colliding source through Style
+Dictionary to see what the build actually emits.
+
+## Harness
+
+Same rebuilt harness as the #85 run — Style Dictionary 4.4.0,
+`build.mjs` (top-level + platform wiring), module installed by copy as
+`lib/{dtcg,native-literal,sd-native}.mjs`. Fixture is the issue's own pair:
+
+```json
+{ "color":   { "bg": { "canvas": { "$value": "4px", "$type": "dimension" } } },
+  "colorBg": {        "canvas": { "$value": "9px", "$type": "dimension" } } }
+```
+
+## Finding 1 — the build emits the same name twice
+
+```
+$ node build.mjs tok-36 out-36
+$ grep 'val ' out-36/Tokens.kt
+  val colorBgCanvas = 4.00.dp
+  val colorBgCanvas = 9.00.dp
+```
+
+Style Dictionary does not dedupe these: the two paths are distinct, and both
+camel-join to `colorBgCanvas`.
+
+## Finding 2 — it does not compile, and the issue never said so
+
+```
+$ node ci/compile-native-output.mjs out-36 --allow-missing
+  [FAIL] kotlin: out-36/Tokens.kt:13:7: error: conflicting declarations:
+                 out-36/Tokens.kt:14:7: error: conflicting declarations:
+  [PASS] swift: parsed only
+```
+
+This is what settles the design question. #36 reads as a matching problem, which
+would argue for an advisory. It is not: the source is genuinely ambiguous for
+native output and the generated file is broken. So the fix **gates**.
+
+## Finding 3 — both failure directions, measured on `a349453`
+
+| output contains | main (0.17.0/0.18.0) | with the fix |
+|---|---|---|
+| both symbols | `ok: false` — but a **`unit-fidelity` failure naming `colorBgCanvas`**, comparing it against `colorBg.canvas` (9px) when `4.00.dp` is correct for `color.bg.canvas`. `matched: 2` | `ok: false`, collision named, `matched: 0`, no false failure |
+| only the winner's symbol | **`ok: true`, `matched: 1`, zero failures** — a green run with `color.bg.canvas` never checked | `ok: false`, collision named |
+
+The second row is the silent one the issue was filed for. The first is worse in
+a way the issue did not record: a **confident wrong diagnosis**, sending the
+author to a token that is correct.
+
+## Design decision, and what it cost
+
+Collided keys are left **out of `byKey`** entirely. A symbol on an ambiguous key
+then matches nothing, falls through before any source comparison, and is not
+counted in `matched` — which is the truth, since it did not match a determinate
+token. That removes the false `unit-fidelity` failure with no special case in
+the matching loop. The literal, foreign-syntax and bare-unit rules still run on
+it, because none of them reads the source.
+
+One report-quality consequence, fixed: with the collided tokens excluded, a small
+source can drop to `matched: 0`, which used to print *"the adapter's naming
+convention does not line up"*. That is a confident wrong cause. The message is
+now collision-aware and points at the collisions instead.
+
+## Regression control
+
+Real zygarden source, light+mobile pin, against the #85 build output:
+
+```
+tokens:validate-output — 208/208 emitted symbols matched a source token (100%)
+10 advisory note(s)
+3 source token(s) had no matching emitted symbol
+```
+
+Unchanged, and **zero collisions** — which is what Spec Decision 4 assumed and
+is now checked rather than assumed.
+
+## Reproduce
+
+```
+$ cd <harness>
+$ node build.mjs tok-36 out-36
+$ node ci/compile-native-output.mjs out-36 --allow-missing        # kotlin FAIL
+$ node <repo>/scripts/validate-token-output.mjs \
+    --source tok-36/collide.json --output out-36/Tokens.kt \
+    --platform android-kotlin --min-match 1
+```

--- a/scripts/validate-token-output.mjs
+++ b/scripts/validate-token-output.mjs
@@ -68,6 +68,34 @@ export function normalizeKey(s) {
   return String(s).toLowerCase().replace(/[^a-z0-9]/g, '');
 }
 
+// Two source paths that normalize to one key, e.g. color.bg.canvas and
+// colorBg.canvas -> colorbgcanvas. Same map-and-compare shape as
+// findModeCollisions, keyed on the normalized form instead of the raw path.
+//
+// This is not only a matching problem, which is why it gates rather than
+// advises. Measured through Style Dictionary on that exact pair: the build
+// emits `val colorBgCanvas` TWICE and kotlinc rejects the file with
+// "conflicting declarations". The source is ambiguous for native output, and
+// the emitted file does not compile.
+//
+// Before this, the second path silently overwrote the first in byKey, with a
+// consequence in each direction: the loser was never checked at all, and every
+// emitted symbol sharing the key was compared against whichever path happened
+// to sort last — which reported a unit-fidelity failure naming a token that was
+// correct. A wrong diagnosis is worse than none, because it sends the author to
+// the wrong file.
+export function findNormalizationCollisions(paths) {
+  const byKey = new Map();
+  for (const path of paths) {
+    const key = normalizeKey(path);
+    if (!byKey.has(key)) byKey.set(key, []);
+    byKey.get(key).push(path);
+  }
+  return [...byKey]
+    .filter(([, ps]) => ps.length > 1)
+    .map(([key, ps]) => ({ key, paths: ps }));
+}
+
 const UNIT = /^(-?(?:\d+(?:\.\d+)?|\.\d+))([a-z%]*)$/;
 
 // Expected native magnitude for an authored source value. iOS points and Android
@@ -151,8 +179,20 @@ export function validate({ sources, output, platform, minMatch = 0.5 }) {
   const types = {};
   for (const { dtcg } of sources) Object.assign(types, flattenDtcgTypes(dtcg));
 
+  // Collided keys are deliberately LEFT OUT of byKey. A symbol whose key is
+  // ambiguous then matches nothing, so it falls through to `continue` before any
+  // source comparison and is not counted as matched — which is the truth: it did
+  // not match a determinate token. That removes the false unit-fidelity failure
+  // without a special case in the loop below. The literal, foreign-syntax and
+  // bare-unit rules still run on it, because none of them reads the source.
+  const normalizationCollisions = findNormalizationCollisions(Object.keys(flat));
+  const collided = new Set(normalizationCollisions.map((c) => c.key));
+
   const byKey = new Map();
-  for (const path of Object.keys(flat)) byKey.set(normalizeKey(path), path);
+  for (const path of Object.keys(flat)) {
+    const key = normalizeKey(path);
+    if (!collided.has(key)) byKey.set(key, path);
+  }
 
   const decls = extractDeclarations(output, platform);
   const failures = [];
@@ -236,14 +276,19 @@ export function validate({ sources, output, platform, minMatch = 0.5 }) {
   }
 
   const matchRate = decls.length ? matched / decls.length : 0;
-  const ok = failures.length === 0 && collisions.length === 0 && matched > 0 && matchRate >= minMatch;
+  const ok =
+    failures.length === 0 &&
+    collisions.length === 0 &&
+    normalizationCollisions.length === 0 &&
+    matched > 0 &&
+    matchRate >= minMatch;
 
   const unparsedLines = countUnparsedLines(output, DECL[platform]);
   const emittedKeys = new Set(decls.map((d) => normalizeKey(d.symbol)));
   let unemittedTokens = 0;
   for (const key of byKey.keys()) if (!emittedKeys.has(key)) unemittedTokens += 1;
 
-  return { total: decls.length, matched, matchRate, failures, advisories, collisions, minMatch, ok, unparsedLines, unemittedTokens };
+  return { total: decls.length, matched, matchRate, failures, advisories, collisions, normalizationCollisions, minMatch, ok, unparsedLines, unemittedTokens };
 }
 
 export function formatReport(r) {
@@ -255,6 +300,17 @@ export function formatReport(r) {
     for (const c of r.collisions) {
       lines.push(`  - ${c.path}: ${c.defs.map((d) => `${d.file}=${JSON.stringify(d.value)}`).join(', ')}`);
     }
+  }
+  if (r.normalizationCollisions?.length) {
+    lines.push(
+      `\n${r.normalizationCollisions.length} name collision(s) — distinct source paths that reduce to one symbol name:`,
+    );
+    for (const c of r.normalizationCollisions) {
+      lines.push(`  - ${c.key}: ${c.paths.join(' vs ')}`);
+    }
+    lines.push(
+      `\nThese emit the same symbol name, so the generated file declares it more than once and will not compile. They are also excluded from matching above, because there is no way to tell which source token an emitted symbol came from. Rename one side in source.`,
+    );
   }
   if (r.failures.length) {
     lines.push(`\n${r.failures.length} rule failure(s):`);
@@ -275,10 +331,20 @@ export function formatReport(r) {
       );
     }
   }
+  // The naming-convention diagnosis is wrong when collisions are what removed
+  // the tokens, and a confident wrong cause sends the author to the wrong file.
+  // Name the collisions instead, and only then fall back to the convention.
+  const collisionNote = r.normalizationCollisions?.length
+    ? ` The ${r.normalizationCollisions.length} name collision(s) above were excluded from matching, which may be the whole of it — resolve those first.`
+    : '';
   if (r.matched === 0) {
-    lines.push(`\nNo emitted symbol matched any source token — the adapter's naming convention does not line up, so nothing was actually verified. A likely cause is a declaration form the DECL pattern does not match (e.g. a different accessControl such as "internal static let ...").`);
+    lines.push(
+      r.normalizationCollisions?.length
+        ? `\nNo emitted symbol matched any source token, so nothing was actually verified.${collisionNote}`
+        : `\nNo emitted symbol matched any source token — the adapter's naming convention does not line up, so nothing was actually verified. A likely cause is a declaration form the DECL pattern does not match (e.g. a different accessControl such as "internal static let ...").`,
+    );
   } else if (r.matchRate < r.minMatch) {
-    lines.push(`\nMatch rate ${pct}% is below the ${(r.minMatch * 100).toFixed(0)}% floor — most output went unchecked.`);
+    lines.push(`\nMatch rate ${pct}% is below the ${(r.minMatch * 100).toFixed(0)}% floor — most output went unchecked.${collisionNote}`);
   }
   if (r.unparsedLines) {
     lines.push(`\n${r.unparsedLines} unparsed line(s) — declaration-shaped lines the extractor could not read; they count in neither the numerator nor the denominator above.`);

--- a/scripts/validate-token-output.test.mjs
+++ b/scripts/validate-token-output.test.mjs
@@ -88,7 +88,7 @@ test('magnitudeOf returns null for non-dimension values', () => {
   assert.equal(magnitudeOf('24px'), null);
 });
 
-import { normalizeKey, expectedMagnitude, findModeCollisions, validate } from './validate-token-output.mjs';
+import { normalizeKey, expectedMagnitude, findModeCollisions, findNormalizationCollisions, validate } from './validate-token-output.mjs';
 
 test('normalizeKey collapses camelCase, snake_case, kebab-case, and dot paths', () => {
   assert.equal(normalizeKey('color.bg.canvas'), 'colorbgcanvas');
@@ -107,6 +107,100 @@ test('expectedMagnitude skips units with no native equivalent', () => {
   assert.ok(expectedMagnitude('100%').skip);
   assert.ok(expectedMagnitude('-0.03em').skip);
   assert.ok(expectedMagnitude('#ffffff').skip);
+});
+
+// #36. Two distinct source paths reducing to one symbol name is not merely a
+// matching problem. Measured through Style Dictionary on this exact pair: the
+// build emits `val colorBgCanvas` twice and kotlinc rejects the file with
+// "conflicting declarations". Before this, the second path silently overwrote
+// the first, so the loser went unchecked AND every symbol on that key was
+// compared against whichever path sorted last — which reported a unit-fidelity
+// failure naming a token that was correct.
+const COLLIDING = [
+  {
+    file: 'a',
+    dtcg: {
+      color: { bg: { canvas: { $value: '4px', $type: 'dimension' } } },
+      colorBg: { canvas: { $value: '9px', $type: 'dimension' } },
+    },
+  },
+];
+
+test('findNormalizationCollisions groups paths that reduce to one key', () => {
+  const c = findNormalizationCollisions(['color.bg.canvas', 'colorBg.canvas', 'space.md']);
+  assert.equal(c.length, 1);
+  assert.equal(c[0].key, 'colorbgcanvas');
+  assert.deepEqual(c[0].paths, ['color.bg.canvas', 'colorBg.canvas']);
+});
+
+test('findNormalizationCollisions is quiet on paths that stay distinct', () => {
+  assert.deepEqual(findNormalizationCollisions(['color.bg.canvas', 'color.bg.raised']), []);
+});
+
+test('a name collision fails the run instead of misreporting a correct token', () => {
+  const r = validate({
+    sources: COLLIDING,
+    output: 'object Tokens {\n  val colorBgCanvas = 4.00.dp\n  val colorBgCanvas = 9.00.dp\n}\n',
+    platform: 'android-kotlin',
+    minMatch: 0,
+  });
+  assert.equal(r.ok, false, 'the emitted file declares one name twice and will not compile');
+  assert.equal(r.normalizationCollisions.length, 1);
+  assert.deepEqual(r.normalizationCollisions[0].paths, ['color.bg.canvas', 'colorBg.canvas']);
+  assert.deepEqual(
+    r.failures.filter((f) => f.rule === 'unit-fidelity'),
+    [],
+    'the old code reported unit-fidelity here, naming color.bg.canvas, which is correct at 4px',
+  );
+  assert.equal(r.matched, 0, 'an ambiguous key matches no determinate token');
+});
+
+// The silent direction, and the one the issue was filed for. When the output
+// carries only the winner's symbol, main matched it, checked it, passed, and
+// never looked at color.bg.canvas at all — a green run with a token unverified.
+// Measured on a349453: ok true, matched 1, zero failures.
+test('a collision is not a green run with one token quietly unchecked', () => {
+  const r = validate({
+    sources: COLLIDING,
+    output: 'object Tokens {\n  val colorBgCanvas = 9.00.dp\n}\n',
+    platform: 'android-kotlin',
+    minMatch: 0,
+  });
+  assert.equal(r.ok, false, 'was true before #36, with color.bg.canvas never checked');
+  assert.equal(r.failures.length, 0, 'the collision is the finding, not a rule failure');
+  assert.equal(r.normalizationCollisions.length, 1);
+});
+
+test('the collision report does not blame the naming convention', () => {
+  const r = validate({
+    sources: COLLIDING,
+    output: 'object Tokens {\n  val colorBgCanvas = 4.00.dp\n}\n',
+    platform: 'android-kotlin',
+    minMatch: 0,
+  });
+  const text = formatReport(r).join('\n');
+  assert.match(text, /name collision/);
+  assert.doesNotMatch(text, /naming convention does not line up/);
+});
+
+test('a collision does not disturb the tokens around it', () => {
+  const r = validate({
+    sources: [
+      {
+        file: 'a',
+        dtcg: {
+          color: { bg: { canvas: { $value: '4px', $type: 'dimension' } } },
+          colorBg: { canvas: { $value: '9px', $type: 'dimension' } },
+          space: { md: { $value: '8px', $type: 'dimension' } },
+        },
+      },
+    ],
+    output: 'object Tokens {\n  val colorBgCanvas = 4.00.dp\n  val spaceMd = 8.00.dp\n}\n',
+    platform: 'android-kotlin',
+    minMatch: 0,
+  });
+  assert.equal(r.matched, 1, 'space.md still matches and is still checked');
+  assert.equal(r.normalizationCollisions.length, 1);
 });
 
 test('findModeCollisions flags a path defined twice with different values', () => {


### PR DESCRIPTION
Closes #36.

Two source paths reducing to one normalized key — `color.bg.canvas` and `colorBg.canvas` both give `colorbgcanvas` — meant the second silently overwrote the first in `byKey`.

## Both directions, measured on `a349453`

| output contains | before | after |
|---|---|---|
| only the winner's symbol | **`ok: true`, matched 1, 0 failures** — green, with `color.bg.canvas` never checked | `ok: false`, collision named |
| both symbols | `ok: false`, but a **`unit-fidelity` failure naming `colorBgCanvas`**, compared against `colorBg.canvas` (9px) when `4.00.dp` is correct for `color.bg.canvas`. matched 2 | `ok: false`, collision named, matched 0, no false failure |

The first row is the silent direction the issue was filed for. The second the issue did not record, and it is worse — a confident wrong diagnosis sends you to a token that is correct.

## Why it gates rather than advises

The issue reads as a matching problem, which would argue for an advisory. Putting the fixture through Style Dictionary shows it is not:

```
$ grep 'val ' out-36/Tokens.kt
  val colorBgCanvas = 4.00.dp
  val colorBgCanvas = 9.00.dp

$ node ci/compile-native-output.mjs out-36 --allow-missing
  [FAIL] kotlin: Tokens.kt:13:7: error: conflicting declarations:
                 Tokens.kt:14:7: error: conflicting declarations:
```

The two paths do not dedupe, the source is ambiguous for native output, and **the generated file does not compile**. Nobody had checked that.

## Design choice worth naming

Collided keys are left **out of `byKey`** entirely, so a symbol on an ambiguous key matches nothing, falls through before any source comparison, and is not counted in `matched` — the truth, since it matched no determinate token. That removes the false `unit-fidelity` failure with no special case in the matching loop. The literal, foreign-syntax and bare-unit rules still run on it, because none reads the source.

## Also fixed while here

Excluding collided tokens can drop a small source to `matched: 0`, which used to print *"the adapter's naming convention does not line up"* — a confident wrong cause, the same shape as the defect being fixed. The message is now collision-aware.

## Regression control

Real zygarden, light+mobile pin: unchanged at **208/208, zero collisions**. That is the assumption Spec Decision 4 accepted on fixture evidence, now checked on every run rather than assumed.

Full run: `docs/superpowers/notes/2026-08-31-normalize-key-collision-e2e.md`.

## Tests

459 pass, 6 new. They cannot run against `main` at all (the new export does not exist there), so both behavioural directions were verified by calling `validate()` directly against `main` — figures in the table above and in the e2e note.