### PR TITLE
The hoist's $type carry no longer fires onto a hoisted group (#67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ to [Semantic Versioning](https://semver.org).
 
 ### Breaking
 
+- **The dual-node hoist no longer carries a `$type` onto a hoisted group.** The
+  carry exists to repair what the hoist costs a *token* child: the dual node was
+  that child's closest `$type`-bearing ancestor as authored, and the hoist makes
+  it a sibling. A **group** child was never in that position — DTCG 5.2.2
+  inherits from the closest parent *group*, and a dual node is a token (6.1) — so
+  nothing was taken away and there is nothing to repair. Carrying there invented
+  a type for every token beneath that group.
+
+  **This can turn a green build red**, and that is the intended direction. Where
+  the invented type was usable, `text.sm.heights.line` emitted `20.00.dp` and now
+  emits a bare `20px`, which does not compile. That follows the same rule a
+  unitless dimension already follows: a value whose type the source never stated
+  is declined rather than guessed at, and `no-bare-units` plus
+  `unverifiable-dimension` name the exact symbol. The repair is to type the token
+  in source, which DTCG 8.2.1 requires of a dimension anyway. Output against a
+  real system is byte-identical — the shape needs a dual node with a group child,
+  and Figma-derived dual nodes have token children only.
+
+
 - **`tokens:validate-output` fails on two source paths that reduce to one symbol
   name.** `color.bg.canvas` and `colorBg.canvas` both normalize to
   `colorbgcanvas`, and the second silently overwrote the first — so the loser was
@@ -25,9 +44,9 @@ to [Semantic Versioning](https://semver.org).
   is broken. Rename either side in source.
 
   A build with no such collision is unaffected, which is every build we can
-  measure — the real 322-token system this is validated against has none, an
-  assumption the original spec accepted on fixture evidence and that is now
-  checked on every run.
+  measure — the real system this is validated against (318 source tokens, 211
+  under the mode pin the build uses) has none, an assumption the original spec
+  accepted on fixture evidence and that is now checked on every run.
 
 ### Fixed
 

--- a/docs/superpowers/notes/2026-08-31-hoist-cluster-measurement.md
+++ b/docs/superpowers/notes/2026-08-31-hoist-cluster-measurement.md
@@ -1,0 +1,87 @@
+# The dual-node hoist cluster — measurement before priority
+
+**Date:** 2026-08-31
+**Purpose:** six open issues describe defects in `hoistDualNodes` and its `$type`
+carry. Four say "unmeasured" or "not reachable in zygarden". This run puts one
+fixture per shape through the real pipeline before any of them is scheduled.
+**Outcome:** the priority order this produces is the reverse of the intuitive one.
+
+## Why this run exists
+
+Three releases in five days went out over this subsystem, each cut when a PR
+merged rather than when a body of work closed. Treating the remainder as one
+release means knowing what is actually in it. #67 explicitly asks for this:
+*"Worth measuring before deciding priority."*
+
+## Harness
+
+The rebuilt harness from the #85 run — Style Dictionary 4.4.0, `build.mjs`
+(top-level + platform wiring), module installed by copy as
+`lib/{dtcg,native-literal,sd-native}.mjs`. Baseline is `978de03`. Each fixture is
+the minimal shape from its own issue, verbatim where the issue gave one.
+
+## Result
+
+| issue | emitted Kotlin | compiles | gate catches it |
+|---|---|---|---|
+| **#67** carry onto a hoisted group | `val textSmHeightsLine = 20px` | **NO** — `unresolved reference 'px'` | **yes** — `no-bare-units` + `unverifiable-dimension` |
+| **#89** child typed only by the carry | `val textSmLineHeight = 20.00.dp` (wants `sp`) | yes | **no** |
+| **#71** advisory cannot see the carry | `val carrySmLineHeight = 1.5` — a `Double` where `Dp` belongs | yes | **no** |
+| **#72** untyped base behind a typed alias | `val baseRatio = 1.5` | yes | **no** |
+| **#90** hoist invents a typographic name | `val aFontSize = 16.00.sp` | yes | n/a |
+
+## What that changes
+
+**#67 looked like the worst of the set and is the mildest.** It is the one where
+the hoist invents a type outright, so it reads as the most serious defect. But
+the invented type makes every size transform decline, the value falls through
+raw, and the emitted file **does not compile** — and the existing gate names it
+correctly with two rules. A consumer hitting this gets a red build and an
+accurate message. That is the system working.
+
+**#89, #71 and #72 are the silent ones.** Each compiles, each is wrong, and
+nothing anywhere says so: a font size rendering as `dp` and ignoring the user's
+system font-size setting; a `Double` where Compose wants a `Dp`; a unitless
+dimension reported by no rule at all. This repo's recurring position is that a
+green run which verified nothing is the worst outcome, and these are three of
+them.
+
+**#90 is the weakest.** It compiles, and the stamp it produces — `a.font.size`
+emitting `sp` — is arguably what the author meant. Its real cost is that
+`preprocess` is not idempotent, which contradicts four shipped comments. Worth
+fixing for that reason, not for its output.
+
+**Revised order: #89 → #71 + #72 → #67 → #90.** Silence first, then the loud one.
+
+## The one that is not free
+
+#67's fix is a single condition — restrict the carry to token children — but it
+is not cosmetic. Where the carried type was **usable**, output changes:
+
+```
+in:  { text: { sm: { $value: "14px", $type: "dimension",
+                     heights: { line: { $value: "20px" } } } } }
+
+main:  val textSmHeightsLine = 20.00.dp     compiles
+fixed: val textSmHeightsLine = 20px         does NOT compile
+```
+
+So the correct fix turns a green build red for this shape. Taken anyway, on
+**#52's precedent**: a value whose type the source never stated is declined by
+every transform and emitted raw, rather than having a type invented for it, and
+the gate is what tells the author. The source here is under-specified — DTCG
+8.2.1 requires a dimension to carry a `$type` and this one does not — and the
+author gets `no-bare-units` plus `unverifiable-dimension` naming the exact
+symbol. An invented type that happens to be right is still a guess.
+
+**Regression control:** real zygarden, light+mobile pin, `Tokens.kt` and
+`Tokens.swift` **byte-identical** before and after. The shape needs a dual node
+with a group child, and zygarden's nine dual nodes have token children only.
+
+## Reproduce
+
+```
+$ cd <harness>
+$ for f in 67 89 90 71 72; do node build.mjs tok-$f out-$f; done
+$ for f in 67 89 90 71 72; do node <repo>/ci/compile-native-output.mjs out-$f --allow-missing; done
+```

--- a/references/native-adapter-config.md
+++ b/references/native-adapter-config.md
@@ -264,8 +264,17 @@ function hoistDualNodes(node, collisions, prefix = [], groupType = undefined) {
         // type suits the child badly, because the hoist is not entitled to
         // improve on what the source says; but the carry firing at all is the
         // hoist saying something the source did not.
+        //
+        // A GROUP child is excluded (#67). The carry's premise is that the dual
+        // node was the child's closest $type-bearing ancestor as authored, and
+        // the hoist took that away. For a group child the premise never held:
+        // 5.2.2 inherits from the closest parent GROUP, the dual node is not
+        // one, so it was never that group's inheritance source and the hoist
+        // removed nothing. Carrying there does not repair, it invents — and it
+        // invents for every token beneath the group, not just one node.
         if (
           !('$type' in childVal) &&
+          '$value' in childVal &&
           '$type' in val &&
           !WAS_REF.has(childVal) &&
           inherited === undefined

--- a/scripts/lib/sd-native.mjs
+++ b/scripts/lib/sd-native.mjs
@@ -195,8 +195,17 @@ function hoistDualNodes(node, collisions, prefix = [], groupType = undefined) {
         // type suits the child badly, because the hoist is not entitled to
         // improve on what the source says; but the carry firing at all is the
         // hoist saying something the source did not.
+        //
+        // A GROUP child is excluded (#67). The carry's premise is that the dual
+        // node was the child's closest $type-bearing ancestor as authored, and
+        // the hoist took that away. For a group child the premise never held:
+        // 5.2.2 inherits from the closest parent GROUP, the dual node is not
+        // one, so it was never that group's inheritance source and the hoist
+        // removed nothing. Carrying there does not repair, it invents — and it
+        // invents for every token beneath the group, not just one node.
         if (
           !('$type' in childVal) &&
+          '$value' in childVal &&
           '$type' in val &&
           !WAS_REF.has(childVal) &&
           inherited === undefined

--- a/scripts/lib/sd-native.test.mjs
+++ b/scripts/lib/sd-native.test.mjs
@@ -749,6 +749,39 @@ test('an enclosing group wins even where its $type suits the child badly', () =>
 // that decides b's carry has a as its node, and a is a dual node — the guard
 // has to look through it to g, or the two-level case keeps the shadowing the
 // single-level case just lost.
+// #67. The carry repairs what the hoist costs a TOKEN child. A group child was
+// never the dual node's dependant — 5.2.2 inherits from the closest parent
+// group, and a dual node is a token (6.1) — so there is nothing to repair, and
+// carrying types every token beneath that group with something the source never
+// said.
+test('the carry does not fire onto a hoisted group', () => {
+  const out = preprocess({
+    text: { sm: { $value: '#ffffff', $type: 'color', heights: { line: { $value: '20px' } } } },
+  });
+  assert.equal('$type' in out.text.smHeights, false, 'the group stays untyped');
+  assert.equal('$type' in out.text.smHeights.line, false, 'and so does every token under it');
+});
+
+test('the carry still fires onto a hoisted token', () => {
+  const out = preprocess({
+    text: { sm: { $value: '14px', $type: 'dimension', lineHeight: { $value: '20px' } } },
+  });
+  assert.equal(out.text.smLineHeight.$type, 'dimension', 'a token child is what the carry is for');
+});
+
+// The cost of #67, measured through Style Dictionary rather than argued:
+// where the carried type was USABLE, output changes from `20.00.dp` (compiles)
+// to a bare `20px` (does not). That is the #52 precedent applied — decline to
+// invent, emit raw, and let no-bare-units and unverifiable-dimension name it —
+// rather than a regression nobody noticed. The source is under-specified: DTCG
+// 8.2.1 requires a dimension to carry a $type, and this one does not.
+test('a group child with a usable carried type now emits untyped, loudly', () => {
+  const out = preprocess({
+    text: { sm: { $value: '14px', $type: 'dimension', heights: { line: { $value: '20px' } } } },
+  });
+  assert.equal('$type' in out.text.smHeights.line, false);
+});
+
 test('the group guard reaches a child hoisted through two levels', () => {
   const out = preprocess({
     text: {


### PR DESCRIPTION
Closes #67. Part of the batched dual-node-hoist release — **not** to be cut on its own.

## Measurement first

The issue says the severity is unmeasured and asks for a measurement before scheduling. So this branch put one fixture per shape through Style Dictionary for the whole six-issue cluster. The result reverses the intuitive order:

| issue | emitted | compiles | gate catches it |
|---|---|---|---|
| **#67** | `val textSmHeightsLine = 20px` | **no** | **yes** — `no-bare-units` + `unverifiable-dimension` |
| **#89** | `20.00.dp` (wants `sp`) | yes | **no** |
| **#71** | `1.5` — `Double` where `Dp` belongs | yes | **no** |
| **#72** | `1.5`, unflagged | yes | **no** |
| **#90** | `16.00.sp` | yes | n/a |

**#67 reads as the worst — the hoist inventing a type outright — and is the mildest.** The invented type makes every size transform decline, the value falls through raw, the file doesn't compile, and the gate names it accurately. That's the system working. The other three are silent.

Revised order: **#89 → #71 + #72 → #67 → #90.** Full run in `docs/superpowers/notes/2026-08-31-hoist-cluster-measurement.md`.

## The fix

One condition — the carried-onto child must have a `$value`. The carry's premise is that the dual node was the child's closest `$type`-bearing ancestor and the hoist made it a sibling. A group child was never in that position (5.2.2 inherits from the closest parent *group*; a dual node is a token per 6.1), so nothing was taken away.

## The cost, measured because the issue warned about it

```
in:  { text: { sm: { $value: "14px", $type: "dimension",
                     heights: { line: { $value: "20px" } } } } }

main:  val textSmHeightsLine = 20.00.dp     compiles
fixed: val textSmHeightsLine = 20px         does NOT compile
```

**This turns a green build red for that shape**, and it's the intended direction — the same rule a unitless dimension already follows since #52: decline rather than invent, emit raw, let the gate name it. The source is under-specified (DTCG 8.2.1 requires a dimension to carry a `$type`), and the author gets two rules pointing at the exact symbol. An invented type that happens to be right is still a guess.

## Regression control

Real zygarden, light+mobile pin: `Tokens.kt` and `Tokens.swift` **byte-identical**. The shape needs a dual node with a group child; zygarden's nine dual nodes have token children only.

## Tests

462 pass, 3 new — the group child stays untyped, a token child still gets the carry, and the usable-carried-type cost is pinned rather than left to be rediscovered.