### PR TITLE
The advisory's type resolution catches up with the pipeline's (#71, #72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- **`unitless-dimension` now sees the hoist's `$type` carry.** A unitless,
+  untyped child of a dimension-typed dual node was a `dimension` to the build and
+  a nothing to the gate, so it emitted a bare `1.5` — a `Double` where Compose
+  wants a `Dp` — and passed every rule clean. That is the silent case this rule
+  most exists to catch. The gate still reads the **raw source**, which is the
+  property that made this hard to fix: it models the carry rather than running
+  against a preprocessed tree, so it continues to check emitted output against
+  what the author actually wrote.
+- **A unitless base token behind a typed alias is reported again.** Skipping any
+  whole-value reference stopped the advisory double-firing, which is right when
+  the base carries its own `$type`. Where it does not, the base never fired
+  (untyped) and the alias was skipped (a reference), so a genuine unitless
+  dimension was reported **nowhere**. The skip is now conditional on the referent
+  being dimension-typed in its own right, and the advisory names the referent —
+  the token whose `$type` or unit you actually have to change — rather than the
+  alias, whose value is a reference with no unit to add.
 - **A line height typed only by the hoist's `$type` carry now emits `sp`.** A
   dual node is a token, not a group, so DTCG gives an untyped child of one no
   type at all; the hoist stamps the dual node's type onto it as a repair for the

--- a/docs/superpowers/notes/2026-08-31-hoist-cluster-measurement.md
+++ b/docs/superpowers/notes/2026-08-31-hoist-cluster-measurement.md
@@ -110,6 +110,29 @@ That is also why the map must be built on the **raw** dict: the carry's last
 condition asks whether a value *was* a whole-value reference, and `resolveInPlace`
 has already rewritten it to a literal by the time the resolved clone exists.
 
+### #71 + #72 — the advisory's type resolution
+
+Both fire, both attributed to the token that needs changing:
+
+```
+#71  [unitless-dimension] carrySmLineHeight: source "1.5" for carry.sm.lineHeight ...
+#72  [unitless-dimension] aliasRatio:        source "1.5" for base.ratio ...
+```
+
+Note #72's attribution: the **symbol** is `aliasRatio`, the **token named** is
+`base.ratio`. The alias's own value is a reference with no unit to add, so
+telling the author to "add the unit you meant" about the alias was advice they
+could not act on.
+
+**#71's stated obstacle turned out to be a false choice.** The issue said fixing
+it meant running the gate against the preprocessed tree, and rejected that
+because the gate would stop checking output against what the author wrote.
+`flattenPipelineTypes` is a third option: read the raw source and *model* the
+carry rather than applying it. The property the issue was protecting is intact.
+
+**Regression control:** zygarden unchanged at 208/208, 10 advisories, 5 of them
+`unitless-dimension` — identical to before.
+
 ## Reproduce
 
 ```

--- a/scripts/validate-token-output.mjs
+++ b/scripts/validate-token-output.mjs
@@ -10,6 +10,7 @@ import { pathToFileURL } from 'node:url';
 import {
   flattenDtcg,
   flattenDtcgTypes,
+  flattenPipelineTypes,
   resolveValue,
   findModeCollisions,
   textRoleGraph,
@@ -145,6 +146,18 @@ const DIMENSIONAL = new Set(['dimension', 'fontSize']);
 // alone would flag both the alias and its referent for the same problem.
 const WHOLE_REF = /^\{[^}]+\}$/;
 
+// Follow whole-value references to the token an advisory's fix belongs on.
+// Stops at the first path that is not a whole-value reference, at an
+// unresolvable one, and on a cycle — this reports, so it must never throw.
+function referentOf(path, flat, seen = new Set()) {
+  const raw = String(flat[path] ?? '').trim();
+  if (!WHOLE_REF.test(raw)) return path;
+  const next = raw.slice(1, -1);
+  if (seen.has(path) || !(next in flat)) return path;
+  seen.add(path);
+  return referentOf(next, flat, seen);
+}
+
 // Lines that are obviously not a would-be token declaration: braces-only,
 // comments, imports/package/annotations, or the container declarations
 // (enum/object/class) themselves. Anything else that DECL failed to match is
@@ -177,7 +190,18 @@ export function validate({ sources, output, platform, minMatch = 0.5 }) {
   for (const { dtcg } of sources) Object.assign(flat, flattenDtcg(dtcg));
 
   const types = {};
-  for (const { dtcg } of sources) Object.assign(types, flattenDtcgTypes(dtcg));
+  // The PIPELINE's types, not the spec's alone (#71). flattenDtcgTypes reads the
+  // raw source, where hoistDualNodes' $type carry has not run — so a unitless,
+  // untyped child of a dimension-typed dual node was a dimension to the build
+  // and a nothing to this gate, which is the silent case this rule most exists
+  // to catch.
+  //
+  // The issue framed the only fix as running this gate against the PREPROCESSED
+  // tree, and rejected it, because the gate would stop checking emitted output
+  // against what the author actually wrote. flattenPipelineTypes is a third
+  // option that keeps that property: it reads the raw source and MODELS the
+  // carry rather than applying it. The gate still reads what the author wrote.
+  for (const { dtcg } of sources) Object.assign(types, flattenPipelineTypes(dtcg));
 
   // Collided keys are deliberately LEFT OUT of byKey. A symbol whose key is
   // ambiguous then matches nothing, so it falls through to `continue` before any
@@ -237,12 +261,22 @@ export function validate({ sources, output, platform, minMatch = 0.5 }) {
     // Advisory, not a failure: the emitted value is correct under the ratio
     // reading this build applies, so it compiles and its magnitude matches.
     // What is wrong is the SOURCE's $type, which only the author can settle.
+    //
+    // An alias is skipped only when its REFERENT is itself dimension-typed, so
+    // the referent's own symbol reports it — that is #69's de-duplication, kept.
+    // A blanket skip on any whole-value reference (#72) meant an untyped base
+    // behind a typed alias was reported nowhere: the base is not dimension-typed
+    // so it never fires, and the alias was skipped for being a reference. The
+    // advisory is attributed to the referent either way, because that is the
+    // token whose $type or unit the author has to change.
+    const aliased = WHOLE_REF.test(String(flat[path]).trim());
+    const target = aliased ? referentOf(path, flat) : path;
     if (
       UNITLESS.test(String(source).trim()) &&
       DIMENSIONAL.has(types[path]) &&
-      !WHOLE_REF.test(String(flat[path]).trim())
+      !(aliased && DIMENSIONAL.has(types[target]))
     ) {
-      advisories.push({ rule: 'unitless-dimension', symbol, token: path, source, emitted: value });
+      advisories.push({ rule: 'unitless-dimension', symbol, token: target, source, emitted: value });
     }
 
     const expected = expectedMagnitude(source);

--- a/scripts/validate-token-output.test.mjs
+++ b/scripts/validate-token-output.test.mjs
@@ -298,19 +298,75 @@ test('unitless-dimension does not double-fire on a typed alias — only the refe
   assert.equal(r.advisories[0].token, 'spacing.space4');
 });
 
-// §6.2: flattenDtcgTypes reads the RAW source, where hoistDualNodes' $type
-// carry has not run yet. A unitless, untyped child of a dimension-typed dual
-// node with no enclosing group $type is flipped from N.dp to bare by the
-// size transforms (§5), but flattenDtcgTypes returns undefined for it here,
-// so DIMENSIONAL.has(undefined) is false and the advisory does not fire.
-// Recorded as a documented limit (spec §6.2), not desired behaviour — a
-// future fix should flip this test rather than go unnoticed.
-test('unitless-dimension misses the hoist carry — documented §6.2 limit', () => {
+// #71, and the §6.2 limit this test was left pinned to record. The gate read
+// the raw source, where hoistDualNodes' $type carry has not run — so a
+// unitless, untyped child of a dimension-typed dual node was a dimension to the
+// build and a nothing here. It emitted a bare 1.5, a Double where a Dp belongs,
+// and passed every rule clean.
+//
+// The issue framed the only fix as pointing the gate at the PREPROCESSED tree,
+// and rejected it: the gate would stop checking output against what the author
+// actually wrote. flattenPipelineTypes keeps that property — it reads the raw
+// source and MODELS the carry instead of applying it.
+test('unitless-dimension sees the hoist carry', () => {
   const sources = [{ file: 't.json', dtcg: {
     leading: { base: { $value: '16px', $type: 'dimension', normal: { $value: '1.5' } } },
   } }];
   const r = validate({ sources, output: 'static let leadingBaseNormal = 1.5', platform: 'ios-swift' });
-  assert.deepEqual(r.advisories, []);
+  assert.deepEqual(r.advisories.map((a) => a.token), ['leading.base.normal']);
+});
+
+// #72. #69 stopped the advisory double-firing by skipping any whole-value
+// reference, which is right when the base carries its own $type. Where it does
+// not, the base never fires (untyped) and the alias was skipped (a reference),
+// so a genuine unitless dimension was reported NOWHERE. The skip is now
+// conditional on the referent being dimension-typed in its own right.
+test('an untyped base behind a typed alias is reported, on the base', () => {
+  const sources = [{ file: 't.json', dtcg: {
+    base: { ratio: { $value: '1.5' } },
+    alias: { ratio: { $value: '{base.ratio}', $type: 'dimension' } },
+  } }];
+  const r = validate({ sources, output: 'static let aliasRatio = 1.5', platform: 'ios-swift' });
+  assert.deepEqual(
+    r.advisories.map((a) => a.token),
+    ['base.ratio'],
+    'attributed to the token whose $type the author has to change',
+  );
+});
+
+// #69's de-duplication, kept: where the referent IS dimension-typed it reports
+// on its own symbol, so the alias stays silent rather than doubling it.
+test('a typed base behind a typed alias is still reported only once', () => {
+  const sources = [{ file: 't.json', dtcg: {
+    base: { ratio: { $value: '1.5', $type: 'dimension' } },
+    alias: { ratio: { $value: '{base.ratio}', $type: 'dimension' } },
+  } }];
+  const r = validate({
+    sources,
+    output: 'static let aliasRatio = 1.5\nstatic let baseRatio = 1.5',
+    platform: 'ios-swift',
+  });
+  assert.deepEqual(r.advisories.map((a) => a.token), ['base.ratio']);
+});
+
+test('a reference chain is followed to the token that needs fixing', () => {
+  const sources = [{ file: 't.json', dtcg: {
+    base: { ratio: { $value: '1.5' } },
+    mid: { ratio: { $value: '{base.ratio}' } },
+    alias: { ratio: { $value: '{mid.ratio}', $type: 'dimension' } },
+  } }];
+  const r = validate({ sources, output: 'static let aliasRatio = 1.5', platform: 'ios-swift' });
+  assert.deepEqual(r.advisories.map((a) => a.token), ['base.ratio']);
+});
+
+test('a circular reference is survived rather than thrown on', () => {
+  const sources = [{ file: 't.json', dtcg: {
+    a: { x: { $value: '{b.y}', $type: 'dimension' } },
+    b: { y: { $value: '{a.x}' } },
+  } }];
+  assert.doesNotThrow(() =>
+    validate({ sources, output: 'static let aX = 1.5', platform: 'ios-swift' }),
+  );
 });
 
 test('formatReport renders the advisory and names the fix', () => {


### PR DESCRIPTION
Closes #71, closes #72. **Stacked on #94 (#89), which is stacked on #93 (#67)** — retarget before the parents merge. Part of the batched dual-node-hoist release.

Done together, as #72 asked. Both are the `unitless-dimension` advisory seeing less than the build does.

## #71 — the carry

A unitless, untyped child of a dimension-typed dual node is a `dimension` to the pipeline and a nothing to the gate. It emitted a bare `1.5` — a `Double` where Compose wants a `Dp` — and passed every rule clean.

**The issue's stated obstacle was a false choice.** It framed the fix as pointing the gate at the *preprocessed* tree, and rejected that because the gate would stop checking emitted output against what the author actually wrote — a real property worth keeping. `flattenPipelineTypes` reads the **raw source** and *models* the carry rather than applying it, so the property survives and the gate sees what the build sees.

It's the same map #89 gives classification, which is the point: two things that reason about types now read one resolution instead of two that drift.

## #72 — the alias

#69 stopped the advisory double-firing by skipping any whole-value reference. Right when the base carries its own `$type`; wrong when it doesn't — the base never fires (untyped), the alias was skipped (a reference), so a genuine unitless dimension was reported **nowhere**. The skip is now conditional on the referent being dimension-typed in its own right, keeping #69's de-duplication and closing the gap it opened.

**Attribution moved with it:**

```
[unitless-dimension] aliasRatio: source "1.5" for base.ratio ...
```

The symbol is `aliasRatio`; the token named is `base.ratio`. The alias's own value is a reference with no unit to add, so *"add the unit you meant"* about the alias was advice the author couldn't act on.

Reference chains are followed to the first non-reference path and stop on a cycle or unresolvable target — this reports, so it must never throw. Both tested.

## Verification

Both fire on their own issue fixtures with correct attribution. **Zygarden unchanged** at 208/208, 10 advisories, 5 of them `unitless-dimension` — identical to before.

## Tests

468 pass. The test #52 left pinned to record the §6.2 limit is **flipped**, which its own comment asked for: *"a future fix should flip this test rather than go unnoticed."*