### PR TITLE
The hoist's $type carry is modelled ahead of classification (#89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+
+- **A line height typed only by the hoist's `$type` carry now emits `sp`.** A
+  dual node is a token, not a group, so DTCG gives an untyped child of one no
+  type at all; the hoist stamps the dual node's type onto it as a repair for the
+  relationship the hoist itself destroys. That repair ran *after* classification,
+  which has to come first because the hoist consumes the leaf name classification
+  matches on — so `text.sm.lineHeight` emitted `20.00.dp`. It compiled, it
+  rendered at a fixed size that ignores the user's font-scale setting, and no
+  rule reported it. The carry is now computed ahead of the hoist from the raw
+  source, so classification reads the type the pipeline is going to apply rather
+  than the type the tree happens to hold at that moment. The ordering is
+  unchanged; only the visibility is. Output against a real system is
+  byte-identical — every dual-node child there carries its own `$type`.
+
 ### Breaking
 
 - **The dual-node hoist no longer carries a `$type` onto a hoisted group.** The

--- a/docs/superpowers/notes/2026-08-31-hoist-cluster-measurement.md
+++ b/docs/superpowers/notes/2026-08-31-hoist-cluster-measurement.md
@@ -78,6 +78,38 @@ symbol. An invented type that happens to be right is still a guess.
 `Tokens.swift` **byte-identical** before and after. The shape needs a dual node
 with a group child, and zygarden's nine dual nodes have token children only.
 
+## Results, appended as the cluster is fixed
+
+One document for the whole release rather than one note per PR — the point of
+batching this work is that the pieces are read together.
+
+### #67 — carry restricted to token children
+
+Output byte-identical on zygarden. On the usable-carried-type shape,
+`20.00.dp` → bare `20px`, which does not compile, by design (see above).
+
+### #89 — the carry is now modelled ahead of the hoist
+
+```
+main:   val textSmLineHeight = 20.00.dp
+fixed:  val textSmLineHeight = 20.00.sp
+```
+
+Compile-verified: `kotlinc` typechecks to bytecode. Zygarden byte-identical in
+both `Tokens.kt` and `Tokens.swift`.
+
+The mechanism worth recording, because it generalises: the ordering did **not**
+change. Classification still runs before the hoist, because the hoist consumes
+the leaf name it matches on. What changed is that the carry is now *computed
+ahead of time* from the raw tree by `flattenPipelineTypes`, so classification
+reads the type the pipeline is going to apply rather than the type the tree
+happens to hold at that instant. A rule that runs later can be modelled earlier
+as long as its inputs are all present earlier — and the carry's are.
+
+That is also why the map must be built on the **raw** dict: the carry's last
+condition asks whether a value *was* a whole-value reference, and `resolveInPlace`
+has already rewritten it to a literal by the time the resolved clone exists.
+
 ## Reproduce
 
 ```

--- a/references/native-adapter-config.md
+++ b/references/native-adapter-config.md
@@ -54,7 +54,7 @@ consumer's repo.
 import { readFileSync } from 'node:fs';
 import {
   flattenDtcg,
-  flattenDtcgTypes,
+  flattenPipelineTypes,
   resolveValue,
   findModeCollisions,
   TEXT_UNIT_NAMES,
@@ -435,14 +435,16 @@ export function preprocess(dict) {
   // the graph is made of.
   const { typographic } = textRoleGraph(dict);
   const resolved = resolveInPlace(structuredClone(dict), flattenDtcg(dict));
-  // DTCG 5.2.2 types for the whole tree, walked once and shared by both passes
-  // below. Neither writes $type or moves a node, so one map is correct for
-  // both, and sharing it is what makes them agree by construction rather than
-  // by two copies of the same rule staying in step (#85).
+  // Types for the whole tree, walked once and shared by both passes below.
+  // Neither writes $type or moves a node, so one map is correct for both, and
+  // sharing it is what makes them agree by construction rather than by two
+  // copies of the same rule staying in step (#85).
   //
-  // Computed on the RESOLVED clone, which is the tree both passes read.
-  // resolveInPlace rewrites $value strings only, so the types are the source's.
-  const types = flattenDtcgTypes(resolved);
+  // Computed on the RAW dict, not the resolved clone. resolveInPlace only
+  // rewrites $value strings, so paths and types are identical between the two —
+  // except for the carry, whose rule asks whether a value WAS a whole-value
+  // reference, and resolution has already destroyed that (#89).
+  const types = flattenPipelineTypes(dict);
   const out = hoistDualNodes(
     applyTextRoleGraph(classifyTextUnits(resolved, types), typographic, types),
     collisions,

--- a/scripts/lib/dtcg.mjs
+++ b/scripts/lib/dtcg.mjs
@@ -4,6 +4,8 @@
 
 const REF = /^\{([^}]+)\}$/;
 
+const isPlainObject = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
+
 // The typographic member names DTCG §9.8 fixes at MUST level, the unit gate a
 // text-role dimension must pass, and this project's $extensions namespace.
 //
@@ -63,6 +65,53 @@ export function flattenDtcgTypes(obj, prefix = [], out = {}, groupType = undefin
   return out;
 }
 
+// DTCG 5.2.2 PLUS the one repair this pipeline applies on top of it, so that
+// anything reasoning about what the build emits reads the same types the build
+// used. flattenDtcgTypes is the spec; this is the spec as this build resolves it.
+//
+// The repair is hoistDualNodes' $type carry. A dual node is a token, not a group
+// (DTCG 6.1), so it is not its children's inheritance source and 5.2.2 gives an
+// untyped child of one no type at all. The hoist then makes that child a sibling
+// of the dual node, which destroys the last relationship it had — so where NO
+// enclosing group supplies a type, the hoist stamps the dual node's own. That is
+// a repair for what the hoist broke, not a reading of the source, which is why
+// it does not belong in flattenDtcgTypes.
+//
+// It has to be modelled somewhere, though, because two things that reason about
+// types could not see it: classification, which runs before the hoist and so
+// declined a child the pipeline goes on to type (#89), and the unitless-dimension
+// advisory, which reads the raw source (#71). Both were silent on shapes the
+// build handles.
+//
+// The conditions mirror hoistDualNodes exactly — an untyped TOKEN child (#67
+// restricted it to those), a dual node that has a $type, no enclosing group type,
+// and a value that is not a whole-value reference. That last one is why this must
+// run on the RAW tree: resolveInPlace rewrites a reference to its literal, and
+// the WeakSet the hoist consults for it does not survive into a fresh call.
+//
+// Keyed on pre-hoist paths, like flattenDtcgTypes, because every consumer of this
+// map runs before the hoist or reports against source paths.
+export function flattenPipelineTypes(dict) {
+  const types = flattenDtcgTypes(dict);
+  (function walk(node, prefix, groupType) {
+    const inherited = '$value' in node ? groupType : (node.$type ?? groupType);
+    for (const [key, val] of Object.entries(node)) {
+      if (key.startsWith('$') || !isPlainObject(val)) continue;
+      const path = [...prefix, key];
+      if ('$value' in val && '$type' in val && inherited === undefined) {
+        for (const [childKey, childVal] of Object.entries(val)) {
+          if (childKey.startsWith('$') || !isPlainObject(childVal)) continue;
+          if ('$value' in childVal && !('$type' in childVal) && !REF.test(String(childVal.$value).trim())) {
+            types[[...path, childKey].join('.')] = val.$type;
+          }
+        }
+      }
+      walk(val, path, inherited);
+    }
+  })(dict, [], undefined);
+  return types;
+}
+
 // Follow {alias} chains to a leaf literal. Throws on missing or circular refs.
 export function resolveValue(name, flat, seen = new Set()) {
   if (!(name in flat)) throw new Error(`token "${name}" not found in DTCG source`);
@@ -104,7 +153,6 @@ export function findModeCollisions(sources) {
 //
 // Each source is cloned on the way in. Merging the caller's own objects would
 // mutate the token trees it still holds, and the validator reads them again.
-const isPlainObject = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 
 function mergeInto(target, src) {
   for (const [key, val] of Object.entries(src)) {

--- a/scripts/lib/sd-native.mjs
+++ b/scripts/lib/sd-native.mjs
@@ -12,7 +12,7 @@
 import { readFileSync } from 'node:fs';
 import {
   flattenDtcg,
-  flattenDtcgTypes,
+  flattenPipelineTypes,
   resolveValue,
   findModeCollisions,
   TEXT_UNIT_NAMES,
@@ -366,14 +366,16 @@ export function preprocess(dict) {
   // the graph is made of.
   const { typographic } = textRoleGraph(dict);
   const resolved = resolveInPlace(structuredClone(dict), flattenDtcg(dict));
-  // DTCG 5.2.2 types for the whole tree, walked once and shared by both passes
-  // below. Neither writes $type or moves a node, so one map is correct for
-  // both, and sharing it is what makes them agree by construction rather than
-  // by two copies of the same rule staying in step (#85).
+  // Types for the whole tree, walked once and shared by both passes below.
+  // Neither writes $type or moves a node, so one map is correct for both, and
+  // sharing it is what makes them agree by construction rather than by two
+  // copies of the same rule staying in step (#85).
   //
-  // Computed on the RESOLVED clone, which is the tree both passes read.
-  // resolveInPlace rewrites $value strings only, so the types are the source's.
-  const types = flattenDtcgTypes(resolved);
+  // Computed on the RAW dict, not the resolved clone. resolveInPlace only
+  // rewrites $value strings, so paths and types are identical between the two —
+  // except for the carry, whose rule asks whether a value WAS a whole-value
+  // reference, and resolution has already destroyed that (#89).
+  const types = flattenPipelineTypes(dict);
   const out = hoistDualNodes(
     applyTextRoleGraph(classifyTextUnits(resolved, types), typographic, types),
     collisions,

--- a/scripts/lib/sd-native.test.mjs
+++ b/scripts/lib/sd-native.test.mjs
@@ -1074,20 +1074,45 @@ test('preprocess is not idempotent where the hoist invents a typographic name', 
   assert.equal(roleOf(preprocess(structuredClone(onceInherited)).a.fontSize), 'text');
 });
 
-// The interaction #85 said a fix had to decide rather than assume. Where NO
-// enclosing group supplies a type, DTCG determines none for this child, and the
-// only thing that types it is hoistDualNodes' carry — which runs AFTER
-// classification, because classification must run before the hoist consumes the
-// leaf name it matches on. So a child typed only by the carry is not stamped.
-// Unchanged by #85 and left that way on purpose: the carry is the hoist
-// repairing what the hoist broke, not a reading of the source, and stamping on
-// an invented type would be a claim the source never made. Filed separately.
-test('a child typed only by the hoist carry is not stamped as text', () => {
+// #89, and the test #85 left pinned in the other direction. Where NO enclosing
+// group supplies a type, DTCG determines none for this child and the only thing
+// that types it is hoistDualNodes' carry — which runs AFTER classification,
+// because classification must run before the hoist consumes the leaf name it
+// matches on. Classification therefore could not see it, and a 20px line height
+// emitted 20.00.dp: compiles, renders at a fixed size, ignores the user's font
+// scale, and nothing reported it.
+//
+// The ordering is unchanged. What changed is that the carry is now MODELLED —
+// flattenPipelineTypes computes it from the raw tree ahead of time, so
+// classification reads the type the pipeline is going to apply rather than the
+// type the tree happens to hold at that instant.
+test('a child typed only by the hoist carry is stamped as text', () => {
   const out = preprocess({
     text: { sm: { $value: '14px', $type: 'dimension', lineHeight: { $value: '20px' } } },
   });
   assert.equal(out.text.smLineHeight.$type, 'dimension', 'the carry supplies the type');
-  assert.equal(roleOf(out.text.smLineHeight), undefined, 'but classification already ran');
+  assert.equal(roleOf(out.text.smLineHeight), 'text', 'and classification now sees it coming');
+});
+
+// The carry's own conditions still bound it. An enclosing group type means the
+// carry never fires, so there is nothing extra to model and 5.2.2 alone decides.
+test('no carry is modelled where an enclosing group supplies the type', () => {
+  const out = preprocess({
+    text: { $type: 'color', sm: { $value: '14px', $type: 'dimension', lineHeight: { $value: '20px' } } },
+  });
+  assert.equal('$type' in out.text.smLineHeight, false, 'the group wins, and it is not dimension');
+  assert.equal(roleOf(out.text.smLineHeight), undefined);
+});
+
+// A reference-valued child already carries its referent's resolved type, which
+// 5.2.2 rule 1 ranks above inheritance, so the hoist does not carry onto it and
+// neither does the model.
+test('no carry is modelled onto a reference-valued child', () => {
+  const out = preprocess({
+    other: { lh: { $value: '20px', $type: 'dimension' } },
+    text: { sm: { $value: '14px', $type: 'dimension', lineHeight: { $value: '{other.lh}' } } },
+  });
+  assert.equal(roleOf(out.text.smLineHeight), undefined, 'the referent states the role, not the hoist');
 });
 
 // The override, and the reason this design needs no new config parameter.


### PR DESCRIPTION
Closes #89. Reopened as a new PR — #94 was auto-closed when its base branch was deleted on merge of #93. Same commit, rebased onto `main`.

Part of the batched dual-node-hoist release.

## The defect

A dual node is a token, not a group (DTCG 6.1), so 5.2.2 gives an untyped child of one no type at all. `hoistDualNodes` stamps the dual node's own `$type` onto it — a repair for the relationship the hoist itself destroys — and that repair runs **after** classification, which has to come first because the hoist consumes the leaf name classification matches on.

So the pipeline typed the child and classification never saw it:

```
main   val textSmLineHeight = 20.00.dp
fixed  val textSmLineHeight = 20.00.sp
```

It compiled, it rendered at a fixed size ignoring the user's font-scale setting, and no rule said anything. That silence is why it sits at the top of the revised cluster order — #67 is louder, this one is invisible.

## The fix, and the bit that generalises

**The ordering is unchanged.** The carry is now *computed ahead of time*: `flattenPipelineTypes` resolves 5.2.2 and then applies the carry's own conditions to the raw tree, so classification reads the type the pipeline is **going to** apply rather than the type the tree happens to hold at that instant.

A rule that runs later can be modelled earlier as long as its inputs are all present earlier — and the carry's are.

It lives beside `flattenDtcgTypes` rather than inside it, deliberately: `flattenDtcgTypes` is the spec, this is the spec *as this build resolves it*, and the carry is not something DTCG says.

Built on the **raw** dict, not the resolved clone — the carry's last condition asks whether a value *was* a whole-value reference, and `resolveInPlace` has rewritten it to a literal by then.

## Verification

- Emitted output, not the stamp: `dp` → `sp` on the issue's own fixture.
- Compile-verified: `kotlinc` typechecks to bytecode.
- **Zygarden byte-identical** in both `Tokens.kt` and `Tokens.swift` — every dual-node child there carries its own `$type`, which is exactly why nothing caught this.

## Tests

464 pass. The test #85 left pinned in the other direction is **flipped**, which the issue predicted whoever fixed this would have to do. Two boundary tests added.