### PR TITLE
The hoist-collision message names authored paths and stops calling arrays groups (#61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- **The hoist-collision error names the path you actually wrote.** The hoist
+  recurses depth-first, so an outer frame already held names an inner frame had
+  synthesised, and a nested dual node's collision reported `x.y.zW` — a path
+  appearing nowhere in the source. It now reports `x.y.z.w`. The `onto` path was
+  always genuine; only the path being complained about was invented.
+- **An array-valued sibling is no longer called "a group" in that error.** An
+  array carries no `$value`, so the group predicate claimed it. It is neither a
+  token nor a group, and an array in that position is not valid DTCG — the
+  message now says so instead of sending you to look for a group.
+
 - **`unitless-dimension` now sees the hoist's `$type` carry.** A unitless,
   untyped child of a dimension-typed dual node was a `dimension` to the build and
   a nothing to the gate, so it emitted a bare `1.5` — a `Double` where Compose

--- a/references/native-adapter-config.md
+++ b/references/native-adapter-config.md
@@ -156,6 +156,18 @@ Both are fixed before Style Dictionary sees the tree.
 // membership along with the rest of the identity, so preprocess(preprocess(x))
 // is deepEqual to preprocess(x) with no leak question to manage.
 const WAS_REF = new WeakSet();
+
+// The path the AUTHOR wrote for a node the hoist has moved. hoistDualNodes
+// recurses depth-first, so by the time an outer frame takes Object.entries it
+// already contains names the inner frame synthesised — and a collision reported
+// from that frame named a path appearing nowhere in the source (#61). Recording
+// the authored path when a node is hoisted lets the outer frame report what the
+// author can actually search for.
+//
+// Keyed on node identity, like WAS_REF, and safe across calls for the same
+// reason: preprocess structuredClones its input, so every call works on fresh
+// objects.
+const AUTHORED_PATH = new WeakMap();
 const WHOLE_REF = /^\{[^}]+\}$/;
 
 function interpolate(value, flat) {
@@ -228,20 +240,27 @@ function hoistDualNodes(node, collisions, prefix = [], groupType = undefined) {
       for (const [childKey, childVal] of Object.entries(val)) {
         if (childKey.startsWith('$') || !childVal || typeof childVal !== 'object') continue;
         const hoisted = key + childKey[0].toUpperCase() + childKey.slice(1);
-        const from = [...prefix, key, childKey].join('.');
+        const from = AUTHORED_PATH.get(childVal) ?? [...prefix, key, childKey].join('.');
         if (Object.hasOwn(node, hoisted)) {
           const existingNode = node[hoisted];
-          const isGroup = existingNode !== null && typeof existingNode === 'object' && !('$value' in existingNode);
+          // An array has no $value either, and was therefore labelled "(a group)"
+          // (#61). It is neither — an array at this position is malformed DTCG.
+          // Say so, rather than naming a shape the author will go looking for.
+          const isArray = Array.isArray(existingNode);
+          const isGroup =
+            existingNode !== null && typeof existingNode === 'object' && !isArray && !('$value' in existingNode);
           collisions.push({
             from,
             onto: [...prefix, hoisted].join('.'),
             isGroup,
+            isArray,
             claimant: claimedBy.get(hoisted),
-            existing: isGroup
-              ? undefined
-              : existingNode && typeof existingNode === 'object'
-                ? existingNode.$value
-                : existingNode,
+            existing:
+              isGroup || isArray
+                ? undefined
+                : existingNode && typeof existingNode === 'object'
+                  ? existingNode.$value
+                  : existingNode,
           });
           continue;
         }
@@ -282,6 +301,7 @@ function hoistDualNodes(node, collisions, prefix = [], groupType = undefined) {
           childVal.$type = val.$type;
         }
         node[hoisted] = childVal;
+        AUTHORED_PATH.set(childVal, from);
         delete val[childKey];
         claimedBy.set(hoisted, from);
       }
@@ -454,6 +474,9 @@ export function preprocess(dict) {
       .slice(0, 5)
       .map((c) => {
         const line = `  ${c.from} -> ${c.onto}`;
+        if (c.isArray) {
+          return line + ' (an array — neither a token nor a group, and not valid DTCG here)';
+        }
         if (c.isGroup) {
           return line + (c.claimant ? ` (a group, already claimed by the hoist of ${c.claimant})` : ' (a group)');
         }

--- a/scripts/lib/sd-native.mjs
+++ b/scripts/lib/sd-native.mjs
@@ -87,6 +87,18 @@ export function colorMixToHex8(value) {
 // membership along with the rest of the identity, so preprocess(preprocess(x))
 // is deepEqual to preprocess(x) with no leak question to manage.
 const WAS_REF = new WeakSet();
+
+// The path the AUTHOR wrote for a node the hoist has moved. hoistDualNodes
+// recurses depth-first, so by the time an outer frame takes Object.entries it
+// already contains names the inner frame synthesised — and a collision reported
+// from that frame named a path appearing nowhere in the source (#61). Recording
+// the authored path when a node is hoisted lets the outer frame report what the
+// author can actually search for.
+//
+// Keyed on node identity, like WAS_REF, and safe across calls for the same
+// reason: preprocess structuredClones its input, so every call works on fresh
+// objects.
+const AUTHORED_PATH = new WeakMap();
 const WHOLE_REF = /^\{[^}]+\}$/;
 
 function interpolate(value, flat) {
@@ -159,20 +171,27 @@ function hoistDualNodes(node, collisions, prefix = [], groupType = undefined) {
       for (const [childKey, childVal] of Object.entries(val)) {
         if (childKey.startsWith('$') || !childVal || typeof childVal !== 'object') continue;
         const hoisted = key + childKey[0].toUpperCase() + childKey.slice(1);
-        const from = [...prefix, key, childKey].join('.');
+        const from = AUTHORED_PATH.get(childVal) ?? [...prefix, key, childKey].join('.');
         if (Object.hasOwn(node, hoisted)) {
           const existingNode = node[hoisted];
-          const isGroup = existingNode !== null && typeof existingNode === 'object' && !('$value' in existingNode);
+          // An array has no $value either, and was therefore labelled "(a group)"
+          // (#61). It is neither — an array at this position is malformed DTCG.
+          // Say so, rather than naming a shape the author will go looking for.
+          const isArray = Array.isArray(existingNode);
+          const isGroup =
+            existingNode !== null && typeof existingNode === 'object' && !isArray && !('$value' in existingNode);
           collisions.push({
             from,
             onto: [...prefix, hoisted].join('.'),
             isGroup,
+            isArray,
             claimant: claimedBy.get(hoisted),
-            existing: isGroup
-              ? undefined
-              : existingNode && typeof existingNode === 'object'
-                ? existingNode.$value
-                : existingNode,
+            existing:
+              isGroup || isArray
+                ? undefined
+                : existingNode && typeof existingNode === 'object'
+                  ? existingNode.$value
+                  : existingNode,
           });
           continue;
         }
@@ -213,6 +232,7 @@ function hoistDualNodes(node, collisions, prefix = [], groupType = undefined) {
           childVal.$type = val.$type;
         }
         node[hoisted] = childVal;
+        AUTHORED_PATH.set(childVal, from);
         delete val[childKey];
         claimedBy.set(hoisted, from);
       }
@@ -385,6 +405,9 @@ export function preprocess(dict) {
       .slice(0, 5)
       .map((c) => {
         const line = `  ${c.from} -> ${c.onto}`;
+        if (c.isArray) {
+          return line + ' (an array — neither a token nor a group, and not valid DTCG here)';
+        }
         if (c.isGroup) {
           return line + (c.claimant ? ` (a group, already claimed by the hoist of ${c.claimant})` : ' (a group)');
         }

--- a/scripts/lib/sd-native.test.mjs
+++ b/scripts/lib/sd-native.test.mjs
@@ -486,6 +486,36 @@ test('a fontFamily containing a parenthesized suffix is quoted and kept, not mis
 
 // A dual node's child is renamed to a camel-joined sibling. If that name is
 // already taken, the pre-fix code overwrote it and a token vanished with no
+// #61.1. hoistDualNodes recurses depth-first, so an outer frame's
+// Object.entries already contains names the inner frame synthesised. The
+// collision then named x.y.zW — a path appearing nowhere in the author's file.
+// The onto path was always genuine; only the from path was invented.
+test('a nested dual node collision names the authored path, not a synthesised one', () => {
+  assert.throws(
+    () => preprocess({ x: { y: { $value: '1', z: { $value: '2', w: { $value: '3' } } }, yZW: { $value: '9' } } }),
+    (err) => {
+      assert.match(err.message, /x\.y\.z\.w -> x\.yZW/, 'the path the author wrote');
+      assert.doesNotMatch(err.message, /x\.y\.zW /, 'not the intermediate the hoist invented');
+      return true;
+    },
+  );
+});
+
+// #61.2. An array has no $value, so the group predicate claimed it. It is
+// neither a token nor a group, and an array at this position is malformed DTCG —
+// naming it "a group" sends the author looking for something that is not there.
+test('an array-valued sibling is not labelled a group', () => {
+  assert.throws(
+    () => preprocess({ text: { sm: { $value: '14px', lineHeight: { $value: '20px' } }, smLineHeight: [1, 2, 3] } }),
+    (err) => {
+      assert.match(err.message, /an array/);
+      assert.doesNotMatch(err.message, /\(a group\)/);
+      assert.doesNotMatch(err.message, /overwrite undefined/, 'and it does not fall through to the token branch');
+      return true;
+    },
+  );
+});
+
 // diagnostic — the same class as the mode collision nativeSources guards.
 test('preprocess throws when a hoisted name collides with an authored token', () => {
   assert.throws(


### PR DESCRIPTION
Closes #61. Part of the batched dual-node-hoist release.

Two independent cosmetic defects in the error `preprocess` throws. Neither loses data, neither changes an exit code — both make the message harder to act on.

## 1. A nested dual node reported a synthesised path

```
before  x.y.zW  -> x.yZW (would overwrite "9")
after   x.y.z.w -> x.yZW (would overwrite "9")
```

The author wrote `x.y.z.w`. `x.y.zW` appears nowhere in their file — so the one instruction the message gives, *rename the child or the sibling*, named something they couldn't find.

Fixed by recording the authored path when a node is hoisted, in a WeakMap keyed on node identity. The issue judged this *"not worth restructuring for"* during #55; a WeakMap turns out not to need the restructuring, because identity survives the move. Safe across calls for the same reason `WAS_REF` is — `preprocess` structuredClones its input.

## 2. An array-valued sibling was labelled "(a group)"

The predicate classified any object without a `$value` as a group, and an array has none. It's neither a token nor a group, and an array in that position isn't valid DTCG — the message now says that instead of sending the author to look for a group. #59 fixed the string and number cases and missed this one.

## Tests

470 pass, 2 new — including that the array case doesn't fall through to the token branch and print `would overwrite undefined`.

Regression control: zygarden `Tokens.kt` and `Tokens.swift` byte-identical.