### PR TITLE
State the idempotency claim no wider than it holds (#90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- **The claim that `preprocess` is idempotent is now stated no wider than it
+  holds.** Four comments asserted it without qualification, one of them
+  load-bearing advice — that declaring the preprocessor at top level *as well as*
+  through `nativePlatform` is harmless. Running it twice is still harmless in
+  every shape measured, and it is the wiring our own usage snippet shows. The
+  exception, now written down: where the hoist invents a name the second pass
+  then classifies (`a.font` with a child `size` camel-joins to `a.fontSize`), the
+  second pass stamps a token the first correctly declined. It changes no emitted
+  output, because Style Dictionary types that child between the two passes
+  anyway. A repair belongs with the hoist, which has no way to record the names
+  it invents, and that is not paid for by a defect with no output consequence.
+
 - **The hoist-collision error names the path you actually wrote.** The hoist
   recurses depth-first, so an outer frame already held names an inner frame had
   synthesised, and a nested dual node's collision reported `x.y.zW` — a path

--- a/references/native-adapter-config.md
+++ b/references/native-adapter-config.md
@@ -152,9 +152,12 @@ Both are fixed before Style Dictionary sees the tree.
 // Marks a node whose AUTHORED $value was a whole-value reference, so the hoist
 // can decline to override the type DTCG 5.2.2 rule 1 already determined from the
 // referent. A WeakSet keyed on the node object, rather than a property written
-// onto it, holds structural idempotency exactly: structuredClone drops the
-// membership along with the rest of the identity, so preprocess(preprocess(x))
-// is deepEqual to preprocess(x) with no leak question to manage.
+// onto it, keeps this mechanism from leaking across calls: structuredClone
+// drops the membership along with the rest of the identity, so a second pass
+// starts clean rather than inheriting the first pass's marks. That is exactly
+// what a property written onto the node would get wrong. It is not on its own a
+// guarantee that preprocess is idempotent — see the limit recorded at
+// nativePlatform's preprocessors line (#90).
 const WAS_REF = new WeakSet();
 
 // The path the AUTHOR wrote for a node the hoist has moved. hoistDualNodes
@@ -408,7 +411,9 @@ function classifyTextUnits(node, types, prefix = []) {
       // one, so a unitless value is declined by every size transform regardless
       // of what is stamped here (see isRatio, #52). Declining to overwrite IS
       // the feature: it costs no configuration parameter, and it is what makes
-      // the pass idempotent.
+      // STAMPING idempotent — a second pass never rewrites a role a first pass
+      // set. What it does not settle is whether a second pass finds the same
+      // candidates; the hoist can rename a node between the two (#90).
       if (!('nativeUnit' in ns)) ns.nativeUnit = 'text';
     }
     classifyTextUnits(val, types, path);
@@ -431,7 +436,8 @@ function classifyTextUnits(node, types, prefix = []) {
 // A path may name no node at all. resolveInPlace deliberately leaves an
 // unresolvable reference in place for Style Dictionary to report, so the graph
 // can hold an edge to a token that does not exist. Skip it. This is also what
-// keeps the second preprocess pass from throwing, and idempotency with it.
+// keeps the second preprocess pass from throwing — which is a precondition for
+// idempotency, not the whole of it (#90).
 function applyTextRoleGraph(node, typographic, types) {
   for (const path of typographic) {
     let target = node;
@@ -798,8 +804,21 @@ export function nativePlatform({ platform, buildPath, className = 'Tokens', pack
     // Carried here, not left to the caller: authored() reads the ORIGINAL
     // $value, so without this preprocessor every aliased dimension still holds
     // an unresolved {spacing.space.4}, no size transform fires, and the build
-    // emits bare px literals. preprocess is idempotent, so a project that also
-    // declares it at top level is harmless.
+    // emits bare px literals.
+    //
+    // A project that ALSO declares this preprocessor at top level runs it twice,
+    // which is harmless in every shape measured — and is the wiring our own
+    // usage snippet shows, so it is the common case rather than a corner.
+    //
+    // Stated no wider than it holds (#90): preprocess is idempotent except where
+    // the hoist invents a name the second pass then classifies. `a.font` with a
+    // child `size` camel-joins to `a.fontSize`; the first pass correctly declines
+    // `size`, and the second sees a typographic member name the source never
+    // authored. It changes no emitted output — Style Dictionary runs
+    // typeDtcgDelegate between the two passes and types that child anyway, so
+    // both passes reach the same file — and the repair belongs with the hoist,
+    // which has no way to record the names it invented. Pinned by test rather
+    // than papered over.
     preprocessors: ['dtcg/resolve-dual-node'],
     buildPath,
     options: { outputReferences: false },

--- a/scripts/lib/sd-native.mjs
+++ b/scripts/lib/sd-native.mjs
@@ -83,9 +83,12 @@ export function colorMixToHex8(value) {
 // Marks a node whose AUTHORED $value was a whole-value reference, so the hoist
 // can decline to override the type DTCG 5.2.2 rule 1 already determined from the
 // referent. A WeakSet keyed on the node object, rather than a property written
-// onto it, holds structural idempotency exactly: structuredClone drops the
-// membership along with the rest of the identity, so preprocess(preprocess(x))
-// is deepEqual to preprocess(x) with no leak question to manage.
+// onto it, keeps this mechanism from leaking across calls: structuredClone
+// drops the membership along with the rest of the identity, so a second pass
+// starts clean rather than inheriting the first pass's marks. That is exactly
+// what a property written onto the node would get wrong. It is not on its own a
+// guarantee that preprocess is idempotent — see the limit recorded at
+// nativePlatform's preprocessors line (#90).
 const WAS_REF = new WeakSet();
 
 // The path the AUTHOR wrote for a node the hoist has moved. hoistDualNodes
@@ -339,7 +342,9 @@ function classifyTextUnits(node, types, prefix = []) {
       // one, so a unitless value is declined by every size transform regardless
       // of what is stamped here (see isRatio, #52). Declining to overwrite IS
       // the feature: it costs no configuration parameter, and it is what makes
-      // the pass idempotent.
+      // STAMPING idempotent — a second pass never rewrites a role a first pass
+      // set. What it does not settle is whether a second pass finds the same
+      // candidates; the hoist can rename a node between the two (#90).
       if (!('nativeUnit' in ns)) ns.nativeUnit = 'text';
     }
     classifyTextUnits(val, types, path);
@@ -362,7 +367,8 @@ function classifyTextUnits(node, types, prefix = []) {
 // A path may name no node at all. resolveInPlace deliberately leaves an
 // unresolvable reference in place for Style Dictionary to report, so the graph
 // can hold an edge to a token that does not exist. Skip it. This is also what
-// keeps the second preprocess pass from throwing, and idempotency with it.
+// keeps the second preprocess pass from throwing — which is a precondition for
+// idempotency, not the whole of it (#90).
 function applyTextRoleGraph(node, typographic, types) {
   for (const path of typographic) {
     let target = node;
@@ -670,8 +676,21 @@ export function nativePlatform({ platform, buildPath, className = 'Tokens', pack
     // Carried here, not left to the caller: authored() reads the ORIGINAL
     // $value, so without this preprocessor every aliased dimension still holds
     // an unresolved {spacing.space.4}, no size transform fires, and the build
-    // emits bare px literals. preprocess is idempotent, so a project that also
-    // declares it at top level is harmless.
+    // emits bare px literals.
+    //
+    // A project that ALSO declares this preprocessor at top level runs it twice,
+    // which is harmless in every shape measured — and is the wiring our own
+    // usage snippet shows, so it is the common case rather than a corner.
+    //
+    // Stated no wider than it holds (#90): preprocess is idempotent except where
+    // the hoist invents a name the second pass then classifies. `a.font` with a
+    // child `size` camel-joins to `a.fontSize`; the first pass correctly declines
+    // `size`, and the second sees a typographic member name the source never
+    // authored. It changes no emitted output — Style Dictionary runs
+    // typeDtcgDelegate between the two passes and types that child anyway, so
+    // both passes reach the same file — and the repair belongs with the hoist,
+    // which has no way to record the names it invented. Pinned by test rather
+    // than papered over.
     preprocessors: ['dtcg/resolve-dual-node'],
     buildPath,
     options: { outputReferences: false },

--- a/scripts/lib/sd-native.test.mjs
+++ b/scripts/lib/sd-native.test.mjs
@@ -1087,8 +1087,14 @@ test('a dual-node child typed by an enclosing group is stamped', () => {
 // $type; resolving the group's type means it now also fires where the child
 // inherits one. Neither changes emitted output in the documented wiring, where
 // Style Dictionary's typeDtcgDelegate runs between the two passes and types the
-// hoisted child anyway. Filed rather than fixed here: the repair belongs with
-// the hoist, not with #85's type resolution.
+// hoisted child anyway.
+//
+// #90 closed on this measurement rather than on a repair. The repair belongs
+// with the hoist, which has no carrier for the names it invents, and the cost of
+// giving it one is not paid for by a defect that changes no output. The four
+// comments that asserted idempotency without qualification now state the limit
+// instead — see nativePlatform's preprocessors line. This test is what keeps the
+// limit honest: if the behaviour ever changes, it fails rather than drifting.
 test('preprocess is not idempotent where the hoist invents a typographic name', () => {
   const own = () => ({
     a: { font: { $value: '2px', $type: 'dimension', size: { $value: '16px', $type: 'dimension' } } },


### PR DESCRIPTION
Closes #90 by narrowing four shipped assertions rather than repairing the hoist — the recommendation agreed before starting. Part of the batched dual-node-hoist release.

## The limit, written down

`preprocess` is idempotent **except** where the hoist invents a name the second pass then classifies. `a.font` with a child `size` camel-joins to `a.fontSize`: the first pass correctly declines `size` (not a typographic member name), the second sees one the source never authored.

## Why narrowed rather than fixed

- **It changes no emitted output.** Style Dictionary runs `typeDtcgDelegate` between the global and platform preprocessor passes, so the hoisted child is typed between the two runs and both reach the same file. Measured both ways — the Kotlin is identical.
- **The repair belongs with the hoist.** Classification's contract is that it matches only names the *source* authored; the hoist creates names that violate that on any later pass. Honouring it needs a carrier for the invented names — one that survives `structuredClone`, doesn't leak into emitted output, and doesn't add `$extensions` surface consumers read. Real cost, for a defect with no output consequence.
- **It's pre-existing**, verified against `a349453` before being attributed. #85 widened the hole; it didn't open it.

## What actually changed

Four comments asserted idempotency without qualification. One is load-bearing advice: *"preprocess is idempotent, so a project that also declares it at top level is harmless."* Running it twice **is** harmless in every shape measured, and it's the wiring our own usage snippet shows — so the advice stays and the exception is now written beside it rather than left to be discovered.

The test pinning both directions stays, and its comment now says what it's for: keeping the stated limit honest, so a behaviour change fails a test rather than drifting past the prose.

470 pass.