### PR TITLE
Report a node carrying both a $value and children as non-conforming (#58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Added
+
+- **`tokens:validate-output` reports a node carrying both a `$value` and child
+  tokens.** That shape is invalid DTCG — §6.1 says an object cannot be both a
+  token and a group, and §6.2 defines `$root` as the sanctioned way for a group
+  to carry a base value alongside children — and nothing told you. **Advisory,
+  never gating, and that is deliberate**: every Figma-derived source has dozens
+  of them, so failing would make the gate useless on day one for exactly the
+  people this tool targets. The build handles the shape and keeps handling it;
+  the advisory exists so someone hand-authoring a source can learn that `$root`
+  is the spelling the spec blesses. One note for the whole finding, listing the
+  paths, rather than one per node.
+
 ### Fixed
 
 - **The claim that `preprocess` is idempotent is now stated no wider than it
@@ -19,7 +32,6 @@ to [Semantic Versioning](https://semver.org).
   output, because Style Dictionary types that child between the two passes
   anyway. A repair belongs with the hoist, which has no way to record the names
   it invents, and that is not paid for by a defect with no output consequence.
-
 - **The hoist-collision error names the path you actually wrote.** The hoist
   recurses depth-first, so an outer frame already held names an inner frame had
   synthesised, and a nested dual node's collision reported `x.y.zW` — a path
@@ -29,7 +41,6 @@ to [Semantic Versioning](https://semver.org).
   array carries no `$value`, so the group predicate claimed it. It is neither a
   token nor a group, and an array in that position is not valid DTCG — the
   message now says so instead of sending you to look for a group.
-
 - **`unitless-dimension` now sees the hoist's `$type` carry.** A unitless,
   untyped child of a dimension-typed dual node was a `dimension` to the build and
   a nothing to the gate, so it emitted a bare `1.5` — a `Double` where Compose
@@ -78,7 +89,6 @@ to [Semantic Versioning](https://semver.org).
   in source, which DTCG 8.2.1 requires of a dimension anyway. Output against a
   real system is byte-identical — the shape needs a dual node with a group child,
   and Figma-derived dual nodes have token children only.
-
 
 - **`tokens:validate-output` fails on two source paths that reduce to one symbol
   name.** `color.bg.canvas` and `colorBg.canvas` both normalize to

--- a/scripts/lib/dtcg.mjs
+++ b/scripts/lib/dtcg.mjs
@@ -112,6 +112,40 @@ export function flattenPipelineTypes(dict) {
   return types;
 }
 
+// Collect nodes carrying BOTH a $value and child tokens or groups.
+//
+// This shape is invalid DTCG. Format Module, Draft Community Group Report of
+// 30 July 2026, §6.1: "The presence of a $value property definitively identifies
+// an object as a token. If an object contains both $value and child
+// tokens/groups, this creates an invalid structure where the object cannot be
+// both a token and a group simultaneously. Tools MUST report this as an error."
+// The prohibition is deliberate rather than an oversight — §6.2 defines $root as
+// the sanctioned way for a group to carry a base value alongside children, which
+// is exactly what a dual node is reaching for.
+//
+// Collecting them is NOT a step towards rejecting them. Figma-derived sources
+// emit dual nodes by the dozen, hoistDualNodes exists precisely to handle them,
+// and refusing them would make this tool useless against the sources it targets.
+// That behaviour is unchanged. What was missing is telling the author their
+// source is non-conforming, which nothing did — so someone hand-authoring
+// text.sm with both a value and a lineHeight child had no way to learn that
+// $root is the blessed spelling.
+//
+// Lives here because flattenDtcg already walks this tree and already descends
+// into dual nodes on purpose, so the knowledge is present and only the reporting
+// was absent.
+export function findDualNodes(obj, prefix = [], out = []) {
+  for (const [key, val] of Object.entries(obj)) {
+    if (key.startsWith('$') || !isPlainObject(val)) continue;
+    const path = [...prefix, key];
+    if ('$value' in val && Object.entries(val).some(([k, v]) => !k.startsWith('$') && isPlainObject(v))) {
+      out.push(path.join('.'));
+    }
+    findDualNodes(val, path, out);
+  }
+  return out;
+}
+
 // Follow {alias} chains to a leaf literal. Throws on missing or circular refs.
 export function resolveValue(name, flat, seen = new Set()) {
   if (!(name in flat)) throw new Error(`token "${name}" not found in DTCG source`);

--- a/scripts/validate-token-output.mjs
+++ b/scripts/validate-token-output.mjs
@@ -11,6 +11,7 @@ import {
   flattenDtcg,
   flattenDtcgTypes,
   flattenPipelineTypes,
+  findDualNodes,
   resolveValue,
   findModeCollisions,
   textRoleGraph,
@@ -301,6 +302,24 @@ export function validate({ sources, output, platform, minMatch = 0.5 }) {
   // build that actually ran, and a build merges with the later source winning.
   // A union would call a token referenced when this build did not reach it,
   // under-reporting the gap in the one direction that matters.
+  // #58. A node carrying both a $value and children is invalid DTCG (§6.1, and
+  // §6.2 defines $root as the sanctioned spelling), and nothing told the author
+  // so. ADVISORY, not a failure, and deliberately: every Figma-derived source
+  // has dozens — the real one this is validated against has 13 — so failing on
+  // it would make the gate useless on day one for exactly the people this tool
+  // targets. The build keeps handling them; the author now learns the shape is
+  // non-conforming and what to write instead.
+  //
+  // One advisory for the whole finding rather than one per node. It is a single
+  // structural fact about the source, and thirteen near-identical lines would
+  // bury the rest of the report.
+  //
+  // Read per source file, not from the merged dict: a merge can conceal a dual
+  // node whose children come from one file and whose $value comes from another,
+  // and the author fixes this file by file.
+  const dualNodes = [...new Set(sources.flatMap((s) => findDualNodes(s.dtcg)))];
+  if (dualNodes.length) advisories.push({ rule: 'dual-node', paths: dualNodes });
+
   const graph = textRoleGraph(mergeDtcg(sources.map((s) => s.dtcg)));
   for (const { path, group } of graph.unreferencedSiblings) {
     advisories.push({ rule: 'unreferenced-text-sibling', token: path, group });
@@ -389,6 +408,14 @@ export function formatReport(r) {
       if (a.rule === 'unreferenced-text-sibling') {
         lines.push(
           `  - [${a.rule}] ${a.token}: nothing references it, so no typographic role could be inferred — but tokens in "${a.group}" were. It emits as a length, or is dropped entirely if its unit is em. On Compose, stamping $extensions["${EXT_NS}"].nativeUnit = "text" on it in source settles it; on Swift there is no sp/dp distinction to settle, and a stamped em still would not emit there. Leave it as is if it is not a text value.`,
+        );
+        continue;
+      }
+      if (a.rule === 'dual-node') {
+        const shown = a.paths.slice(0, 5).join(', ');
+        const more = a.paths.length > 5 ? `, ...and ${a.paths.length - 5} more` : '';
+        lines.push(
+          `  - [${a.rule}] ${a.paths.length} node(s) carry both a $value and child tokens: ${shown}${more}. DTCG §6.1 makes that invalid — an object cannot be both a token and a group — and §6.2 defines $root as the way a group carries a base value alongside children. The build handles this shape and will keep handling it; nothing here is broken. Rewrite them as $root only if you want the source to conform.`,
         );
         continue;
       }

--- a/scripts/validate-token-output.test.mjs
+++ b/scripts/validate-token-output.test.mjs
@@ -313,7 +313,10 @@ test('unitless-dimension sees the hoist carry', () => {
     leading: { base: { $value: '16px', $type: 'dimension', normal: { $value: '1.5' } } },
   } }];
   const r = validate({ sources, output: 'static let leadingBaseNormal = 1.5', platform: 'ios-swift' });
-  assert.deepEqual(r.advisories.map((a) => a.token), ['leading.base.normal']);
+  assert.deepEqual(
+    r.advisories.filter((a) => a.rule === 'unitless-dimension').map((a) => a.token),
+    ['leading.base.normal'],
+  );
 });
 
 // #72. #69 stopped the advisory double-firing by skipping any whole-value
@@ -321,6 +324,37 @@ test('unitless-dimension sees the hoist carry', () => {
 // not, the base never fires (untyped) and the alias was skipped (a reference),
 // so a genuine unitless dimension was reported NOWHERE. The skip is now
 // conditional on the referent being dimension-typed in its own right.
+// #58. A node with both a $value and children is invalid DTCG (§6.1); §6.2's
+// $root is the sanctioned spelling. Advisory and never gating: every
+// Figma-derived source has dozens, so failing would make the gate useless on day
+// one for exactly the people this targets.
+test('a dual node is reported as non-conforming, without failing the run', () => {
+  const sources = [{ file: 't.json', dtcg: {
+    text: { sm: { $value: '14px', $type: 'dimension', lineHeight: { $value: '20px', $type: 'dimension' } } },
+  } }];
+  const r = validate({ sources, output: 'static let textSm = 14', platform: 'ios-swift', minMatch: 0 });
+  const dual = r.advisories.filter((a) => a.rule === 'dual-node');
+  assert.equal(dual.length, 1, 'one advisory for the finding, not one per node');
+  assert.deepEqual(dual[0].paths, ['text.sm']);
+  assert.equal(r.failures.length, 0, 'the build still handles this shape');
+});
+
+test('a source with no dual node says nothing about them', () => {
+  const sources = [{ file: 't.json', dtcg: { text: { sm: { $value: '14px', $type: 'dimension' } } } }];
+  const r = validate({ sources, output: 'static let textSm = 14', platform: 'ios-swift', minMatch: 0 });
+  assert.deepEqual(r.advisories.filter((a) => a.rule === 'dual-node'), []);
+});
+
+test('the dual-node advisory names $root and says the build still works', () => {
+  const sources = [{ file: 't.json', dtcg: {
+    text: { sm: { $value: '14px', $type: 'dimension', lineHeight: { $value: '20px', $type: 'dimension' } } },
+  } }];
+  const r = validate({ sources, output: 'static let textSm = 14', platform: 'ios-swift', minMatch: 0 });
+  const text = formatReport(r).join('\n');
+  assert.match(text, /\$root/);
+  assert.match(text, /keep handling it/);
+});
+
 test('an untyped base behind a typed alias is reported, on the base', () => {
   const sources = [{ file: 't.json', dtcg: {
     base: { ratio: { $value: '1.5' } },


### PR DESCRIPTION
Closes #58. The last of the batched dual-node-hoist release.

## What and why

DTCG §6.1 is normative: an object with both `$value` and child tokens *"creates an invalid structure... Tools MUST report this as an error."* The prohibition is deliberate — §6.2 defines `$root` as the sanctioned way for a group to carry a base value alongside children, which is exactly what a dual node reaches for.

Nothing in this project said so. Someone hand-authoring `text.sm` with both a value and a `lineHeight` child had no way to learn the shape is invalid, or that `$root` exists.

## Advisory, never gating — against what the spec's MUST suggests

Every Figma-derived source emits dual nodes by the dozen. Failing on them makes the gate useless on day one for precisely the users this tool targets. `hoistDualNodes` exists to handle the shape and keeps handling it — **nothing about the build changes**, and the message says so, so nobody reads it as a break.

```
- [dual-node] 13 node(s) carry both a $value and child tokens: text.xs, text.sm,
  text.base, text.lg, text.xl, ...and 8 more. DTCG §6.1 makes that invalid — an
  object cannot be both a token and a group — and §6.2 defines $root as the way a
  group carries a base value alongside children. The build handles this shape and
  will keep handling it; nothing here is broken. Rewrite them as $root only if you
  want the source to conform.
```

zygarden: exit 0, 208/208 matched, 11 advisories (was 10).

## Design choices

- **One advisory for the whole finding**, not one per node — a single structural fact about the source; thirteen near-identical lines would bury the rest of the report.
- **Read per source file**, not from the merged dict: a merge can conceal a dual node whose children come from one file and whose `$value` comes from another, and the author fixes this file by file.
- **Lives in `lib/dtcg.mjs`** beside `flattenDtcg`, which already walks this tree and already descends into dual nodes on purpose. Not in `hoistDualNodes` — the preprocessor's job is to make the build work, silently.

## One correction to the issue

It says zygarden has **9** dual nodes, `text.xs` through `text.5xl`. It has **13** — the range continues to `text.9xl` and every one carries a `lineHeight` child. Same undercount shape as the 322-token figure corrected earlier this week.

The two comments the issue lists as asserting the opposite were already fixed in #55 — verified rather than assumed.

473 pass.