### PR TITLE
One list of CSS construct names, named drops, and a diagnostic for a primitive $extensions (#57, #62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,25 @@ to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- **A token dropped for having no native form is now named, not just counted.**
+  The report said "3 source token(s) had no matching emitted symbol" and stopped
+  there. It now names them. On a real system those three turn out to be a
+  gradient, a `max()` width and an unreferenced letter-spacing — none obvious
+  from a number.
+- **The output filter and the `no-foreign-syntax` rule read one list of CSS
+  construct names.** `native-literal.mjs` said they were kept together "so the
+  build and the gate cannot drift apart", and the gate held its own independent
+  copy of the same alternation. Adding a fourth name would have taught the filter
+  to keep a construct the gate had never been taught to name — the same
+  unreachable-rule defect that was fixed once already. One list now, with the
+  build's anchored form and the gate's unanchored form derived from it. The
+  asymmetry is deliberate and now documented: a construct nested inside another
+  function is dropped rather than kept, because nothing here can tell a rescuable
+  outer function from `linear-gradient(...)`.
+- **A value with foreign syntax no longer also reports `unverifiable-dimension`.**
+  `no-foreign-syntax` already names the cause; "the token was never actually
+  compared" beside it points at the symptom and reads as a second, unrelated
+  defect.
 - **The claim that `preprocess` is idempotent is now stated no wider than it
   holds.** Four comments asserted it without qualification, one of them
   load-bearing advice — that declaring the preprocessor at top level *as well as*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- **A `$extensions` namespace holding a primitive names the token instead of
+  crashing.** A DTCG `$extensions` namespace key may hold any JSON value, so
+  `$extensions: { "com.radicool.throughline": "text" }` is **conformant input**
+  this tool did not handle — not malformed input. It died on the `in` operator
+  with a bare `TypeError` naming no token, no path and no value, alone among this
+  module's diagnostics. It now names the token and the offending value, and says
+  what shape it expected. Three read sites shared the defect; the issue found
+  two.
 - **A token dropped for having no native form is now named, not just counted.**
   The report said "3 source token(s) had no matching emitted symbol" and stopped
   there. It now names them. On a real system those three turn out to be a

--- a/references/native-adapter-config.md
+++ b/references/native-adapter-config.md
@@ -55,6 +55,7 @@ import { readFileSync } from 'node:fs';
 import {
   flattenDtcg,
   flattenPipelineTypes,
+  extNamespace,
   resolveValue,
   findModeCollisions,
   TEXT_UNIT_NAMES,
@@ -403,6 +404,9 @@ function classifyTextUnits(node, types, prefix = []) {
       types[path.join('.')] === 'dimension' &&
       TEXT_ROLE_UNIT.test(String(val.$value).trim())
     ) {
+      // extNamespace throws with the token path if the source authored either
+      // level as a primitive — legal DTCG this module does not handle (#62).
+      extNamespace(val, path.join('.'));
       val.$extensions ??= {};
       val.$extensions[EXT_NS] ??= {};
       const ns = val.$extensions[EXT_NS];
@@ -447,6 +451,7 @@ function applyTextRoleGraph(node, typographic, types) {
     if (!target || typeof target !== 'object' || !('$value' in target)) continue;
     if (types[path] !== 'dimension') continue;
     if (!TEXT_ROLE_UNIT.test(String(target.$value).trim())) continue;
+    extNamespace(target, path);
     target.$extensions ??= {};
     target.$extensions[EXT_NS] ??= {};
     const ns = target.$extensions[EXT_NS];

--- a/scripts/lib/dtcg.mjs
+++ b/scripts/lib/dtcg.mjs
@@ -18,6 +18,42 @@ export const TEXT_UNIT_NAMES = new Set(['fontSize', 'letterSpacing', 'lineHeight
 export const TEXT_ROLE_UNIT = /^-?(?:\d+(?:\.\d+)?|\.\d+)(?:px|rem|em)$/;
 export const EXT_NS = 'com.radicool.throughline';
 
+// Read this project's $extensions namespace off a node, refusing a shape that
+// cannot hold one.
+//
+// A DTCG $extensions namespace key may hold ANY JSON value, so a source that
+// authored ours as a string is CONFORMANT input this module does not handle —
+// not malformed input. That distinction is why it gets a diagnostic rather than
+// a shrug: the module's contract is that it consumes conformant DTCG.
+//
+// Before #62 the three places that read this namespace all hit the `in`
+// operator on a primitive and threw a bare TypeError naming no token, no path
+// and no value — out of step with every other diagnostic here. nativeSources
+// names the colliding path and both files; the hoist-collision throw names both
+// paths and the value it would overwrite; nativePlatform names the unknown
+// platform and the expected set.
+export function extNamespace(node, path) {
+  const ext = node.$extensions;
+  if (ext === undefined) return undefined;
+  if (!isPlainObject(ext)) {
+    throw new Error(
+      `token "${path}" has a $extensions that is ${JSON.stringify(ext)}, not an object.\n` +
+        'DTCG 5.4 makes $extensions a map of namespace keys. Remove it, or give it the shape ' +
+        `{ "${EXT_NS}": { "nativeUnit": "text" } }.`,
+    );
+  }
+  const ns = ext[EXT_NS];
+  if (ns === undefined) return undefined;
+  if (!isPlainObject(ns)) {
+    throw new Error(
+      `token "${path}" has $extensions["${EXT_NS}"] set to ${JSON.stringify(ns)}, not an object.\n` +
+        `The namespace holds named settings, so a bare value cannot be read. Write ` +
+        `{ "nativeUnit": ${JSON.stringify(ns)} } if that is the setting you meant.`,
+    );
+  }
+  return ns;
+}
+
 // Flatten nested DTCG groups into { "dot.path": rawValue }. Skips $-prefixed meta keys.
 //
 // A node carrying BOTH a $value and children yields its own value AND is descended
@@ -278,7 +314,7 @@ export function textRoleGraph(dict) {
         types[dotted] === 'dimension' &&
         TEXT_ROLE_UNIT.test(String(val.$value).trim()) &&
         !referrers.has(dotted) &&
-        !('nativeUnit' in (val.$extensions?.[EXT_NS] ?? {})) &&
+        !('nativeUnit' in (extNamespace(val, dotted) ?? {})) &&
         inferredGroups.has(group)
       ) {
         unreferencedSiblings.push({ path: dotted, group });

--- a/scripts/lib/native-literal.mjs
+++ b/scripts/lib/native-literal.mjs
@@ -64,8 +64,28 @@ export const GRAMMAR = {
 // `var` are valid identifiers, and `color-mix` has a rescue in sd-native.mjs
 // that merely did not match this variant. So they must reach the output and
 // fail loudly under no-foreign-syntax, never be silently dropped by a filter.
-// Kept here, beside the grammar, so the build and the gate cannot drift apart.
-export const CSS_CONSTRUCT = /^(?:color-mix|calc|var)\s*\(/;
+// Kept here, beside the grammar, so the build and the gate cannot drift apart —
+// which until #57 was a promise this file made and did not keep. The gate
+// defined its own independent copy of the same alternation, so adding a fourth
+// name here would have taught the filter to keep a construct the gate had never
+// been taught to name. One list now, two anchorings derived from it.
+//
+// The BUILD anchors: only a construct that LEADS the value is exempt from the
+// output filter, because only then is the whole value the unimplemented rescue.
+// The GATE does not anchor: it names the construct wherever it appears.
+//
+// The asymmetry is deliberate and it is a stated limit, not a closed class.
+// `rgba(var(--brand), 0.5)` is dropped by the filter rather than kept, because
+// the module cannot tell an unimplemented rescue nested inside a rescuable
+// function from one nested inside `linear-gradient(...)`, which has no native
+// form at any depth. Closing that needs a notion of which outer functions are
+// rescuable, which does not exist here. What #57 does instead is make the drop
+// NAMED rather than counted — see the unemitted-token report in
+// validate-token-output.mjs.
+export const CSS_CONSTRUCT_NAMES = ['color-mix', 'calc', 'var'];
+const CSS_CONSTRUCT_ALT = CSS_CONSTRUCT_NAMES.join('|');
+export const CSS_CONSTRUCT = new RegExp(`^(?:${CSS_CONSTRUCT_ALT})\\s*\\(`);
+export const CSS_CONSTRUCT_ANYWHERE = new RegExp(`(?:${CSS_CONSTRUCT_ALT})\\s*\\(`);
 
 export function parseLiteral(value, grammar = {}) {
   const s = String(value);

--- a/scripts/lib/sd-native.mjs
+++ b/scripts/lib/sd-native.mjs
@@ -13,6 +13,7 @@ import { readFileSync } from 'node:fs';
 import {
   flattenDtcg,
   flattenPipelineTypes,
+  extNamespace,
   resolveValue,
   findModeCollisions,
   TEXT_UNIT_NAMES,
@@ -334,6 +335,9 @@ function classifyTextUnits(node, types, prefix = []) {
       types[path.join('.')] === 'dimension' &&
       TEXT_ROLE_UNIT.test(String(val.$value).trim())
     ) {
+      // extNamespace throws with the token path if the source authored either
+      // level as a primitive — legal DTCG this module does not handle (#62).
+      extNamespace(val, path.join('.'));
       val.$extensions ??= {};
       val.$extensions[EXT_NS] ??= {};
       const ns = val.$extensions[EXT_NS];
@@ -378,6 +382,7 @@ function applyTextRoleGraph(node, typographic, types) {
     if (!target || typeof target !== 'object' || !('$value' in target)) continue;
     if (types[path] !== 'dimension') continue;
     if (!TEXT_ROLE_UNIT.test(String(target.$value).trim())) continue;
+    extNamespace(target, path);
     target.$extensions ??= {};
     target.$extensions[EXT_NS] ??= {};
     const ns = target.$extensions[EXT_NS];

--- a/scripts/lib/sd-native.test.mjs
+++ b/scripts/lib/sd-native.test.mjs
@@ -1171,6 +1171,34 @@ test('preprocess honours a nativeUnit the source already set', () => {
   assert.equal(roleOf(out.t.size), 'text');
 });
 
+// #62. A $extensions namespace key may hold ANY JSON value, so this is
+// conformant DTCG the module does not handle — not malformed input. It used to
+// die on the `in` operator with a bare TypeError naming no token, no path and no
+// value, alone among this module's diagnostics.
+test('a primitive in our $extensions namespace names the token', () => {
+  assert.throws(
+    () => preprocess({ t: { fontSize: { $value: '30px', $type: 'dimension', $extensions: { [EXT_NS]: 'text' } } } }),
+    (err) => {
+      assert.ok(!(err instanceof TypeError), 'not a bare TypeError');
+      assert.match(err.message, /t\.fontSize/);
+      assert.match(err.message, /"text"/, 'and the offending value');
+      return true;
+    },
+  );
+});
+
+test('a primitive $extensions itself names the token', () => {
+  assert.throws(
+    () => preprocess({ t: { fontSize: { $value: '30px', $type: 'dimension', $extensions: 'x' } } }),
+    (err) => {
+      assert.ok(!(err instanceof TypeError));
+      assert.match(err.message, /t\.fontSize/);
+      assert.match(err.message, /DTCG 5\.4/, 'and says what the shape should be');
+      return true;
+    },
+  );
+});
+
 test('preprocess leaves an unrelated $extensions namespace untouched', () => {
   const out = preprocess({
     t: {

--- a/scripts/validate-token-output.mjs
+++ b/scripts/validate-token-output.mjs
@@ -18,7 +18,7 @@ import {
   mergeDtcg,
   EXT_NS,
 } from './lib/dtcg.mjs';
-import { parseLiteral, isValidLiteral, GRAMMAR } from './lib/native-literal.mjs';
+import { parseLiteral, isValidLiteral, GRAMMAR, CSS_CONSTRUCT_ANYWHERE } from './lib/native-literal.mjs';
 
 // Re-exported so consumers (and the test file) keep one import surface.
 export { flattenDtcg, flattenDtcgTypes, resolveValue, findModeCollisions };
@@ -131,7 +131,21 @@ export function expectedMagnitude(sourceValue) {
 // "var(" (e.g. a $type: string value describing CSS) would also match. The
 // isValidLiteral gate below is what tells those apart: a value the grammar
 // accepts as a literal is not foreign syntax, whatever text it contains.
-const FOREIGN = /(?:color-mix|calc|var)\s*\(/;
+//
+// That holds for Swift. It does NOT hold unconditionally for Kotlin (#57):
+// `${...}` inside a Kotlin string is executable code, and the grammar accepts an
+// unescaped `$`, so `"${calc(1)}"` parses as a valid literal and is exempted
+// here. The exemption also covers a small set of values that are well-formed
+// literals AND named-foreign — calc(2), var(1), and on Kotlin calc(2.dp) — which
+// are kept, pass every rule, and do not compile. None is producible CSS, and
+// this was shipped knowingly when the gate was added; it is written down so the
+// next person meets it as a decision rather than a surprise.
+// Imported, not redeclared (#57). This was an independent copy of the same
+// alternation, while native-literal.mjs's comment promised the build and the
+// gate could not drift apart. Adding a fourth construct name there would have
+// taught the output filter to keep something this rule had never been taught to
+// name — recreating exactly the unreachable-rule defect #56 fixed.
+const FOREIGN = CSS_CONSTRUCT_ANYWHERE;
 const BARE_UNIT = /^-?(?:\d+(?:\.\d+)?|\.\d+)(?:px|rem|em|%)$/;
 
 // #52. A unitless value is a ratio, not a measurement: DTCG 8.2.1 requires a
@@ -284,7 +298,13 @@ export function validate({ sources, output, platform, minMatch = 0.5 }) {
     if (expected.skip) continue;
     const actual = magnitudeOf(value);
     if (actual === null) {
-      failures.push({ rule: 'unverifiable-dimension', symbol, token: path, source, emitted: value });
+      // no-foreign-syntax already explains why the magnitude could not be read,
+      // and names the actual cause. "The token was never actually compared" beside
+      // it is a red herring pointing at the symptom (#57). Same suppression the
+      // three literal rules already apply to each other.
+      if (!foreign) {
+        failures.push({ rule: 'unverifiable-dimension', symbol, token: path, source, emitted: value });
+      }
       continue;
     }
     if (Math.abs(actual - expected.magnitude) > 0.001) {
@@ -337,11 +357,18 @@ export function validate({ sources, output, platform, minMatch = 0.5 }) {
     matchRate >= minMatch;
 
   const unparsedLines = countUnparsedLines(output, DECL[platform]);
+  // NAMED, not just counted (#57). A token with no native form is filtered out
+  // of native output, and a nested construct like rgba(var(--brand), 0.5) is one
+  // of them — the filter's exemption is anchored, deliberately, because the
+  // module cannot tell a rescuable outer function from linear-gradient(). Before
+  // this the only trace such a token left was a number, which is the same
+  // silence this release exists to remove everywhere else.
   const emittedKeys = new Set(decls.map((d) => normalizeKey(d.symbol)));
-  let unemittedTokens = 0;
-  for (const key of byKey.keys()) if (!emittedKeys.has(key)) unemittedTokens += 1;
+  const unemittedPaths = [];
+  for (const [key, path] of byKey) if (!emittedKeys.has(key)) unemittedPaths.push(path);
+  const unemittedTokens = unemittedPaths.length;
 
-  return { total: decls.length, matched, matchRate, failures, advisories, collisions, normalizationCollisions, minMatch, ok, unparsedLines, unemittedTokens };
+  return { total: decls.length, matched, matchRate, failures, advisories, collisions, normalizationCollisions, minMatch, ok, unparsedLines, unemittedTokens, unemittedPaths };
 }
 
 export function formatReport(r) {
@@ -431,7 +458,13 @@ export function formatReport(r) {
     }
   }
   if (r.unemittedTokens) {
-    lines.push(`\n${r.unemittedTokens} source token(s) had no matching emitted symbol.`);
+    const paths = r.unemittedPaths ?? [];
+    const shown = paths.slice(0, 10).join(', ');
+    const more = paths.length > 10 ? `, ...and ${paths.length - 10} more` : '';
+    lines.push(
+      `\n${r.unemittedTokens} source token(s) had no matching emitted symbol${paths.length ? `: ${shown}${more}` : ''}.` +
+        ' A value with no native form is filtered out of native output rather than emitted broken — a CSS construct nested inside another function is the common case.',
+    );
   }
   return lines;
 }

--- a/scripts/validate-token-output.test.mjs
+++ b/scripts/validate-token-output.test.mjs
@@ -328,6 +328,54 @@ test('unitless-dimension sees the hoist carry', () => {
 // $root is the sanctioned spelling. Advisory and never gating: every
 // Figma-derived source has dozens, so failing would make the gate useless on day
 // one for exactly the people this targets.
+// #57.1. native-literal.mjs promised the build and the gate could not drift
+// apart, and the gate held an independent copy of the same alternation. The
+// promise is now enforced: one list, two anchorings derived from it, so adding a
+// construct name cannot teach the filter something the gate does not know.
+test('the gate and the build read one list of CSS construct names', () => {
+  assert.equal(
+    CSS_CONSTRUCT_ANYWHERE.source.includes(CSS_CONSTRUCT_NAMES.join('|')),
+    true,
+    'the unanchored form is built from the shared list',
+  );
+  assert.equal(CSS_CONSTRUCT.source, `^(?:${CSS_CONSTRUCT_NAMES.join('|')})\\s*\\(`);
+});
+
+// #57.2. The build's exemption is anchored and the gate's is not, deliberately:
+// a nested construct cannot be told apart from one inside linear-gradient(),
+// which has no native form at any depth. So it is dropped — but NAMED, which is
+// what changed. Before, the only trace was a count.
+test('a token dropped for having no native form is named, not just counted', () => {
+  const sources = [{ file: 't.json', dtcg: {
+    brand: {
+      lead: { $value: 'color-mix(in srgb, #fff 50%, #000)', $type: 'color' },
+      nested: { $value: 'rgba(var(--brand), 0.5)', $type: 'color' },
+    },
+  } }];
+  const r = validate({
+    sources,
+    output: 'object Tokens {\n  val brandLead = color-mix(in srgb, #fff 50%, #000)\n}\n',
+    platform: 'android-kotlin',
+    minMatch: 0,
+  });
+  assert.deepEqual(r.unemittedPaths, ['brand.nested']);
+  assert.match(formatReport(r).join('\n'), /brand\.nested/);
+});
+
+// #57.4. no-foreign-syntax already names the cause. "The token was never
+// actually compared" beside it points at the symptom and reads as a second,
+// unrelated defect.
+test('a foreign-syntax value does not also report unverifiable-dimension', () => {
+  const sources = [{ file: 't.json', dtcg: { space: { four: { $value: '1rem', $type: 'dimension' } } } }];
+  const r = validate({
+    sources,
+    output: 'object Tokens {\n  val spaceFour = calc(1rem + 2px)\n}\n',
+    platform: 'android-kotlin',
+    minMatch: 0,
+  });
+  assert.deepEqual(r.failures.map((f) => f.rule), ['no-foreign-syntax']);
+});
+
 test('a dual node is reported as non-conforming, without failing the run', () => {
   const sources = [{ file: 't.json', dtcg: {
     text: { sm: { $value: '14px', $type: 'dimension', lineHeight: { $value: '20px', $type: 'dimension' } } },
@@ -538,6 +586,7 @@ test('a clean matched run reports neither unparsedLines nor unemittedTokens', ()
 });
 
 import { formatReport } from './validate-token-output.mjs';
+import { CSS_CONSTRUCT, CSS_CONSTRUCT_ANYWHERE, CSS_CONSTRUCT_NAMES } from './lib/native-literal.mjs';
 import { execFileSync } from 'node:child_process';
 import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';


### PR DESCRIPTION
Closes #57, closes #62. The native tail I listed and then didn't come back to — caught by the question *"are you sure there is not more native app work?"*. There was.

## #57.1 — a comment promising a guarantee the code didn't provide

`native-literal.mjs` said `CSS_CONSTRUCT` was kept beside the grammar *"so the build and the gate cannot drift apart"*. `validate-token-output.mjs` defined its own independent `FOREIGN` with the same alternation and imported nothing. Adding a fourth construct name to either would have taught the output filter to keep something the gate had never been taught to name — recreating exactly the unreachable-rule defect #56 fixed.

One list now: `CSS_CONSTRUCT_NAMES`, with the build's anchored form and the gate's unanchored form derived from it.

## #57.2 — a nested construct was dropped, and the only trace was a number

```
val brandLead = color-mix(...)     kept, and NAMED by no-foreign-syntax
rgba(var(--brand), 0.5)            dropped → "1 source token(s)"
```

The anchoring asymmetry **stays** and is now written down rather than implied: a construct nested inside another function can't be told apart from one inside `linear-gradient(...)`, which has no native form at any depth. Closing that needs a notion of which outer functions are rescuable, which doesn't exist here.

What changed is the silence — **unemitted tokens are named**. On the real source the three anonymous drops turn out to be `gradient.brand.primary`, `spacing.grid.containerMax` and `typography.letterSpacing.widest`. None guessable from a count, and this fixes the silence for every drop cause, not just this one.

## #57.3 / #57.4

The Kotlin `${...}` caveat is recorded (it's executable code, the grammar accepts an unescaped `$`, so `"${calc(1)}"` is exempt), along with the small set of values that are both well-formed literals *and* named-foreign. Shipped knowingly — now written down so the next person meets it as a decision.

A foreign-syntax value no longer also reports `unverifiable-dimension`; that message points at the symptom beside a rule that already named the cause.

## #62 — a primitive `$extensions` named nothing

```
before  TypeError: Cannot use 'in' operator to search for 'nativeUnit' in text
after   token "t.fontSize" has $extensions["com.radicool.throughline"] set to
        "text", not an object. ... Write { "nativeUnit": "text" } if that is the
        setting you meant.
```

This is **conformant** DTCG the module didn't handle — a namespace key may hold any JSON value — not malformed input, which is what makes it worth a diagnostic. It was alone among this module's failures in naming nothing.

**Three read sites shared the defect; the issue found two.** `textRoleGraph`'s walk does `'nativeUnit' in (val.$extensions?.[EXT_NS] ?? {})`, and `?? {}` doesn't replace a string — so the advisory pass threw on the same input. All three now go through one reader.

## Verification

478 pass. Zygarden `Tokens.kt` and `Tokens.swift` byte-identical, exit 0, 208/208.