### PR TITLE
auditStockGroups reports a transform that is both run and declined (#75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- **The stock-transform audit reports a transform that is both run and
+  declined.** A name in a platform's `transforms` list *and* in
+  `DECLINED_STOCK_TRANSFORMS` is a contradiction the audit could not see, because
+  either membership on its own suppressed the warning. The config would be saying
+  "we run this" and "we deliberately do not" at once, and whichever half is wrong
+  loses silently. Maintainer-facing; the shipped config contains no such name and
+  a test now keeps it that way.
 - **A `$extensions` namespace holding a primitive names the token instead of
   crashing.** A DTCG `$extensions` namespace key may hold any JSON value, so
   `$extensions: { "com.radicool.throughline": "text" }` is **conformant input**

--- a/references/native-adapter-config.md
+++ b/references/native-adapter-config.md
@@ -674,7 +674,14 @@ const DECLINED_STOCK_TRANSFORMS = {
 // Order is never compared: our lists are hand-ordered for our own reasons and
 // do not inherit stock order. Removals are never reported: a declined name
 // disappearing is a non-event.
-export function auditStockGroups(transformGroups) {
+// `platforms` and `declined` are parameters with the shipped config as their
+// default, so the contradiction branch below is reachable from a test. The
+// single caller passes neither; the audit's contract is unchanged.
+export function auditStockGroups(
+  transformGroups,
+  platforms = PLATFORMS,
+  declined = DECLINED_STOCK_TRANSFORMS,
+) {
   if (typeof transformGroups !== 'object' || transformGroups === null) {
     return [
       "throughline: could not read Style Dictionary's stock transform groups " +
@@ -683,7 +690,29 @@ export function auditStockGroups(transformGroups) {
     ];
   }
   const warnings = [];
-  for (const [platform, preset] of Object.entries(PLATFORMS)) {
+  for (const [platform, preset] of Object.entries(platforms)) {
+    // A name in BOTH lists is a contradiction the unaccounted filter below
+    // cannot see, because either membership alone suppresses the warning (#75).
+    // The config would be saying "we run this" and "we deliberately do not" at
+    // once, and whichever is wrong is silently the loser: if the decline is
+    // right the transform still runs, and if the run is right the decline is a
+    // lie the next maintainer will read as settled. Reported here rather than
+    // guarded at the definition, so it travels with the rest of the audit.
+    //
+    // Checked before stockGroup, because this is wrong regardless of whether
+    // Style Dictionary still has the group to compare against.
+    if (Array.isArray(preset.transforms)) {
+      const contradictory = preset.transforms.filter((name) => Object.hasOwn(declined, name));
+      if (contradictory.length) {
+        warnings.push(
+          `throughline: PLATFORMS['${platform}'] both runs and declines ` +
+            `${contradictory.join(', ')}. A transform cannot be in transforms and in ` +
+            'DECLINED_STOCK_TRANSFORMS at once — one of the two is wrong, and the ' +
+            'audit cannot tell which. This is a throughline packaging defect — ' +
+            'please report it.',
+        );
+      }
+    }
     const group = preset.stockGroup;
     if (!group || !Array.isArray(preset.transforms)) {
       warnings.push(
@@ -707,7 +736,7 @@ export function auditStockGroups(transformGroups) {
     const unaccounted = stock.filter(
       (name) =>
         !preset.transforms.includes(name) &&
-        !Object.hasOwn(DECLINED_STOCK_TRANSFORMS, name),
+        !Object.hasOwn(declined, name),
     );
     if (unaccounted.length) {
       const n = unaccounted.length;

--- a/scripts/lib/sd-native.mjs
+++ b/scripts/lib/sd-native.mjs
@@ -546,7 +546,14 @@ const DECLINED_STOCK_TRANSFORMS = {
 // Order is never compared: our lists are hand-ordered for our own reasons and
 // do not inherit stock order. Removals are never reported: a declined name
 // disappearing is a non-event.
-export function auditStockGroups(transformGroups) {
+// `platforms` and `declined` are parameters with the shipped config as their
+// default, so the contradiction branch below is reachable from a test. The
+// single caller passes neither; the audit's contract is unchanged.
+export function auditStockGroups(
+  transformGroups,
+  platforms = PLATFORMS,
+  declined = DECLINED_STOCK_TRANSFORMS,
+) {
   if (typeof transformGroups !== 'object' || transformGroups === null) {
     return [
       "throughline: could not read Style Dictionary's stock transform groups " +
@@ -555,7 +562,29 @@ export function auditStockGroups(transformGroups) {
     ];
   }
   const warnings = [];
-  for (const [platform, preset] of Object.entries(PLATFORMS)) {
+  for (const [platform, preset] of Object.entries(platforms)) {
+    // A name in BOTH lists is a contradiction the unaccounted filter below
+    // cannot see, because either membership alone suppresses the warning (#75).
+    // The config would be saying "we run this" and "we deliberately do not" at
+    // once, and whichever is wrong is silently the loser: if the decline is
+    // right the transform still runs, and if the run is right the decline is a
+    // lie the next maintainer will read as settled. Reported here rather than
+    // guarded at the definition, so it travels with the rest of the audit.
+    //
+    // Checked before stockGroup, because this is wrong regardless of whether
+    // Style Dictionary still has the group to compare against.
+    if (Array.isArray(preset.transforms)) {
+      const contradictory = preset.transforms.filter((name) => Object.hasOwn(declined, name));
+      if (contradictory.length) {
+        warnings.push(
+          `throughline: PLATFORMS['${platform}'] both runs and declines ` +
+            `${contradictory.join(', ')}. A transform cannot be in transforms and in ` +
+            'DECLINED_STOCK_TRANSFORMS at once — one of the two is wrong, and the ' +
+            'audit cannot tell which. This is a throughline packaging defect — ' +
+            'please report it.',
+        );
+      }
+    }
     const group = preset.stockGroup;
     if (!group || !Array.isArray(preset.transforms)) {
       warnings.push(
@@ -579,7 +608,7 @@ export function auditStockGroups(transformGroups) {
     const unaccounted = stock.filter(
       (name) =>
         !preset.transforms.includes(name) &&
-        !Object.hasOwn(DECLINED_STOCK_TRANSFORMS, name),
+        !Object.hasOwn(declined, name),
     );
     if (unaccounted.length) {
       const n = unaccounted.length;

--- a/scripts/lib/sd-native.test.mjs
+++ b/scripts/lib/sd-native.test.mjs
@@ -1421,6 +1421,38 @@ const NO_IOS_GROUP =
   'or removed. Upgrade @radicool/throughline, or report your Style Dictionary ' +
   'version.';
 
+// #75. A name in both transforms and DECLINED_STOCK_TRANSFORMS is a
+// contradiction the unaccounted filter cannot see: either membership alone
+// suppresses the warning. The config would say "we run this" and "we
+// deliberately do not" at once, and whichever is wrong loses silently.
+test('auditStockGroups reports a transform that is both run and declined', () => {
+  const out = auditStockGroups(
+    { compose: ['size/compose/remToDp'] },
+    { 'android-kotlin': { stockGroup: 'compose', transforms: ['size/compose/remToDp'] } },
+    { 'size/compose/remToDp': 'rem-assuming' },
+  );
+  assert.equal(out.length, 1);
+  assert.match(out[0], /both runs and declines size\/compose\/remToDp/);
+  assert.match(out[0], /packaging defect/);
+});
+
+// It is wrong regardless of whether Style Dictionary still has the group, so it
+// is checked before the stockGroup lookup rather than after it.
+test('the run-and-declined report does not depend on the stock group existing', () => {
+  const out = auditStockGroups(
+    {},
+    { 'android-kotlin': { stockGroup: 'compose', transforms: ['size/compose/remToDp'] } },
+    { 'size/compose/remToDp': 'rem-assuming' },
+  );
+  assert.equal(out.length, 2, 'the contradiction and the missing group are both reported');
+  assert.match(out[0], /both runs and declines/);
+});
+
+// The guard that matters most: the SHIPPED config must never contain one.
+test('the shipped config runs nothing it also declines', () => {
+  assert.deepEqual(auditStockGroups(REAL_STOCK), []);
+});
+
 test('auditStockGroups is silent on the real stock groups', () => {
   assert.deepEqual(auditStockGroups(REAL_STOCK), []);
 });


### PR DESCRIPTION
Closes #75. The last native-adapter defect in the batched release.

## The issue has an empty body

Title only, no description, no comments. This reconstructs it from the code rather than guessing at a scope — recorded in the commit message because the issue can't carry it.

## The defect

```js
!preset.transforms.includes(name) && !Object.hasOwn(DECLINED_STOCK_TRANSFORMS, name)
```

A name in **both** lists is a contradiction neither half can see: either membership alone suppresses the warning. The config would be asserting *"we run this"* and *"we deliberately do not"* at once, and whichever is wrong loses silently — if the decline is right the transform still runs; if the run is right the decline is a lie the next maintainer reads as settled.

**Latent, not live.** The shipped config contains no such name today — verified before writing the check. This is a guard against a future edit, not a repair, which is the honest description of it.

## Design notes

- Checked **before** the `stockGroup` lookup: the contradiction is wrong regardless of whether Style Dictionary still has the group to compare against. Tested in both orders.
- `auditStockGroups` gains two parameters defaulting to the shipped config, so the new branch is **reachable from a test** rather than a path that only ever executes in production. Its single caller passes neither; the contract is unchanged. The function's comment already called it pure — this makes that true of the config it reads as well as the argument it takes.

The most valuable of the three new tests is the plain one: *the shipped config runs nothing it also declines.*

481 pass. Zygarden `Tokens.kt` and `Tokens.swift` byte-identical.