### PR TITLE
refactor: one source-tree walker, shared by every repo scanner (#39)

### DIFF
--- a/adapters/codex/prompts/token-crosswalk-builder.md
+++ b/adapters/codex/prompts/token-crosswalk-builder.md
@@ -67,6 +67,8 @@ Copy these from `.throughline/scripts/` into the user's repo **verbatim**
 - `lib/crosswalk.mjs` → `packages/tokens/scripts/lib/crosswalk.mjs`
 - `lib/dtcg.mjs` → `packages/tokens/scripts/lib/dtcg.mjs` (required by
   `validate-crosswalk.mjs` — copying the validator without it breaks the gate at import)
+- `lib/source-scan.mjs` → `packages/tokens/scripts/lib/source-scan.mjs` (required by
+  `guard-token-removal.mjs` — copying the guard without it breaks it at import)
 - `validate-crosswalk.mjs` → `packages/tokens/scripts/validate-crosswalk.mjs`
 - `build-reverse-index.mjs` → `packages/tokens/scripts/build-reverse-index.mjs`
 - `guard-token-removal.mjs` → `packages/tokens/scripts/guard-token-removal.mjs`

--- a/adapters/cursor/.cursor/rules/token-crosswalk-builder.mdc
+++ b/adapters/cursor/.cursor/rules/token-crosswalk-builder.mdc
@@ -71,6 +71,8 @@ Copy these from `.throughline/scripts/` into the user's repo **verbatim**
 - `lib/crosswalk.mjs` → `packages/tokens/scripts/lib/crosswalk.mjs`
 - `lib/dtcg.mjs` → `packages/tokens/scripts/lib/dtcg.mjs` (required by
   `validate-crosswalk.mjs` — copying the validator without it breaks the gate at import)
+- `lib/source-scan.mjs` → `packages/tokens/scripts/lib/source-scan.mjs` (required by
+  `guard-token-removal.mjs` — copying the guard without it breaks it at import)
 - `validate-crosswalk.mjs` → `packages/tokens/scripts/validate-crosswalk.mjs`
 - `build-reverse-index.mjs` → `packages/tokens/scripts/build-reverse-index.mjs`
 - `guard-token-removal.mjs` → `packages/tokens/scripts/guard-token-removal.mjs`

--- a/adapters/generic/skills/token-crosswalk-builder/SKILL.md
+++ b/adapters/generic/skills/token-crosswalk-builder/SKILL.md
@@ -67,6 +67,8 @@ Copy these from `.throughline/scripts/` into the user's repo **verbatim**
 - `lib/crosswalk.mjs` → `packages/tokens/scripts/lib/crosswalk.mjs`
 - `lib/dtcg.mjs` → `packages/tokens/scripts/lib/dtcg.mjs` (required by
   `validate-crosswalk.mjs` — copying the validator without it breaks the gate at import)
+- `lib/source-scan.mjs` → `packages/tokens/scripts/lib/source-scan.mjs` (required by
+  `guard-token-removal.mjs` — copying the guard without it breaks it at import)
 - `validate-crosswalk.mjs` → `packages/tokens/scripts/validate-crosswalk.mjs`
 - `build-reverse-index.mjs` → `packages/tokens/scripts/build-reverse-index.mjs`
 - `guard-token-removal.mjs` → `packages/tokens/scripts/guard-token-removal.mjs`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,6 +11,7 @@ tested here; copied verbatim by `token-crosswalk-builder` into the user's
 | `build-reverse-index.mjs` | Emit a `codeToken -> newToken` map from the crosswalk to semi-automate SCSS/Tailwind swaps. | `tokens:reverse-index` |
 | `guard-token-removal.mjs` | Grep `.ts/.tsx` (minus generated + tests) for about-to-be-deleted symbols; blocks cleanup until zero references remain. | run during the cleanup phase |
 | `validate-token-output.mjs` | Assert generated native token output matches its DTCG source: authored-unit fidelity, no leaked CSS syntax, no bare unit literals, no mode collisions. Fails when no emitted symbol matches a source token, and reports match rate, unparsed lines, and unemitted tokens on every run. | `tokens:validate-output` |
+| `lib/source-scan.mjs` | Shared source-tree walker (`walk`, `DEFAULT_EXCLUDES`, `SOURCE_EXT`) plus `normalizeName`, the display-name-to-code-identifier fold. Every gate that scans a consumer's repo reads it from here rather than carrying its own copy. | copied alongside `guard-token-removal.mjs` |
 | `lib/crosswalk.mjs` | Shared loader + structural validation for `crosswalk.json` (used by the validator and reverse-index). | copied alongside |
 | `lib/dtcg.mjs` | Shared DTCG flatten + `{alias}` resolution. Dual-node aware: a node carrying both a `$value` and children yields its own value **and** is descended into. Used by `validate-crosswalk.mjs` and `validate-token-output.mjs`. | copied alongside both |
 | `lib/sd-native.mjs` | The Style Dictionary native configuration as code: unit-aware dimension transforms, `color-mix` computation, dual-node preprocessing, platform assembly, and a per-mode source guard. Style Dictionary is a parameter, never an import. | copied alongside `validate-token-output.mjs` |
@@ -60,7 +61,8 @@ conflict, or remaining reference), `2` bad CLI arguments.
 ## How the skill installs these
 
 `token-crosswalk-builder` copies `lib/crosswalk.mjs`, `lib/dtcg.mjs`,
-`validate-crosswalk.mjs`, `build-reverse-index.mjs`, `guard-token-removal.mjs`, and
+`lib/source-scan.mjs`, `validate-crosswalk.mjs`, `build-reverse-index.mjs`,
+`guard-token-removal.mjs`, and
 `crosswalk.schema.json` into the user's `packages/tokens/scripts/` (schema beside `crosswalk.json`), then
 wires `packages/tokens/package.json`:
 

--- a/scripts/grep-color-usage.mjs
+++ b/scripts/grep-color-usage.mjs
@@ -6,10 +6,17 @@
 // Usage:
 //   node grep-color-usage.mjs --root <dir> [--config <patterns.json>] [--out <counts.json>]
 //     patterns.json: { "<category>": { "files": "<regex>", "pattern": "<regex with g flag>" }, ... }
-import { readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
-import { join, relative } from 'node:path';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { relative } from 'node:path';
 import { parseArgs } from 'node:util';
 import { pathToFileURL } from 'node:url';
+import { walk, DEFAULT_EXCLUDES, SOURCE_EXT } from './lib/source-scan.mjs';
+
+// This script has exported `walk` and DEFAULT_EXCLUDES since it was written;
+// keep that surface intact now that both live one file over. SOURCE_EXT is not
+// re-exported because it was never exported from here — import it from
+// lib/source-scan.mjs. `walk`'s second parameter is now an options object.
+export { walk, DEFAULT_EXCLUDES };
 
 // The five categories from the case study. Each: which files it applies to, and the
 // (global) match pattern. Tuned defaults — design-system-audit may override per repo.
@@ -36,33 +43,6 @@ export const DEFAULT_CATEGORIES = {
   },
 };
 
-export const DEFAULT_EXCLUDES = [
-  /(^|\/)node_modules(\/|$)/,
-  /(^|\/)generated(\/|$)/,
-  /\.generated\./,
-  /\.test\./,
-  /\.spec\./,
-  /(^|\/)__tests__(\/|$)/,
-  /(^|\/)dist(\/|$)/,
-  /(^|\/)\.next(\/|$)/,
-];
-
-// Source extensions worth opening at all (union of every category's `files`).
-const SOURCE_EXT = /\.(scss|sass|css|tsx?|jsx?|mjs|cjs|vue|svelte|html|svg)$/;
-
-export function* walk(root, excludes = DEFAULT_EXCLUDES) {
-  for (const entry of readdirSync(root)) {
-    const full = join(root, entry);
-    if (excludes.some((re) => re.test(full))) continue;
-    const st = statSync(full);
-    if (st.isDirectory()) {
-      yield* walk(full, excludes);
-    } else if (SOURCE_EXT.test(full)) {
-      yield full;
-    }
-  }
-}
-
 // Count matches per category in one file. A category contributes only if its `files`
 // regex matches this path. Returns { <category>: count } for every category key.
 export function scanFile(path, categories) {
@@ -82,7 +62,7 @@ export function grepColorUsage(root, categories = DEFAULT_CATEGORIES, excludes =
   const counts = {};
   for (const key of Object.keys(categories)) counts[key] = 0;
   const byFile = [];
-  for (const file of walk(root, excludes)) {
+  for (const file of walk(root, { excludes, fileFilter: SOURCE_EXT })) {
     const fileCounts = scanFile(file, categories);
     const total = Object.values(fileCounts).reduce((a, b) => a + b, 0);
     if (total > 0) {

--- a/scripts/guard-token-removal.mjs
+++ b/scripts/guard-token-removal.mjs
@@ -7,34 +7,16 @@
 // Usage:
 //   node guard-token-removal.mjs --root <dir> --symbols <symbols.txt>
 //     symbols file: one symbol per line (blank lines and # comments ignored)
-import { readFileSync, readdirSync, statSync } from 'node:fs';
-import { join, relative } from 'node:path';
+import { readFileSync } from 'node:fs';
+import { relative } from 'node:path';
 import { parseArgs } from 'node:util';
 import { pathToFileURL } from 'node:url';
+import { walk, DEFAULT_EXCLUDES } from './lib/source-scan.mjs';
 
-export const DEFAULT_EXCLUDES = [
-  /(^|\/)node_modules(\/|$)/,
-  /(^|\/)generated(\/|$)/,
-  /\.generated\./,
-  /\.test\./,
-  /\.spec\./,
-  /(^|\/)__tests__(\/|$)/,
-  /(^|\/)dist(\/|$)/,
-  /(^|\/)\.next(\/|$)/,
-];
-
-export function* walk(root, excludes = DEFAULT_EXCLUDES) {
-  for (const entry of readdirSync(root)) {
-    const full = join(root, entry);
-    if (excludes.some((re) => re.test(full))) continue;
-    const st = statSync(full);
-    if (st.isDirectory()) {
-      yield* walk(full, excludes);
-    } else if (/\.tsx?$/.test(full)) {
-      yield full;
-    }
-  }
-}
+// This script has exported `walk` and DEFAULT_EXCLUDES since it was written;
+// keep that surface intact now that both live one file over. `walk`'s second
+// parameter is now an options object.
+export { walk, DEFAULT_EXCLUDES };
 
 export function scanFile(path, symbols) {
   const lines = readFileSync(path, 'utf8').split('\n');
@@ -51,7 +33,9 @@ export function scanFile(path, symbols) {
 
 export function guard(root, symbols, excludes = DEFAULT_EXCLUDES) {
   const findings = [];
-  for (const file of walk(root, excludes)) {
+  // .ts/.tsx is this guard's own contract, so the filter stays here rather
+  // than moving into the shared walker's default.
+  for (const file of walk(root, { excludes, fileFilter: /\.tsx?$/ })) {
     for (const hit of scanFile(file, symbols)) {
       findings.push({ file: relative(root, file), ...hit });
     }

--- a/scripts/lib/source-scan.mjs
+++ b/scripts/lib/source-scan.mjs
@@ -1,0 +1,44 @@
+// Walking a consumer's source tree, shared by every gate that scans one.
+//
+// grep-color-usage.mjs and guard-token-removal.mjs each carried their own copy
+// of this — identical excludes, and a walk that differed only in which file
+// extensions it yielded. The duplication was the shape #57 was filed for: two
+// definitions of one rule, agreeing today, with nothing keeping them in step.
+//
+// The file filter is the caller's, not a built-in: a colour scan wants
+// stylesheets and a symbol guard does not, and neither should have to fork the
+// walker to say so.
+import { readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+export const DEFAULT_EXCLUDES = [
+  /(^|\/)node_modules(\/|$)/,
+  /(^|\/)generated(\/|$)/,
+  /\.generated\./,
+  /\.test\./,
+  /\.spec\./,
+  /(^|\/)__tests__(\/|$)/,
+  /(^|\/)dist(\/|$)/,
+  /(^|\/)\.next(\/|$)/,
+];
+
+// Every text file a design system's values can hide in.
+export const SOURCE_EXT = /\.(scss|sass|css|tsx?|jsx?|mjs|cjs|vue|svelte|html|svg)$/;
+
+export function* walk(root, { excludes = DEFAULT_EXCLUDES, fileFilter = SOURCE_EXT } = {}) {
+  for (const entry of readdirSync(root)) {
+    const full = join(root, entry);
+    if (excludes.some((re) => re.test(full))) continue;
+    const st = statSync(full);
+    if (st.isDirectory()) yield* walk(full, { excludes, fileFilter });
+    else if (fileFilter.test(full)) yield full;
+  }
+}
+
+// A design system records a component's DISPLAY name — a real manifest holds
+// "Select Menu" — while the code exports <SelectMenu>. Nothing in the schema
+// says `name` is a code identifier, and nothing should be changed to make it
+// one: a display name is right for a doc surface. So the comparison normalises,
+// the same way validate-token-output.mjs already folds adapter naming
+// conventions onto each other.
+export const normalizeName = (s) => String(s).toLowerCase().replace(/[^a-z0-9]/g, '');

--- a/scripts/lib/source-scan.test.mjs
+++ b/scripts/lib/source-scan.test.mjs
@@ -1,0 +1,46 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { walk, DEFAULT_EXCLUDES, SOURCE_EXT, normalizeName } from './source-scan.mjs';
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), 'scan-'));
+  mkdirSync(join(root, 'src'));
+  mkdirSync(join(root, 'node_modules'));
+  writeFileSync(join(root, 'src', 'a.tsx'), '');
+  writeFileSync(join(root, 'src', 'b.css'), '');
+  writeFileSync(join(root, 'src', 'c.md'), '');
+  writeFileSync(join(root, 'node_modules', 'd.tsx'), '');
+  return root;
+}
+
+test('walk applies the caller file filter, not a built-in one', () => {
+  const root = fixture();
+  const tsx = [...walk(root, { fileFilter: /\.tsx?$/ })].map((f) => f.split('/').pop());
+  assert.deepEqual(tsx, ['a.tsx']);
+  const src = [...walk(root, { fileFilter: SOURCE_EXT })].map((f) => f.split('/').pop()).sort();
+  assert.deepEqual(src, ['a.tsx', 'b.css']);
+});
+
+test('walk excludes node_modules by default', () => {
+  const files = [...walk(fixture(), { fileFilter: /\.tsx?$/ })];
+  assert.equal(
+    files.some((f) => f.includes('node_modules')),
+    false,
+  );
+});
+
+test('DEFAULT_EXCLUDES is one array, not two that agree today', () => {
+  assert.ok(DEFAULT_EXCLUDES.some((re) => re.test('/x/node_modules/y')));
+  assert.ok(DEFAULT_EXCLUDES.some((re) => re.test('/x/dist/y')));
+});
+
+// The display-name problem, measured: components.built holds "Select Menu"
+// while the code exports <SelectMenu>.
+test('normalizeName folds display names onto code identifiers', () => {
+  assert.equal(normalizeName('Select Menu'), normalizeName('SelectMenu'));
+  assert.equal(normalizeName('select_menu'), normalizeName('SelectMenu'));
+  assert.notEqual(normalizeName('SelectMenu'), normalizeName('SelectMenuItem'));
+});

--- a/skills/token-crosswalk-builder/SKILL.md
+++ b/skills/token-crosswalk-builder/SKILL.md
@@ -72,6 +72,8 @@ Copy these from `${CLAUDE_PLUGIN_ROOT}/scripts/` into the user's repo **verbatim
 - `lib/crosswalk.mjs` → `packages/tokens/scripts/lib/crosswalk.mjs`
 - `lib/dtcg.mjs` → `packages/tokens/scripts/lib/dtcg.mjs` (required by
   `validate-crosswalk.mjs` — copying the validator without it breaks the gate at import)
+- `lib/source-scan.mjs` → `packages/tokens/scripts/lib/source-scan.mjs` (required by
+  `guard-token-removal.mjs` — copying the guard without it breaks it at import)
 - `validate-crosswalk.mjs` → `packages/tokens/scripts/validate-crosswalk.mjs`
 - `build-reverse-index.mjs` → `packages/tokens/scripts/build-reverse-index.mjs`
 - `guard-token-removal.mjs` → `packages/tokens/scripts/guard-token-removal.mjs`


### PR DESCRIPTION
First of two PRs implementing the code adherence gate (#39). This one ships alone because it changes an exported signature in a script that installs into user repos — a different blast radius from the gate itself.

## The duplication

`grep-color-usage.mjs` and `guard-token-removal.mjs` each carried:
- a byte-identical `DEFAULT_EXCLUDES` array (8 patterns)
- a byte-identical `walk` generator, differing **only** in the file-extension test inside the loop

The adherence gate needs the same walk. It would have been the third copy — the exact shape #57 was filed for: two definitions of one rule, agreeing today, with nothing keeping them in step.

## What moved

`scripts/lib/source-scan.mjs` now exports `walk`, `DEFAULT_EXCLUDES`, `SOURCE_EXT`, `normalizeName`.

The file filter becomes the caller's option rather than a built-in — a colour scan wants stylesheets, a symbol guard does not, and neither should fork the walker to say so. `guard-token-removal` keeps its `.ts`/`.tsx` scope at its own call site, where that contract belongs.

`normalizeName` ships here rather than in the gate: it is the same fold `validate-token-output.mjs` already applies to adapter naming conventions, and it is the fix for a **measured** bug — `design-system.json` holds the display name `"Select Menu"` while the code exports `<SelectMenu>`.

## Public API change

`walk`'s second parameter is now an options object. The positional `walk(root, excludes)` is gone. Both scripts re-export `walk` and `DEFAULT_EXCLUDES`, so their own surfaces are intact.

`SOURCE_EXT` is deliberately **not** re-exported from `grep-color-usage` — it was never exported from there, so re-exporting would widen the surface rather than preserve it. (The plan said to re-export both; checking found the premise wrong on both counts, so this deviates.)

## Consumer copy list

`guard-token-removal.mjs` installs into user repos, so `lib/source-scan.mjs` is added to the `token-crosswalk-builder` copy list, `scripts/README.md`'s table and install prose, and the regenerated adapters. **Copying the guard without it breaks it at import.**

## Verification

- `node --test` — 485 pass, 0 fail (4 new)
- Proven a no-op by diffing real output against `main` from a worktree:
  - `grep-color-usage` on `~/Dev/throughline-sample`: **byte-identical**, 2083 matches across 58 files
  - `guard-token-removal` on the same tree: **byte-identical**, 216 findings, same exit code
- `ci/validate-skills.mjs`, `ci/validate-plugin.mjs`, `scripts/adapters/generate.mjs --check` all pass

Plan: `docs/superpowers/plans/2026-08-31-code-adherence-gate.md`, Task 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTHVx1DcCcd4DzAgLjYiJU