### PR TITLE
fix: the docs install set was missing a file the gate imports (#39)

### DIFF
--- a/adapters/codex/prompts/storybook-chromatic-builder.md
+++ b/adapters/codex/prompts/storybook-chromatic-builder.md
@@ -27,7 +27,7 @@ system). Wire it to consume `packages/tokens` output so stories render with the
 real design tokens (import the generated CSS/theme). Checkpoint: confirm
 Storybook runs and shows the token-themed canvas.
 
-Install the documentation scripts alongside the token scripts: copy the seven
+Install the documentation scripts alongside the token scripts: copy the eight
 files and register the four npm scripts listed under **Documentation scripts —
 install as a set** in `.throughline/scripts/README.md`. `adherence:check`
 needs the repo's own values substituted in — the UI package's specifier for

--- a/adapters/cursor/.cursor/rules/storybook-chromatic-builder.mdc
+++ b/adapters/cursor/.cursor/rules/storybook-chromatic-builder.mdc
@@ -31,7 +31,7 @@ system). Wire it to consume `packages/tokens` output so stories render with the
 real design tokens (import the generated CSS/theme). Checkpoint: confirm
 Storybook runs and shows the token-themed canvas.
 
-Install the documentation scripts alongside the token scripts: copy the seven
+Install the documentation scripts alongside the token scripts: copy the eight
 files and register the four npm scripts listed under **Documentation scripts —
 install as a set** in `.throughline/scripts/README.md`. `adherence:check`
 needs the repo's own values substituted in — the UI package's specifier for

--- a/adapters/generic/skills/storybook-chromatic-builder/SKILL.md
+++ b/adapters/generic/skills/storybook-chromatic-builder/SKILL.md
@@ -27,7 +27,7 @@ system). Wire it to consume `packages/tokens` output so stories render with the
 real design tokens (import the generated CSS/theme). Checkpoint: confirm
 Storybook runs and shows the token-themed canvas.
 
-Install the documentation scripts alongside the token scripts: copy the seven
+Install the documentation scripts alongside the token scripts: copy the eight
 files and register the four npm scripts listed under **Documentation scripts —
 install as a set** in `.throughline/scripts/README.md`. `adherence:check`
 needs the repo's own values substituted in — the UI package's specifier for

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -31,7 +31,7 @@ tested here; copied verbatim by `token-crosswalk-builder` into the user's
 registering them leaves a repo with a script on disk and no entry point, which
 is how a stale `docs:check` went unnoticed for a full release. Both
 `storybook-chromatic-builder` (first-time setup) and `/document-component`
-(freshness refresh) install the same seven files and register the same four
+(freshness refresh) install the same eight files and register the same four
 scripts:
 
 | File | npm script |
@@ -43,6 +43,7 @@ scripts:
 | `lib/doc-card-plan.mjs` | — (imported by the above) |
 | `validate-adherence.mjs` | `"adherence:check": "node scripts/validate-adherence.mjs --root ../../apps --system ../.. --package <specifier> --tokens dtcg/tokens.json"` |
 | `lib/source-scan.mjs` | — (imported by the above) |
+| `lib/dtcg.mjs` | — (imported by the above) |
 
 A refresh that adds a file must also add its npm script; check `package.json`
 for all four every time, not just the file that changed.

--- a/scripts/build-doc-card-builder.mjs
+++ b/scripts/build-doc-card-builder.mjs
@@ -130,7 +130,7 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
   });
   if (process.argv.includes('--check')) {
     let onDisk = null;
-    try { onDisk = readFileSync(OUT, 'utf8'); } catch (e) { /* missing counts as drift */ }
+    try { onDisk = readFileSync(OUT, 'utf8'); } catch { /* missing counts as drift */ }
     if (onDisk !== result) {
       console.error('✗ references/doc-card-builder.md out of date; run: node scripts/build-doc-card-builder.mjs');
       process.exit(1);

--- a/skills/storybook-chromatic-builder/SKILL.md
+++ b/skills/storybook-chromatic-builder/SKILL.md
@@ -32,7 +32,7 @@ system). Wire it to consume `packages/tokens` output so stories render with the
 real design tokens (import the generated CSS/theme). Checkpoint: confirm
 Storybook runs and shows the token-themed canvas.
 
-Install the documentation scripts alongside the token scripts: copy the seven
+Install the documentation scripts alongside the token scripts: copy the eight
 files and register the four npm scripts listed under **Documentation scripts —
 install as a set** in `${CLAUDE_PLUGIN_ROOT}/scripts/README.md`. `adherence:check`
 needs the repo's own values substituted in — the UI package's specifier for


### PR DESCRIPTION
## What this fixes

`scripts/validate-adherence.mjs` imports **two** local libraries:

```js
import { walk, normalizeName } from './lib/source-scan.mjs';
import { flattenDtcg, resolveValue } from './lib/dtcg.mjs';
```

The **Documentation scripts — install as a set** table in `scripts/README.md`
listed `lib/source-scan.mjs` but not `lib/dtcg.mjs`. That file is otherwise
installed only by `token-sync-layer`, under a heading that reads *"Install the
native token toolkit"* — which a web-only project would reasonably skip.

So a consumer following the table exactly got a gate that **could not start**.

## How it was verified

Built a consumer repo containing exactly the seven files the table listed, and
ran the gate the way the table registers it:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../scripts/lib/dtcg.mjs'
  imported from .../scripts/validate-adherence.mjs
exit=1
```

With the row added — same fixture, eight files:

```
A. correct code    → 1 of 1 literal attributes matched a declared axis    exit=0
B. size="enormous" → [unknown-variant-value] declared values are sm, lg   exit=1
```

So the gate now both starts and retains its ability to fail.

## Notes

- This is the same failure class as the `lib/source-scan.mjs` entry added in
  #103 — same list, missed on the same PR.
- **"Four npm scripts" is unchanged.** The added file has no entry point of its
  own, so only the file count moved (seven → eight).
- `/document-component` needs no edit: it defers to the table rather than
  restating the list, so the fix propagates to it.
- Adapter mirrors regenerated, as a skill file changed.

## Also included

One unrelated one-line cleanup, committed separately: an unused `catch (e)`
binding in `build-doc-card-builder.mjs` becomes `catch {`, the form already used
in `install.mjs` for the same case.

## Verification

- `node --test` — 517 pass, 0 fail
- All five CI gates exit 0
- `npm pack` + install from the tarball succeeds for all three targets

## Residual risk

The fix is proven against a consumer repo I constructed. No real project has run
this install path, so the eight-file list is verified but not field-tested.

Follow-up worth considering: nothing checks that a documented copy list covers
what its scripts import — which is how this survived #103. A ~30-line checker
that derives both copy lists from the docs and verifies transitive imports would
close the class. Not included here, since a new CI gate is a feature rather than
a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTHVx1DcCcd4DzAgLjYiJU